### PR TITLE
Feature/lan server discovery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,7 @@ TEST_GAME_SRCS := \
 	server/sv_init.c \
 	server/sv_send.c \
 	server/sv_info.c \
+	server/sv_lan.c \
 	client/cl_browser.c \
 	common/net.c \
 	common/net_oob.c \

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ else
         RPATH     := -Wl,-rpath,'$$ORIGIN/../lib'
         CFLAGS    += -fPIC
         LDFLAGS   := -L$(LIB_DIR) -Wl,-z,defs
-        LIBS      := -lSDL2 -lstorm -ljpeg -lEGL -lGL -lm
+        LIBS      := -lSDL2 -lstorm -ljpeg -lEGL -lGL -lavahi-client -lavahi-common -lm
     endif
 endif
 
@@ -148,6 +148,8 @@ TEST_GAME_SRCS := \
 	game/skills/s_train.c \
 	server/sv_init.c \
 	server/sv_send.c \
+	server/sv_info.c \
+	client/cl_browser.c \
 	common/net.c \
 	common/msg.c
 
@@ -163,7 +165,8 @@ TEST_SRCS := \
 	tests/test_api.c \
 	tests/test_game.c \
 	tests/test_combat.c \
-	tests/test_server_net.c
+	tests/test_server_net.c \
+	tests/test_lan_discovery.c
 
 TEST_CFLAGS := -Wall -Itests/stubs -Icmath3/types -Igame -Iserver -Icommon -Igame/skills
 

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,11 @@ else
         RPATH     := -Wl,-rpath,'$$ORIGIN/../lib'
         CFLAGS    += -fPIC
         LDFLAGS   := -L$(LIB_DIR) -Wl,-z,defs
-        LIBS      := -lSDL2 -lstorm -ljpeg -lEGL -lGL -lavahi-client -lavahi-common -lm
+        # Prefer pkg-config for Avahi so non-Debian distros that put the
+        # libs in non-standard paths still link.  Fall back to plain
+        # -l flags if pkg-config isn't present.
+        AVAHI_LIBS := $(shell pkg-config --libs avahi-client 2>/dev/null || echo -lavahi-client -lavahi-common)
+        LIBS      := -lSDL2 -lstorm -ljpeg -lEGL -lGL $(AVAHI_LIBS) -lm
     endif
 endif
 
@@ -151,6 +155,7 @@ TEST_GAME_SRCS := \
 	server/sv_info.c \
 	client/cl_browser.c \
 	common/net.c \
+	common/net_oob.c \
 	common/msg.c
 
 TEST_SRCS := \

--- a/client/cl_browser.c
+++ b/client/cl_browser.c
@@ -1,0 +1,189 @@
+/*
+ * cl_browser.c - LAN server browser implementation.
+ *
+ * Sends OOB getinfo broadcasts on demand, parses infoResponse replies
+ * into a fixed-size in-memory list, expires stale entries.  No I/O,
+ * no UI: this module is the model layer only.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <time.h>
+#include <arpa/inet.h>
+
+#include "cl_browser.h"
+#include "../common/net.h"
+#include "../common/net_oob.h"
+
+static server_info_t browse_entries[SERVER_BROWSE_MAX_ENTRIES];
+static int browse_count = 0;
+
+static DWORD CL_BrowserNowMs(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (DWORD)((unsigned long long)ts.tv_sec * 1000ULL +
+                   (unsigned long long)ts.tv_nsec / 1000000ULL);
+}
+
+void CL_BrowserInit(void) {
+    memset(browse_entries, 0, sizeof(browse_entries));
+    browse_count = 0;
+}
+
+void CL_RefreshServerList(void) {
+    netadr_t bcast;
+    memset(&bcast, 0, sizeof(bcast));
+    bcast.type  = NA_BROADCAST;
+    bcast.ip[0] = 255;
+    bcast.ip[1] = 255;
+    bcast.ip[2] = 255;
+    bcast.ip[3] = 255;
+    bcast.port  = htons(PORT_SERVER);
+
+    Netchan_OutOfBandPrint(NS_CLIENT, bcast,
+                           OOB_GETINFO " %d", PROTOCOL_VERSION);
+}
+
+/* Copy a value substring (between two backslashes or end-of-payload) into
+ * dst with bounded length and null termination. */
+static void copy_value(char *dst, int dstcap, const char *src, int srclen) {
+    int n = srclen < (dstcap - 1) ? srclen : (dstcap - 1);
+    if (n < 0) n = 0;
+    memcpy(dst, src, n);
+    dst[n] = '\0';
+}
+
+/* Look up the value for `key` in a Quake3-style backslash-delimited
+ * key/value blob.  The blob looks like:
+ *
+ *     \k1\v1\k2\v2...
+ *
+ * (leading backslash is part of the format).  Returns true and fills
+ * dst on hit; returns false on miss without touching dst. */
+static bool kv_get(const char *blob, int bloblen,
+                   const char *key, char *dst, int dstcap) {
+    int keylen = (int)strlen(key);
+    int i = 0;
+    while (i < bloblen) {
+        if (blob[i] != '\\') {
+            i++;
+            continue;
+        }
+        // At a separator: token is between i+1 and the next backslash.
+        int kstart = i + 1;
+        int kend = kstart;
+        while (kend < bloblen && blob[kend] != '\\') kend++;
+        int klen = kend - kstart;
+        // Value runs from after the next backslash to the one after that.
+        int vstart = kend + 1;
+        int vend = vstart;
+        while (vend < bloblen && blob[vend] != '\\') vend++;
+        if (klen == keylen && memcmp(blob + kstart, key, keylen) == 0) {
+            copy_value(dst, dstcap, blob + vstart, vend - vstart);
+            return true;
+        }
+        // Advance to the next key separator (the one before vend if present).
+        i = vend;
+    }
+    return false;
+}
+
+/* Find an existing entry matching from, or allocate a fresh one.
+ * Returns NULL if the list is full and no expired slot can be reused. */
+static server_info_t *find_or_alloc(const netadr_t *from) {
+    for (int i = 0; i < browse_count; i++) {
+        const netadr_t *a = &browse_entries[i].address;
+        if (a->type == from->type &&
+            memcmp(a->ip, from->ip, sizeof(a->ip)) == 0 &&
+            a->port == from->port) {
+            return &browse_entries[i];
+        }
+    }
+    if (browse_count < SERVER_BROWSE_MAX_ENTRIES) {
+        server_info_t *slot = &browse_entries[browse_count++];
+        memset(slot, 0, sizeof(*slot));
+        slot->address = *from;
+        return slot;
+    }
+    return NULL;
+}
+
+void CL_BrowserUpsert(const netadr_t *from,
+                      const char *hostname,
+                      const char *map,
+                      DWORD clients,
+                      DWORD maxclients,
+                      int protocol) {
+    server_info_t *slot = find_or_alloc(from);
+    if (!slot) {
+        fprintf(stderr, "CL_BrowserUpsert: server list full\n");
+        return;
+    }
+    if (hostname) {
+        strncpy(slot->hostname, hostname, sizeof(slot->hostname) - 1);
+        slot->hostname[sizeof(slot->hostname) - 1] = '\0';
+    } else {
+        slot->hostname[0] = '\0';
+    }
+    if (map) {
+        strncpy(slot->map, map, sizeof(slot->map) - 1);
+        slot->map[sizeof(slot->map) - 1] = '\0';
+    } else {
+        slot->map[0] = '\0';
+    }
+    slot->clients     = clients;
+    slot->maxclients  = maxclients;
+    slot->protocol    = protocol;
+    slot->last_seen_ms = CL_BrowserNowMs();
+}
+
+void CL_BrowserHandleInfoResponse(const netadr_t *from,
+                                  const char *payload,
+                                  int len) {
+    char hostname[SERVER_BROWSE_HOSTNAME_LEN] = "";
+    char map[SERVER_BROWSE_MAP_LEN] = "";
+    DWORD clients = 0, maxclients = 0;
+    int protocol = 0;
+
+    char buf[64];
+    if (kv_get(payload, len, OOB_KEY_HOSTNAME, buf, sizeof(buf))) {
+        strncpy(hostname, buf, sizeof(hostname) - 1);
+        hostname[sizeof(hostname) - 1] = '\0';
+    }
+    if (kv_get(payload, len, OOB_KEY_MAP, buf, sizeof(buf))) {
+        strncpy(map, buf, sizeof(map) - 1);
+        map[sizeof(map) - 1] = '\0';
+    }
+    if (kv_get(payload, len, OOB_KEY_CLIENTS, buf, sizeof(buf))) {
+        clients = (DWORD)strtoul(buf, NULL, 10);
+    }
+    if (kv_get(payload, len, OOB_KEY_MAXCLIENTS, buf, sizeof(buf))) {
+        maxclients = (DWORD)strtoul(buf, NULL, 10);
+    }
+    if (kv_get(payload, len, OOB_KEY_PROTOCOL, buf, sizeof(buf))) {
+        protocol = (int)strtol(buf, NULL, 10);
+    }
+
+    CL_BrowserUpsert(from, hostname, map, clients, maxclients, protocol);
+}
+
+void CL_BrowserPurgeExpired(void) {
+    DWORD now = CL_BrowserNowMs();
+    int write = 0;
+    for (int read = 0; read < browse_count; read++) {
+        DWORD age = now - browse_entries[read].last_seen_ms;
+        if (age <= SERVER_BROWSE_EXPIRY_MS) {
+            if (write != read) {
+                browse_entries[write] = browse_entries[read];
+            }
+            write++;
+        }
+    }
+    browse_count = write;
+}
+
+const server_info_t *CL_BrowserList(int *count) {
+    if (count) *count = browse_count;
+    return browse_entries;
+}

--- a/client/cl_browser.c
+++ b/client/cl_browser.c
@@ -1,9 +1,17 @@
 /*
  * cl_browser.c - LAN server browser implementation.
  *
- * Sends OOB getinfo broadcasts on demand, parses infoResponse replies
- * into a fixed-size in-memory list, expires stale entries.  No I/O,
- * no UI: this module is the model layer only.
+ * Storage: flat array of SERVER_BROWSE_MAX_ENTRIES entries plus an
+ * open-addressing hash index keyed on netadr_t for O(1) lookup
+ * (the array scan in find_or_alloc was O(N) per upsert).
+ *
+ * Time: a `now_ms` static is updated by CL_BrowserTick once per main
+ * loop iteration so that upserts within the same frame share a
+ * timestamp and we don't pay clock_gettime per call.
+ *
+ * Parsing: kv blobs from the OOB transport are walked once into a
+ * server_info_t; the mDNS transport feeds the same struct directly
+ * from cl_mdns.c.
  */
 
 #include <stdio.h>
@@ -16,24 +24,104 @@
 #include "../common/net.h"
 #include "../common/net_oob.h"
 
-static server_info_t browse_entries[SERVER_BROWSE_MAX_ENTRIES];
-static int browse_count = 0;
+#define HASH_BUCKETS (SERVER_BROWSE_MAX_ENTRIES * 2)
+#define HASH_EMPTY    0xFFFF
 
-static DWORD CL_BrowserNowMs(void) {
+static server_info_t browse_entries[SERVER_BROWSE_MAX_ENTRIES];
+static int           browse_count = 0;
+
+/* hash_index[bucket] holds 0..SERVER_BROWSE_MAX_ENTRIES-1, or HASH_EMPTY.
+ * Open addressing with linear probing.  HASH_BUCKETS = 128 so the load
+ * factor caps at 0.5 and probe chains stay short. */
+static unsigned short hash_index[HASH_BUCKETS];
+
+static DWORD cl_browser_now_ms = 0;
+static DWORD cl_browser_last_purge_ms = 0;
+static bool  cl_browser_full_warned = false;
+
+/* ---------------------------------------------------------------------- */
+
+static DWORD clock_now_ms(void) {
     struct timespec ts;
-    clock_gettime(CLOCK_MONOTONIC, &ts);
+    if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) {
+        return 0;
+    }
     return (DWORD)((unsigned long long)ts.tv_sec * 1000ULL +
                    (unsigned long long)ts.tv_nsec / 1000000ULL);
 }
 
+/* Cached "now" for the current frame, or a one-shot clock_gettime if
+ * CL_BrowserTick hasn't been called yet (tests, early init). */
+static DWORD browser_now(void) {
+    if (cl_browser_now_ms != 0) return cl_browser_now_ms;
+    return clock_now_ms();
+}
+
+static DWORD addr_hash(const netadr_t *a) {
+    /* FNV-1a over the 4 ip bytes + 2 port bytes + 1 type byte.
+     * Cheap, well-distributed for our key space. */
+    DWORD h = 2166136261u;
+    h = (h ^ (DWORD)a->type)   * 16777619u;
+    h = (h ^ (DWORD)a->ip[0])  * 16777619u;
+    h = (h ^ (DWORD)a->ip[1])  * 16777619u;
+    h = (h ^ (DWORD)a->ip[2])  * 16777619u;
+    h = (h ^ (DWORD)a->ip[3])  * 16777619u;
+    h = (h ^ ((DWORD)a->port & 0xFF))   * 16777619u;
+    h = (h ^ (((DWORD)a->port >> 8) & 0xFF)) * 16777619u;
+    return h;
+}
+
+static bool addr_eq(const netadr_t *a, const netadr_t *b) {
+    return a->type == b->type &&
+           a->port == b->port &&
+           memcmp(a->ip, b->ip, sizeof(a->ip)) == 0;
+}
+
+static int hash_lookup(const netadr_t *from) {
+    DWORD h = addr_hash(from);
+    for (int probe = 0; probe < HASH_BUCKETS; probe++) {
+        DWORD bucket = (h + (DWORD)probe) % HASH_BUCKETS;
+        unsigned short idx = hash_index[bucket];
+        if (idx == HASH_EMPTY) return -1;
+        if (idx < (unsigned short)browse_count &&
+            addr_eq(&browse_entries[idx].address, from)) {
+            return (int)idx;
+        }
+    }
+    return -1;
+}
+
+static void hash_insert(const netadr_t *from, int slot) {
+    DWORD h = addr_hash(from);
+    for (int probe = 0; probe < HASH_BUCKETS; probe++) {
+        DWORD bucket = (h + (DWORD)probe) % HASH_BUCKETS;
+        if (hash_index[bucket] == HASH_EMPTY) {
+            hash_index[bucket] = (unsigned short)slot;
+            return;
+        }
+    }
+}
+
+static void hash_rebuild(void) {
+    for (int i = 0; i < HASH_BUCKETS; i++) hash_index[i] = HASH_EMPTY;
+    for (int i = 0; i < browse_count; i++) {
+        hash_insert(&browse_entries[i].address, i);
+    }
+}
+
+/* ---------------------------------------------------------------------- */
+
 void CL_BrowserInit(void) {
     memset(browse_entries, 0, sizeof(browse_entries));
+    for (int i = 0; i < HASH_BUCKETS; i++) hash_index[i] = HASH_EMPTY;
     browse_count = 0;
+    cl_browser_now_ms = 0;
+    cl_browser_last_purge_ms = 0;
+    cl_browser_full_warned = false;
 }
 
 void CL_RefreshServerList(void) {
     netadr_t bcast;
-    memset(&bcast, 0, sizeof(bcast));
     bcast.type  = NA_BROADCAST;
     bcast.ip[0] = 255;
     bcast.ip[1] = 255;
@@ -45,132 +133,119 @@ void CL_RefreshServerList(void) {
                            OOB_GETINFO " %d", PROTOCOL_VERSION);
 }
 
-/* Copy a value substring (between two backslashes or end-of-payload) into
- * dst with bounded length and null termination. */
-static void copy_value(char *dst, int dstcap, const char *src, int srclen) {
-    int n = srclen < (dstcap - 1) ? srclen : (dstcap - 1);
-    if (n < 0) n = 0;
-    memcpy(dst, src, n);
-    dst[n] = '\0';
+void CL_BrowserTick(DWORD now_ms) {
+    cl_browser_now_ms = now_ms;
+    if (now_ms - cl_browser_last_purge_ms >= SERVER_BROWSE_PURGE_PERIOD_MS) {
+        CL_BrowserPurgeExpired();
+        cl_browser_last_purge_ms = now_ms;
+    }
 }
 
-/* Look up the value for `key` in a Quake3-style backslash-delimited
- * key/value blob.  The blob looks like:
+/* Copy into a fixed-size field with bounded length + null term.  Avoids
+ * the strncpy zero-pad. */
+static void copy_field(char *dst, int dstcap, const char *src) {
+    if (!src) {
+        dst[0] = '\0';
+        return;
+    }
+    int len = 0;
+    while (len < dstcap - 1 && src[len] != '\0') len++;
+    memcpy(dst, src, (size_t)len);
+    dst[len] = '\0';
+}
+
+/* Single-pass parse of an OOB infoResponse kv blob into `out`.
  *
- *     \k1\v1\k2\v2...
+ * Blob shape: "\k1\v1\k2\v2..." (leading backslash is part of the
+ * format).  Unknown keys are silently skipped (forward-compat).
  *
- * (leading backslash is part of the format).  Returns true and fills
- * dst on hit; returns false on miss without touching dst. */
-static bool kv_get(const char *blob, int bloblen,
-                   const char *key, char *dst, int dstcap) {
-    int keylen = (int)strlen(key);
+ * Replaces the previous per-key kv_get loop which walked the blob 5x. */
+static void parse_info_blob(const char *blob, int bloblen, server_info_t *out) {
     int i = 0;
     while (i < bloblen) {
-        if (blob[i] != '\\') {
-            i++;
-            continue;
-        }
-        // At a separator: token is between i+1 and the next backslash.
+        if (blob[i] != '\\') { i++; continue; }
         int kstart = i + 1;
         int kend = kstart;
         while (kend < bloblen && blob[kend] != '\\') kend++;
         int klen = kend - kstart;
-        // Value runs from after the next backslash to the one after that.
         int vstart = kend + 1;
         int vend = vstart;
         while (vend < bloblen && blob[vend] != '\\') vend++;
-        if (klen == keylen && memcmp(blob + kstart, key, keylen) == 0) {
-            copy_value(dst, dstcap, blob + vstart, vend - vstart);
-            return true;
+        int vlen = vend - vstart;
+
+        /* Dispatch on first char + key length to avoid 5 strcmps. */
+        const char *k = blob + kstart;
+        const char *v = blob + vstart;
+        char vbuf[64];
+        int vcap = vlen < (int)sizeof(vbuf) - 1 ? vlen : (int)sizeof(vbuf) - 1;
+        memcpy(vbuf, v, (size_t)vcap);
+        vbuf[vcap] = '\0';
+
+        if (klen == 8 && memcmp(k, "hostname", 8) == 0) {
+            copy_field(out->hostname, sizeof(out->hostname), vbuf);
+        } else if (klen == 3 && memcmp(k, "map", 3) == 0) {
+            copy_field(out->map, sizeof(out->map), vbuf);
+        } else if (klen == 7 && memcmp(k, "clients", 7) == 0) {
+            out->clients = (DWORD)strtoul(vbuf, NULL, 10);
+        } else if (klen == 10 && memcmp(k, "maxclients", 10) == 0) {
+            out->maxclients = (DWORD)strtoul(vbuf, NULL, 10);
+        } else if (klen == 8 && memcmp(k, "protocol", 8) == 0) {
+            out->protocol = (int)strtol(vbuf, NULL, 10);
         }
-        // Advance to the next key separator (the one before vend if present).
         i = vend;
     }
-    return false;
-}
-
-/* Find an existing entry matching from, or allocate a fresh one.
- * Returns NULL if the list is full and no expired slot can be reused. */
-static server_info_t *find_or_alloc(const netadr_t *from) {
-    for (int i = 0; i < browse_count; i++) {
-        const netadr_t *a = &browse_entries[i].address;
-        if (a->type == from->type &&
-            memcmp(a->ip, from->ip, sizeof(a->ip)) == 0 &&
-            a->port == from->port) {
-            return &browse_entries[i];
-        }
-    }
-    if (browse_count < SERVER_BROWSE_MAX_ENTRIES) {
-        server_info_t *slot = &browse_entries[browse_count++];
-        memset(slot, 0, sizeof(*slot));
-        slot->address = *from;
-        return slot;
-    }
-    return NULL;
-}
-
-void CL_BrowserUpsert(const netadr_t *from,
-                      const char *hostname,
-                      const char *map,
-                      DWORD clients,
-                      DWORD maxclients,
-                      int protocol) {
-    server_info_t *slot = find_or_alloc(from);
-    if (!slot) {
-        fprintf(stderr, "CL_BrowserUpsert: server list full\n");
-        return;
-    }
-    if (hostname) {
-        strncpy(slot->hostname, hostname, sizeof(slot->hostname) - 1);
-        slot->hostname[sizeof(slot->hostname) - 1] = '\0';
-    } else {
-        slot->hostname[0] = '\0';
-    }
-    if (map) {
-        strncpy(slot->map, map, sizeof(slot->map) - 1);
-        slot->map[sizeof(slot->map) - 1] = '\0';
-    } else {
-        slot->map[0] = '\0';
-    }
-    slot->clients     = clients;
-    slot->maxclients  = maxclients;
-    slot->protocol    = protocol;
-    slot->last_seen_ms = CL_BrowserNowMs();
 }
 
 void CL_BrowserHandleInfoResponse(const netadr_t *from,
                                   const char *payload,
                                   int len) {
-    char hostname[SERVER_BROWSE_HOSTNAME_LEN] = "";
-    char map[SERVER_BROWSE_MAP_LEN] = "";
-    DWORD clients = 0, maxclients = 0;
-    int protocol = 0;
+    server_info_t info;
+    info.address = *from;
+    info.hostname[0] = '\0';
+    info.map[0] = '\0';
+    info.clients = 0;
+    info.maxclients = 0;
+    info.protocol = 0;
+    info.last_seen_ms = 0;  /* CL_BrowserUpsert overwrites */
+    parse_info_blob(payload, len, &info);
+    CL_BrowserUpsert(&info);
+}
 
-    char buf[64];
-    if (kv_get(payload, len, OOB_KEY_HOSTNAME, buf, sizeof(buf))) {
-        strncpy(hostname, buf, sizeof(hostname) - 1);
-        hostname[sizeof(hostname) - 1] = '\0';
-    }
-    if (kv_get(payload, len, OOB_KEY_MAP, buf, sizeof(buf))) {
-        strncpy(map, buf, sizeof(map) - 1);
-        map[sizeof(map) - 1] = '\0';
-    }
-    if (kv_get(payload, len, OOB_KEY_CLIENTS, buf, sizeof(buf))) {
-        clients = (DWORD)strtoul(buf, NULL, 10);
-    }
-    if (kv_get(payload, len, OOB_KEY_MAXCLIENTS, buf, sizeof(buf))) {
-        maxclients = (DWORD)strtoul(buf, NULL, 10);
-    }
-    if (kv_get(payload, len, OOB_KEY_PROTOCOL, buf, sizeof(buf))) {
-        protocol = (int)strtol(buf, NULL, 10);
+void CL_BrowserUpsert(const server_info_t *info) {
+    int idx = hash_lookup(&info->address);
+    server_info_t *slot;
+
+    if (idx >= 0) {
+        slot = &browse_entries[idx];
+    } else if (browse_count < SERVER_BROWSE_MAX_ENTRIES) {
+        int new_slot = browse_count++;
+        slot = &browse_entries[new_slot];
+        slot->address = info->address;
+        hash_insert(&info->address, new_slot);
+    } else {
+        if (!cl_browser_full_warned) {
+            fprintf(stderr,
+                    "CL_BrowserUpsert: server list full at %d entries; "
+                    "further upserts dropped silently\n",
+                    SERVER_BROWSE_MAX_ENTRIES);
+            cl_browser_full_warned = true;
+        }
+        return;
     }
 
-    CL_BrowserUpsert(from, hostname, map, clients, maxclients, protocol);
+    /* Direct field assignment, no memset+overwrite. */
+    copy_field(slot->hostname, sizeof(slot->hostname), info->hostname);
+    copy_field(slot->map,      sizeof(slot->map),      info->map);
+    slot->clients      = info->clients;
+    slot->maxclients   = info->maxclients;
+    slot->protocol     = info->protocol;
+    slot->last_seen_ms = browser_now();
 }
 
 void CL_BrowserPurgeExpired(void) {
-    DWORD now = CL_BrowserNowMs();
+    DWORD now = browser_now();
     int write = 0;
+    bool dropped_any = false;
     for (int read = 0; read < browse_count; read++) {
         DWORD age = now - browse_entries[read].last_seen_ms;
         if (age <= SERVER_BROWSE_EXPIRY_MS) {
@@ -178,9 +253,16 @@ void CL_BrowserPurgeExpired(void) {
                 browse_entries[write] = browse_entries[read];
             }
             write++;
+        } else {
+            dropped_any = true;
         }
     }
     browse_count = write;
+    if (dropped_any) {
+        /* Re-warn next time we hit full. */
+        cl_browser_full_warned = false;
+        hash_rebuild();
+    }
 }
 
 const server_info_t *CL_BrowserList(int *count) {

--- a/client/cl_browser.h
+++ b/client/cl_browser.h
@@ -1,0 +1,66 @@
+#ifndef cl_browser_h
+#define cl_browser_h
+
+/*
+ * cl_browser.h - LAN server browser model.
+ *
+ * Maintains an in-memory list of servers discovered via OOB getinfo
+ * broadcast.  Entries are upserted on each infoResponse and expire
+ * after SERVER_INFO_EXPIRY_MS without a refresh.  This module owns
+ * neither networking nor UI; cl_main.c pumps it from the packet
+ * dispatch loop and (eventually) a menu module reads CL_BrowserList
+ * for display.
+ *
+ * Discovery surfaces *untrusted* candidates.  Anyone on the network
+ * can advertise a server with any name.  Trust enforcement happens at
+ * the connect handshake, not here.
+ */
+
+#include "../common/shared.h"
+#include "../common/net.h"
+
+#define SERVER_BROWSE_MAX_ENTRIES   64
+#define SERVER_BROWSE_HOSTNAME_LEN  64
+#define SERVER_BROWSE_MAP_LEN       64
+#define SERVER_BROWSE_EXPIRY_MS     5000
+
+typedef struct {
+    netadr_t address;
+    char     hostname[SERVER_BROWSE_HOSTNAME_LEN];
+    char     map[SERVER_BROWSE_MAP_LEN];
+    DWORD    clients;
+    DWORD    maxclients;
+    int      protocol;
+    DWORD    last_seen_ms;
+} server_info_t;
+
+void CL_BrowserInit(void);
+void CL_RefreshServerList(void);
+
+// Called by the OOB packet dispatcher in cl_main.c with the payload
+// that follows the OOB_INFORESPONSE token.  Upserts the entry into
+// the in-memory list (keyed by address) and stamps its last-seen time.
+void CL_BrowserHandleInfoResponse(const netadr_t *from,
+                                  const char *payload,
+                                  int len);
+
+// Shared upsert primitive used by both the OOB-broadcast path
+// (CL_BrowserHandleInfoResponse) and the mDNS path (cl_mdns.c).
+// Both discovery transports are parallel and equally untrusted; auth
+// happens at the connect handshake, not the discovery layer.
+void CL_BrowserUpsert(const netadr_t *from,
+                      const char *hostname,
+                      const char *map,
+                      DWORD clients,
+                      DWORD maxclients,
+                      int protocol);
+
+// Drop entries whose last_seen_ms is older than SERVER_BROWSE_EXPIRY_MS.
+// Safe to call every frame from CL_Frame.
+void CL_BrowserPurgeExpired(void);
+
+// Return a pointer to the current list and its length.  Valid until
+// the next call to any other CL_Browser* function.
+const server_info_t *CL_BrowserList(int *count);
+
+#endif /* cl_browser_h */

--- a/client/cl_browser.h
+++ b/client/cl_browser.h
@@ -5,15 +5,19 @@
  * cl_browser.h - LAN server browser model.
  *
  * Maintains an in-memory list of servers discovered via OOB getinfo
- * broadcast.  Entries are upserted on each infoResponse and expire
- * after SERVER_INFO_EXPIRY_MS without a refresh.  This module owns
- * neither networking nor UI; cl_main.c pumps it from the packet
- * dispatch loop and (eventually) a menu module reads CL_BrowserList
- * for display.
+ * broadcast and via mDNS.  Both transports feed CL_BrowserUpsert with
+ * a fully-populated server_info_t; the OOB transport additionally
+ * exposes CL_BrowserHandleInfoResponse as a wrapper that parses the
+ * kv blob first.
  *
  * Discovery surfaces *untrusted* candidates.  Anyone on the network
  * can advertise a server with any name.  Trust enforcement happens at
  * the connect handshake, not here.
+ *
+ * Time: CL_BrowserTick(now_ms) must be called once per main-loop
+ * iteration to advance the internal clock and run the rate-limited
+ * purge of expired entries.  Tests that don't care about expiry can
+ * skip Tick; CL_BrowserUpsert lazily backstops with clock_gettime.
  */
 
 #include "../common/shared.h"
@@ -23,6 +27,7 @@
 #define SERVER_BROWSE_HOSTNAME_LEN  64
 #define SERVER_BROWSE_MAP_LEN       64
 #define SERVER_BROWSE_EXPIRY_MS     5000
+#define SERVER_BROWSE_PURGE_PERIOD_MS 1000
 
 typedef struct {
     netadr_t address;
@@ -35,38 +40,40 @@ typedef struct {
 } server_info_t;
 
 void CL_BrowserInit(void);
+
+/* Send the OOB getinfo broadcast.  Replies arrive asynchronously via
+ * the OOB packet pump (CL_BrowserHandleInfoResponse). */
 void CL_RefreshServerList(void);
 
-// Called by the OOB packet dispatcher in cl_main.c with the payload
-// that follows the OOB_INFORESPONSE token.  Upserts the entry into
-// the in-memory list (keyed by address) and stamps its last-seen time.
+/* Per-frame housekeeping: caches `now_ms` so subsequent Upsert calls
+ * stamp entries with the same time, and runs the expired-entry sweep
+ * on a 1 Hz cadence (not every frame). */
+void CL_BrowserTick(DWORD now_ms);
+
+/* Parse an OOB infoResponse kv blob into a server_info_t (single pass)
+ * and Upsert.  The address is taken from the `from` argument, not from
+ * the blob. */
 void CL_BrowserHandleInfoResponse(const netadr_t *from,
                                   const char *payload,
                                   int len);
 
-// Shared upsert primitive used by both the OOB-broadcast path
-// (CL_BrowserHandleInfoResponse) and the mDNS path (cl_mdns.c).
-// Both discovery transports are parallel and equally untrusted; auth
-// happens at the connect handshake, not the discovery layer.
-//
-// Snapshot semantics: every call replaces all six fields for the given
-// address.  A NULL hostname / map argument is treated as the empty
-// string, overwriting any previous value.  Callers that mean to
-// "preserve previous fields if absent" should read the current entry
-// first via CL_BrowserList and pass through the unchanged values.
-void CL_BrowserUpsert(const netadr_t *from,
-                      const char *hostname,
-                      const char *map,
-                      DWORD clients,
-                      DWORD maxclients,
-                      int protocol);
+/* Shared upsert primitive used by both the OOB-broadcast path and the
+ * mDNS path (cl_mdns.c).  Caller passes a fully-populated server_info_t
+ * including the address field.  The list key is info->address (type,
+ * ip, port tuple).
+ *
+ * Snapshot semantics: every call replaces all fields.  Callers that
+ * mean "merge non-empty fields" should read the current entry first
+ * via CL_BrowserList and copy through unchanged values. */
+void CL_BrowserUpsert(const server_info_t *info);
 
-// Drop entries whose last_seen_ms is older than SERVER_BROWSE_EXPIRY_MS.
-// Safe to call every frame from CL_Frame.
+/* Drop entries whose last_seen_ms is older than SERVER_BROWSE_EXPIRY_MS.
+ * Normally driven from CL_BrowserTick on a rate-limited schedule; safe
+ * to call directly from tests. */
 void CL_BrowserPurgeExpired(void);
 
-// Return a pointer to the current list and its length.  Valid until
-// the next call to any other CL_Browser* function.
+/* Return a pointer to the current list and its length.  Valid until
+ * the next call to any other CL_Browser* function. */
 const server_info_t *CL_BrowserList(int *count);
 
 #endif /* cl_browser_h */

--- a/client/cl_browser.h
+++ b/client/cl_browser.h
@@ -48,6 +48,12 @@ void CL_BrowserHandleInfoResponse(const netadr_t *from,
 // (CL_BrowserHandleInfoResponse) and the mDNS path (cl_mdns.c).
 // Both discovery transports are parallel and equally untrusted; auth
 // happens at the connect handshake, not the discovery layer.
+//
+// Snapshot semantics: every call replaces all six fields for the given
+// address.  A NULL hostname / map argument is treated as the empty
+// string, overwriting any previous value.  Callers that mean to
+// "preserve previous fields if absent" should read the current entry
+// first via CL_BrowserList and pass through the unchanged values.
 void CL_BrowserUpsert(const netadr_t *from,
                       const char *hostname,
                       const char *map,

--- a/client/cl_main.c
+++ b/client/cl_main.c
@@ -10,7 +10,10 @@
  * CL_Init() sets up the renderer and input bindings at startup.
  */
 #include "client.h"
+#include "cl_browser.h"
+#include "cl_mdns.h"
 #include "renderer.h"
+#include "../common/net_oob.h"
 #include <arpa/inet.h>
 
 refExport_t re;
@@ -87,8 +90,10 @@ void CL_Init(void) {
     Key_SetBinding(K_MOUSE1, "+select");
     Key_SetBinding('q', "cmd quests");
     Key_SetBinding(K_ESCAPE, "cmd cancel");
-    
+
     CL_InitInput();
+    CL_BrowserInit();
+    CL_MDNS_Init();
 }
 
 void CL_ConnectionlessPacket(void) {
@@ -97,7 +102,13 @@ void CL_ConnectionlessPacket(void) {
 }
 
 /* Read all available server packets from the network buffer and dispatch each
- * message type to the appropriate CL_Parse* handler in cl_parse.c. */
+ * message type to the appropriate CL_Parse* handler in cl_parse.c.
+ *
+ * OOB packets are routed by the ASCII token that follows the -1 sequence
+ * marker.  Previously this function treated every OOB packet as a
+ * "client_connect" ack and unconditionally replied with "new"; that broke
+ * once any other OOB type (infoResponse from the server browser, future
+ * challenge replies) existed.  Unknown OOB tokens are logged and dropped. */
 void CL_ReadPackets(void) {
     static BYTE net_message_buffer[MAX_MSGLEN];
     static sizeBuf_t net_message = {
@@ -115,7 +126,25 @@ void CL_ReadPackets(void) {
             int hdr;
             memcpy(&hdr, net_message.data, sizeof(hdr));
             if (hdr == -1) {
-                CL_ConnectionlessPacket();
+                const char *oob_token = (const char *)net_message.data + 4;
+                int oob_token_max = r - 4;
+                if (oob_token_max >= (int)(sizeof(OOB_CLIENT_CONNECT) - 1) &&
+                    memcmp(oob_token, OOB_CLIENT_CONNECT,
+                           sizeof(OOB_CLIENT_CONNECT) - 1) == 0) {
+                    CL_ConnectionlessPacket();
+                } else if (oob_token_max >= (int)(sizeof(OOB_INFORESPONSE) - 1) &&
+                           memcmp(oob_token, OOB_INFORESPONSE,
+                                  sizeof(OOB_INFORESPONSE) - 1) == 0) {
+                    int token_len = (int)(sizeof(OOB_INFORESPONSE) - 1);
+                    CL_BrowserHandleInfoResponse(
+                        &from,
+                        oob_token + token_len,
+                        oob_token_max - token_len);
+                } else {
+                    fprintf(stderr,
+                            "CL_ReadPackets: unknown OOB token (%d bytes)\n",
+                            oob_token_max);
+                }
                 continue;
             }
         }
@@ -146,6 +175,7 @@ void CL_Connect(LPCSTR host, unsigned short port) {
 }
 
 void CL_Shutdown(void) {
+    CL_MDNS_Shutdown();
     FOR_LOOP(modelIndex, MAX_MODELS) {
         SAFE_DELETE(cl.models[modelIndex], re.ReleaseModel);
         SAFE_DELETE(cl.portraits[modelIndex], re.ReleaseModel);
@@ -166,6 +196,9 @@ void CL_Frame(DWORD msec) {
     cl.time += msec;
 
     CL_ReadPackets();
+
+    CL_MDNS_Tick();
+    CL_BrowserPurgeExpired();
 
     CL_Input();
 

--- a/client/cl_main.c
+++ b/client/cl_main.c
@@ -132,6 +132,16 @@ void CL_ReadPackets(void) {
                                               OOB_CLIENT_CONNECT)) {
                     CL_ConnectionlessPacket();
                 } else if (OOB_TOKEN_MATCHES_LITERAL(oob_token, oob_token_max,
+                                                    OOB_REJECT_MSG)) {
+                    /* Server refused us before allocating a slot.
+                     * Surface the reason to stderr; a UI layer can
+                     * pattern-match the reason string later. */
+                    int rj_len = (int)(sizeof(OOB_REJECT_MSG) - 1);
+                    fprintf(stderr,
+                            "CL_ReadPackets: server rejected connection: %.*s\n",
+                            oob_token_max - rj_len,
+                            oob_token + rj_len + (oob_token_max > rj_len ? 1 : 0));
+                } else if (OOB_TOKEN_MATCHES_LITERAL(oob_token, oob_token_max,
                                                     OOB_INFORESPONSE)) {
                     int token_len = (int)(sizeof(OOB_INFORESPONSE) - 1);
                     CL_BrowserHandleInfoResponse(
@@ -165,9 +175,10 @@ void CL_Connect(LPCSTR host, unsigned short port) {
     }
     cls.netchan.remote_address = adr;
     SZ_Init(&cls.netchan.message, cls.netchan.message_buf, MAX_MSGLEN);
-    // Send an out-of-band "connect" request; the server will register this
-    // client slot and reply with "client_connect".
-    Netchan_OutOfBandPrint(NS_CLIENT, adr, "connect");
+    /* Wire form: "connect <PROTOCOL_VERSION>".  Servers that don't
+     * recognize the version reply with OOB "rejectMsg
+     * protocol_version_mismatch" rather than allocating a slot. */
+    Netchan_OutOfBandPrint(NS_CLIENT, adr, OOB_CONNECT " %d", PROTOCOL_VERSION);
     fprintf(stderr, "CL_Connect: connecting to %d.%d.%d.%d:%u\n",
             adr.ip[0], adr.ip[1], adr.ip[2], adr.ip[3], ntohs(adr.port));
 }

--- a/client/cl_main.c
+++ b/client/cl_main.c
@@ -128,13 +128,11 @@ void CL_ReadPackets(void) {
             if (hdr == -1) {
                 const char *oob_token = (const char *)net_message.data + 4;
                 int oob_token_max = r - 4;
-                if (oob_token_max >= (int)(sizeof(OOB_CLIENT_CONNECT) - 1) &&
-                    memcmp(oob_token, OOB_CLIENT_CONNECT,
-                           sizeof(OOB_CLIENT_CONNECT) - 1) == 0) {
+                if (OOB_TokenMatches(oob_token, oob_token_max,
+                                     OOB_CLIENT_CONNECT)) {
                     CL_ConnectionlessPacket();
-                } else if (oob_token_max >= (int)(sizeof(OOB_INFORESPONSE) - 1) &&
-                           memcmp(oob_token, OOB_INFORESPONSE,
-                                  sizeof(OOB_INFORESPONSE) - 1) == 0) {
+                } else if (OOB_TokenMatches(oob_token, oob_token_max,
+                                            OOB_INFORESPONSE)) {
                     int token_len = (int)(sizeof(OOB_INFORESPONSE) - 1);
                     CL_BrowserHandleInfoResponse(
                         &from,

--- a/client/cl_main.c
+++ b/client/cl_main.c
@@ -128,11 +128,11 @@ void CL_ReadPackets(void) {
             if (hdr == -1) {
                 const char *oob_token = (const char *)net_message.data + 4;
                 int oob_token_max = r - 4;
-                if (OOB_TokenMatches(oob_token, oob_token_max,
-                                     OOB_CLIENT_CONNECT)) {
+                if (OOB_TOKEN_MATCHES_LITERAL(oob_token, oob_token_max,
+                                              OOB_CLIENT_CONNECT)) {
                     CL_ConnectionlessPacket();
-                } else if (OOB_TokenMatches(oob_token, oob_token_max,
-                                            OOB_INFORESPONSE)) {
+                } else if (OOB_TOKEN_MATCHES_LITERAL(oob_token, oob_token_max,
+                                                    OOB_INFORESPONSE)) {
                     int token_len = (int)(sizeof(OOB_INFORESPONSE) - 1);
                     CL_BrowserHandleInfoResponse(
                         &from,
@@ -196,7 +196,10 @@ void CL_Frame(DWORD msec) {
     CL_ReadPackets();
 
     CL_MDNS_Tick();
-    CL_BrowserPurgeExpired();
+    /* Tick advances the browser's cached now and rate-limits the
+     * expired-entry purge to 1 Hz so the frame-rate loop isn't paying
+     * for a full-list scan dozens of times per second. */
+    CL_BrowserTick(cl.time);
 
     CL_Input();
 

--- a/client/cl_mdns.c
+++ b/client/cl_mdns.c
@@ -66,45 +66,56 @@ static void cl_mdns_resolve_callback(AvahiServiceResolver *r,
         return;
     }
 
-    char hostname_v[64] = "";
-    char map_v[64]      = "";
-    DWORD clients_v     = 0;
-    DWORD maxclients_v  = 0;
-    int   protocol_v    = 0;
+    server_info_t info;
+    memset(&info, 0, sizeof(info));
+    info.address.type = NA_IP;
+    /* AvahiAddress.data.ipv4.address is in network byte order already. */
+    memcpy(info.address.ip, &address->data.ipv4.address, 4);
+    info.address.port = htons(port);
 
     for (AvahiStringList *cur = txt; cur; cur = avahi_string_list_get_next(cur)) {
         char  *key = NULL;
         char  *val = NULL;
         size_t vlen = 0;
-        if (avahi_string_list_get_pair(cur, &key, &val, &vlen) == 0) {
-            if (key && val) {
-                if (strcmp(key, "hostname") == 0) {
-                    strncpy(hostname_v, val, sizeof(hostname_v) - 1);
-                    hostname_v[sizeof(hostname_v) - 1] = '\0';
-                } else if (strcmp(key, "map") == 0) {
-                    strncpy(map_v, val, sizeof(map_v) - 1);
-                    map_v[sizeof(map_v) - 1] = '\0';
-                } else if (strcmp(key, "clients") == 0) {
-                    clients_v = (DWORD)strtoul(val, NULL, 10);
-                } else if (strcmp(key, "maxclients") == 0) {
-                    maxclients_v = (DWORD)strtoul(val, NULL, 10);
-                } else if (strcmp(key, "protocol") == 0) {
-                    protocol_v = (int)strtol(val, NULL, 10);
-                }
-            }
+        if (avahi_string_list_get_pair(cur, &key, &val, &vlen) != 0 ||
+            !key || !val) {
             avahi_free(key);
             avahi_free(val);
+            continue;
         }
+        /* First-char dispatch keeps the average case to one strcmp
+         * instead of five. */
+        switch (key[0]) {
+        case 'h':
+            if (strcmp(key, "hostname") == 0) {
+                strncpy(info.hostname, val, sizeof(info.hostname) - 1);
+                info.hostname[sizeof(info.hostname) - 1] = '\0';
+            }
+            break;
+        case 'm':
+            if (strcmp(key, "map") == 0) {
+                strncpy(info.map, val, sizeof(info.map) - 1);
+                info.map[sizeof(info.map) - 1] = '\0';
+            } else if (strcmp(key, "maxclients") == 0) {
+                info.maxclients = (DWORD)strtoul(val, NULL, 10);
+            }
+            break;
+        case 'c':
+            if (strcmp(key, "clients") == 0) {
+                info.clients = (DWORD)strtoul(val, NULL, 10);
+            }
+            break;
+        case 'p':
+            if (strcmp(key, "protocol") == 0) {
+                info.protocol = (int)strtol(val, NULL, 10);
+            }
+            break;
+        }
+        avahi_free(key);
+        avahi_free(val);
     }
 
-    netadr_t adr;
-    memset(&adr, 0, sizeof(adr));
-    adr.type = NA_IP;
-    /* AvahiAddress.data.ipv4.address is in network byte order already. */
-    memcpy(adr.ip, &address->data.ipv4.address, 4);
-    adr.port = htons(port);
-
-    CL_BrowserUpsert(&adr, hostname_v, map_v, clients_v, maxclients_v, protocol_v);
+    CL_BrowserUpsert(&info);
 
     avahi_service_resolver_free(r);
 }

--- a/client/cl_mdns.c
+++ b/client/cl_mdns.c
@@ -1,0 +1,204 @@
+/*
+ * cl_mdns.c - mDNS/DNS-SD service browser feeding the shared server list.
+ *
+ * Avahi-based on Linux; stubs elsewhere.  Resolves each discovered
+ * service to its IPv4 address + port + TXT records, then calls
+ * CL_BrowserUpsert (defined in cl_browser.c) to feed the same in-memory
+ * list as the UDP-broadcast OOB path.
+ */
+
+#include "cl_mdns.h"
+
+#ifdef __linux__
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <arpa/inet.h>
+
+#include <avahi-client/client.h>
+#include <avahi-client/lookup.h>
+#include <avahi-common/simple-watch.h>
+#include <avahi-common/error.h>
+#include <avahi-common/malloc.h>
+#include <avahi-common/strlst.h>
+#include <avahi-common/address.h>
+
+#include "cl_browser.h"
+#include "../common/shared.h"
+#include "../common/net.h"
+#include "../common/net_oob.h"
+
+static AvahiSimplePoll     *cl_mdns_poll    = NULL;
+static AvahiClient         *cl_mdns_client  = NULL;
+static AvahiServiceBrowser *cl_mdns_browser = NULL;
+
+static void cl_mdns_resolve_callback(AvahiServiceResolver *r,
+                             AvahiIfIndex interface,
+                             AvahiProtocol protocol,
+                             AvahiResolverEvent event,
+                             const char *name,
+                             const char *type,
+                             const char *domain,
+                             const char *host_name,
+                             const AvahiAddress *address,
+                             uint16_t port,
+                             AvahiStringList *txt,
+                             AvahiLookupResultFlags flags,
+                             void *userdata) {
+    (void)interface;
+    (void)protocol;
+    (void)flags;
+    (void)userdata;
+    (void)name;
+    (void)type;
+    (void)domain;
+    (void)host_name;
+
+    if (event != AVAHI_RESOLVER_FOUND) {
+        avahi_service_resolver_free(r);
+        return;
+    }
+    /* netadr_t carries only 4 ip bytes; restrict to IPv4 for now.
+     * IPv6 lands when netadr_t grows to support it (out of scope here). */
+    if (address->proto != AVAHI_PROTO_INET) {
+        avahi_service_resolver_free(r);
+        return;
+    }
+
+    char hostname_v[64] = "";
+    char map_v[64]      = "";
+    DWORD clients_v     = 0;
+    DWORD maxclients_v  = 0;
+    int   protocol_v    = 0;
+
+    for (AvahiStringList *cur = txt; cur; cur = avahi_string_list_get_next(cur)) {
+        char  *key = NULL;
+        char  *val = NULL;
+        size_t vlen = 0;
+        if (avahi_string_list_get_pair(cur, &key, &val, &vlen) == 0) {
+            if (key && val) {
+                if (strcmp(key, "hostname") == 0) {
+                    strncpy(hostname_v, val, sizeof(hostname_v) - 1);
+                    hostname_v[sizeof(hostname_v) - 1] = '\0';
+                } else if (strcmp(key, "map") == 0) {
+                    strncpy(map_v, val, sizeof(map_v) - 1);
+                    map_v[sizeof(map_v) - 1] = '\0';
+                } else if (strcmp(key, "clients") == 0) {
+                    clients_v = (DWORD)strtoul(val, NULL, 10);
+                } else if (strcmp(key, "maxclients") == 0) {
+                    maxclients_v = (DWORD)strtoul(val, NULL, 10);
+                } else if (strcmp(key, "protocol") == 0) {
+                    protocol_v = (int)strtol(val, NULL, 10);
+                }
+            }
+            avahi_free(key);
+            avahi_free(val);
+        }
+    }
+
+    netadr_t adr;
+    memset(&adr, 0, sizeof(adr));
+    adr.type = NA_IP;
+    /* AvahiAddress.data.ipv4.address is in network byte order already. */
+    memcpy(adr.ip, &address->data.ipv4.address, 4);
+    adr.port = htons(port);
+
+    CL_BrowserUpsert(&adr, hostname_v, map_v, clients_v, maxclients_v, protocol_v);
+
+    avahi_service_resolver_free(r);
+}
+
+static void cl_mdns_browse_callback(AvahiServiceBrowser *b,
+                            AvahiIfIndex interface,
+                            AvahiProtocol protocol,
+                            AvahiBrowserEvent event,
+                            const char *name,
+                            const char *type,
+                            const char *domain,
+                            AvahiLookupResultFlags flags,
+                            void *userdata) {
+    (void)b;
+    (void)flags;
+    (void)userdata;
+
+    if (event == AVAHI_BROWSER_NEW) {
+        /* Kick off a resolver; result lands in cl_mdns_resolve_callback. */
+        if (!avahi_service_resolver_new(cl_mdns_client, interface, protocol,
+                                        name, type, domain, AVAHI_PROTO_INET,
+                                        0, cl_mdns_resolve_callback, NULL)) {
+            fprintf(stderr, "CL_MDNS: resolver_new failed: %s\n",
+                    avahi_strerror(avahi_client_errno(cl_mdns_client)));
+        }
+    }
+    /* AVAHI_BROWSER_REMOVE / CACHE_EXHAUSTED / ALL_FOR_NOW / FAILURE: ignore.
+     * Stale entries are pruned by CL_BrowserPurgeExpired, not by the browser. */
+}
+
+static void cl_mdns_client_callback(AvahiClient *c,
+                            AvahiClientState state,
+                            void *userdata) {
+    (void)c;
+    (void)userdata;
+    if (state == AVAHI_CLIENT_FAILURE) {
+        fprintf(stderr, "CL_MDNS: client failure: %s\n",
+                avahi_strerror(avahi_client_errno(c)));
+    }
+}
+
+void CL_MDNS_Init(void) {
+    cl_mdns_poll = avahi_simple_poll_new();
+    if (!cl_mdns_poll) {
+        fprintf(stderr, "CL_MDNS: avahi_simple_poll_new failed\n");
+        return;
+    }
+    int error;
+    cl_mdns_client = avahi_client_new(avahi_simple_poll_get(cl_mdns_poll), 0,
+                                    cl_mdns_client_callback, NULL, &error);
+    if (!cl_mdns_client) {
+        fprintf(stderr, "CL_MDNS: avahi_client_new failed: %s\n",
+                avahi_strerror(error));
+        avahi_simple_poll_free(cl_mdns_poll);
+        cl_mdns_poll = NULL;
+        return;
+    }
+    cl_mdns_browser = avahi_service_browser_new(cl_mdns_client,
+                                              AVAHI_IF_UNSPEC,
+                                              AVAHI_PROTO_INET,
+                                              MDNS_SERVICE_TYPE,
+                                              NULL, 0,
+                                              cl_mdns_browse_callback, NULL);
+    if (!cl_mdns_browser) {
+        fprintf(stderr, "CL_MDNS: service_browser_new failed: %s\n",
+                avahi_strerror(avahi_client_errno(cl_mdns_client)));
+    }
+}
+
+void CL_MDNS_Tick(void) {
+    if (cl_mdns_poll) {
+        avahi_simple_poll_iterate(cl_mdns_poll, 0);
+    }
+}
+
+void CL_MDNS_Shutdown(void) {
+    if (cl_mdns_browser) {
+        avahi_service_browser_free(cl_mdns_browser);
+        cl_mdns_browser = NULL;
+    }
+    if (cl_mdns_client) {
+        avahi_client_free(cl_mdns_client);
+        cl_mdns_client = NULL;
+    }
+    if (cl_mdns_poll) {
+        avahi_simple_poll_free(cl_mdns_poll);
+        cl_mdns_poll = NULL;
+    }
+}
+
+#else /* !__linux__ */
+
+void CL_MDNS_Init(void)     {}
+void CL_MDNS_Tick(void)     {}
+void CL_MDNS_Shutdown(void) {}
+
+#endif

--- a/client/cl_mdns.h
+++ b/client/cl_mdns.h
@@ -1,0 +1,25 @@
+#ifndef cl_mdns_h
+#define cl_mdns_h
+
+/*
+ * cl_mdns.h - Client-side mDNS/DNS-SD service browser.
+ *
+ * Discovers `_openwarcraft3._udp.local.` services on the LAN and feeds
+ * each resolution into the shared server-browser model via
+ * CL_BrowserUpsert.  mDNS is a parallel transport to the UDP broadcast
+ * getinfo flow in cl_browser.c; both produce equally untrusted
+ * candidates and the auth gate is the connect handshake, not the
+ * discovery layer.
+ *
+ * Linux implementation uses Avahi.  Non-Linux platforms link the
+ * stub variants and the feature is silently disabled.
+ *
+ * Requires avahi-daemon to be running on the host for browse results
+ * to actually arrive.
+ */
+
+void CL_MDNS_Init(void);
+void CL_MDNS_Tick(void);
+void CL_MDNS_Shutdown(void);
+
+#endif /* cl_mdns_h */

--- a/common/main.c
+++ b/common/main.c
@@ -79,6 +79,11 @@ int main(int argc, LPSTR argv[]) {
         SV_MDNS_UpdateInfo(map,
                            svs.num_clients,
                            ge ? ge->max_clients : 0);
+        // atexit only fires on clean exit (not on signal-induced kill),
+        // so this is the unprivileged best-effort path.  The Avahi
+        // daemon will reap our group on socket close even if atexit
+        // doesn't fire.
+        atexit(SV_MDNS_Shutdown);
     }
 
     DWORD startTime = SDL_GetTicks();

--- a/common/main.c
+++ b/common/main.c
@@ -1,5 +1,6 @@
 #include "../client/client.h"
 #include "../server/server.h"
+#include "../server/sv_mdns.h"
 
 #include <SDL2/SDL.h>
 
@@ -71,8 +72,13 @@ int main(int argc, LPSTR argv[]) {
         // Remote-client mode: skip the local server, connect over UDP.
         CL_Connect(connect_addr, PORT_SERVER);
     } else {
-        // Listen-server mode: load the map and spawn entities.
+        // Listen-server mode: load the map and spawn entities, then
+        // advertise on mDNS so LAN browsers can find us.
         SV_Map(map);
+        SV_MDNS_Init(PORT_SERVER);
+        SV_MDNS_UpdateInfo(map,
+                           svs.num_clients,
+                           ge ? ge->max_clients : 0);
     }
 
     DWORD startTime = SDL_GetTicks();

--- a/common/main.c
+++ b/common/main.c
@@ -77,7 +77,7 @@ int main(int argc, LPSTR argv[]) {
         SV_Map(map);
         SV_MDNS_Init(PORT_SERVER);
         SV_MDNS_UpdateInfo(map,
-                           svs.num_clients,
+                           SV_NumLiveClients(),
                            ge ? ge->max_clients : 0);
         // atexit only fires on clean exit (not on signal-induced kill),
         // so this is the unprivileged best-effort path.  The Avahi

--- a/common/net.c
+++ b/common/net.c
@@ -177,6 +177,9 @@ bool NET_Init(unsigned short port) {
 
     int flag = 1;
     setsockopt(udp_socket, SOL_SOCKET, SO_REUSEADDR, &flag, sizeof(flag));
+    // Required for sendto to 255.255.255.255 (limited broadcast) used by
+    // LAN server discovery in cl_browser.c.
+    setsockopt(udp_socket, SOL_SOCKET, SO_BROADCAST, &flag, sizeof(flag));
 
     struct sockaddr_in addr;
     memset(&addr, 0, sizeof(addr));

--- a/common/net.h
+++ b/common/net.h
@@ -5,6 +5,12 @@
 
 #define PORT_SERVER 27910
 
+// Wire protocol version reported in OOB infoResponse and (in a later
+// slice) checked by the connect handshake.  Bump on any wire-format
+// change.  Old/new clients with mismatched versions are filtered out
+// of server-browser results by the client, not the server.
+#define PROTOCOL_VERSION 1
+
 typedef void const *LPCVOID;
 typedef struct sizeBuf_s *LPSIZEBUF;
 typedef struct entityState_s entityState_t;

--- a/common/net_oob.c
+++ b/common/net_oob.c
@@ -1,0 +1,33 @@
+/*
+ * net_oob.c - Helpers for parsing OOB packet tokens.
+ *
+ * Kept pure (no globals, no I/O, no transport coupling) so the test
+ * binary can link this without dragging in the server's StormLib or
+ * renderer dependencies.
+ */
+
+#include <string.h>
+
+#include "net_oob.h"
+
+bool OOB_TokenMatches(const char *payload, int len, const char *token) {
+    if (!payload || !token || len <= 0) {
+        return false;
+    }
+    int toklen = (int)strlen(token);
+    if (toklen <= 0 || len < toklen) {
+        return false;
+    }
+    if (memcmp(payload, token, toklen) != 0) {
+        return false;
+    }
+    /* Boundary check: the byte AFTER the token must terminate it.
+     * Otherwise "getinfo" would match "getinfoXYZ" or "connect" would
+     * match "connectABC", and Slice 2's getchallenge/challenge tokens
+     * would collide with each other via prefix match. */
+    if (len == toklen) {
+        return true;          /* token is the entire payload */
+    }
+    char next = payload[toklen];
+    return next == ' ' || next == '\0';
+}

--- a/common/net_oob.h
+++ b/common/net_oob.h
@@ -1,0 +1,46 @@
+#ifndef net_oob_h
+#define net_oob_h
+
+/*
+ * net_oob.h - Out-of-band (OOB) opcode tokens for LAN server discovery.
+ *
+ * OOB packets are detected by a 4-byte -1 sequence marker (see
+ * Netchan_OutOfBand in net.c).  The payload that follows is an ASCII
+ * token, optionally followed by space-separated arguments.  Servers
+ * dispatch on the leading token before any client slot is allocated.
+ *
+ * Format and tokens are borrowed from Quake 3 / dpmaster:
+ *   client -> server:  "getinfo <protocol_version>"
+ *   server -> client:  "infoResponse\hostname\<n>\map\<m>\clients\<c>\maxclients\<m>\protocol\<v>"
+ *
+ * The infoResponse payload is a backslash-delimited key/value blob
+ * (alternating keys and values, no trailing backslash).  The leading
+ * backslash before "hostname" is part of the wire format.
+ *
+ * Discovery via these tokens carries no authentication.  Anyone on the
+ * LAN can emit either packet with arbitrary fields.  The auth gate is
+ * the connect handshake (see sv_init.c:SV_DirectConnect and Slice 2
+ * connect-token validation when it lands), not the discovery layer.
+ */
+
+#define OOB_CONNECT          "connect"
+#define OOB_CLIENT_CONNECT   "client_connect"
+#define OOB_GETSERVERS       "getservers"
+#define OOB_GETINFO          "getinfo"
+#define OOB_INFORESPONSE     "infoResponse"
+
+/* Key names inside the infoResponse key/value blob. */
+#define OOB_KEY_HOSTNAME   "hostname"
+#define OOB_KEY_MAP        "map"
+#define OOB_KEY_CLIENTS    "clients"
+#define OOB_KEY_MAXCLIENTS "maxclients"
+#define OOB_KEY_PROTOCOL   "protocol"
+
+#define OOB_KV_SEPARATOR   "\\"
+
+/* mDNS / DNS-SD service type used by sv_mdns.c (advertise) and
+ * cl_mdns.c (browse).  One definition because the unity build
+ * concatenates all .c files in a directory into a single TU. */
+#define MDNS_SERVICE_TYPE  "_openwarcraft3._udp"
+
+#endif /* net_oob_h */

--- a/common/net_oob.h
+++ b/common/net_oob.h
@@ -26,9 +26,15 @@
 #define OOB_CONNECT          "connect"
 #define OOB_CLIENT_CONNECT   "client_connect"
 #define OOB_DISCONNECT       "disconnect"
+#define OOB_REJECT_MSG       "rejectMsg"
 #define OOB_GETSERVERS       "getservers"
 #define OOB_GETINFO          "getinfo"
 #define OOB_INFORESPONSE     "infoResponse"
+
+/* Reason strings sent in OOB_REJECT_MSG replies.  Stable wire strings;
+ * clients may pattern-match on them for localized error display. */
+#define OOB_REJECT_VERSION_MISMATCH "protocol_version_mismatch"
+#define OOB_REJECT_SERVER_FULL      "server_full"
 
 /* Key names inside the infoResponse key/value blob. */
 #define OOB_KEY_HOSTNAME   "hostname"

--- a/common/net_oob.h
+++ b/common/net_oob.h
@@ -43,4 +43,16 @@
  * concatenates all .c files in a directory into a single TU. */
 #define MDNS_SERVICE_TYPE  "_openwarcraft3._udp"
 
+#include "shared.h"
+
+/* Test whether `payload[0 .. len-1]` begins with the OOB ASCII `token`
+ * AND that the byte immediately after the token is a word boundary
+ * (space, NUL, or end-of-payload).  This is the strict variant that
+ * prefix-match dispatch needs: it accepts "getinfo", "getinfo 1",
+ * "getinfo\0...", but rejects "getinfoXYZ" or "getinfomore".
+ *
+ * Returns false on any of: NULL payload, NULL token, len < strlen(token),
+ * bytes-mismatch, or non-boundary trailing byte. */
+bool OOB_TokenMatches(const char *payload, int len, const char *token);
+
 #endif /* net_oob_h */

--- a/common/net_oob.h
+++ b/common/net_oob.h
@@ -25,6 +25,7 @@
 
 #define OOB_CONNECT          "connect"
 #define OOB_CLIENT_CONNECT   "client_connect"
+#define OOB_DISCONNECT       "disconnect"
 #define OOB_GETSERVERS       "getservers"
 #define OOB_GETINFO          "getinfo"
 #define OOB_INFORESPONSE     "infoResponse"

--- a/common/net_oob.h
+++ b/common/net_oob.h
@@ -55,4 +55,15 @@
  * bytes-mismatch, or non-boundary trailing byte. */
 bool OOB_TokenMatches(const char *payload, int len, const char *token);
 
+/* Compile-time-token variant: same semantics but resolves the token
+ * length via sizeof, avoiding strlen() in the hot dispatch loop.
+ * Only safe when TOKEN is a string literal (so sizeof is the buffer
+ * size including NUL). */
+#define OOB_TOKEN_MATCHES_LITERAL(payload, len, TOKEN) \
+    ( (payload) && (len) >= (int)(sizeof(TOKEN) - 1) && \
+      memcmp((payload), (TOKEN), sizeof(TOKEN) - 1) == 0 && \
+      ((int)(len) == (int)(sizeof(TOKEN) - 1) || \
+       (payload)[sizeof(TOKEN) - 1] == ' ' || \
+       (payload)[sizeof(TOKEN) - 1] == '\0') )
+
 #endif /* net_oob_h */

--- a/server/server.h
+++ b/server/server.h
@@ -173,6 +173,18 @@ void SV_InitGameProgs(void);
 // sv_main.c
 void SV_WriteConfigString(LPSIZEBUF msg, DWORD i);
 
+// sv_lan.c
+/* Central OOB packet dispatcher.  Called from SV_ReadPackets with the
+ * full netchan buffer (including the leading 4-byte -1 marker).  No-op
+ * if the packet is shorter than 4 bytes or doesn't carry the OOB
+ * sequence marker.
+ *
+ * Adopted from upstream feature/lan-games' abstraction (corepunch/
+ * openwarcraft3@634b82e).  We keep our Quake 3-flavored wire format
+ * (OOB_GETINFO / OOB_INFORESPONSE) inside the dispatcher; only the
+ * structural pattern is borrowed. */
+void SV_ConnectionlessPacket(const netadr_t *from, LPSIZEBUF msg);
+
 // sv_user.c
 void SV_ExecuteUserCommand(LPSIZEBUF msg, LPCLIENT client);
 

--- a/server/server.h
+++ b/server/server.h
@@ -62,7 +62,16 @@ struct client {
     clientState_t state;
     edict_t *edict; // EDICT_NUM(clientnum+1)
     DWORD lastframe;
+    DWORD drop_time;   // svs.realtime at SV_DropClient; used by SV_Frame
+                       // to transition cs_zombie -> cs_free after
+                       // ZOMBIE_TIME_MS.
 };
+
+/* Milliseconds a cs_zombie slot stays unreusable so an unintended
+ * reconnect from the same address doesn't immediately get the
+ * still-warm state.  Chosen to be longer than typical NAT rebind
+ * latency. */
+#define ZOMBIE_TIME_MS 2000
 
 extern struct server_static {
     struct client clients[MAX_CLIENTS];
@@ -116,6 +125,24 @@ void SV_Map(LPCSTR pFilename);
 void SV_InitGame(void);
 LPCLIENT SV_FindClientByAddr(const netadr_t *from);
 void SV_DirectConnect(const netadr_t *from);
+
+/* Transition `client` to cs_zombie, record drop_time, and bump
+ * sv_advertised_state_version.  The slot moves to cs_free after
+ * ZOMBIE_TIME_MS via the per-frame sweep in SV_Frame.
+ *
+ * Does NOT decrement svs.num_clients; cs_free slots within the
+ * existing range are reused by SV_DirectConnect before growing
+ * num_clients further. */
+void SV_DropClient(LPCLIENT client, LPCSTR reason);
+
+/* Count of currently live (cs_connected or cs_spawned) slots.  This
+ * is what advertised "clients" fields should report, not
+ * svs.num_clients, which counts all slots including cs_zombie / cs_free. */
+DWORD SV_NumLiveClients(void);
+
+/* Walk svs.clients and transition cs_zombie -> cs_free for slots whose
+ * grace period elapsed.  Called once per game tick from SV_Frame. */
+void SV_RunZombieExpiry(void);
 void SV_BuildClientFrame(LPCLIENT client);
 void SV_WriteFrameToClient(LPCLIENT client);
 void SV_ParseClientMessage(LPSIZEBUF msg, LPCLIENT client);

--- a/server/server.h
+++ b/server/server.h
@@ -62,9 +62,12 @@ struct client {
     clientState_t state;
     edict_t *edict; // EDICT_NUM(clientnum+1)
     DWORD lastframe;
-    DWORD drop_time;   // svs.realtime at SV_DropClient; used by SV_Frame
-                       // to transition cs_zombie -> cs_free after
-                       // ZOMBIE_TIME_MS.
+    DWORD drop_time;       // svs.realtime at SV_DropClient; used by
+                           // SV_Frame to transition cs_zombie -> cs_free
+                           // after ZOMBIE_TIME_MS.
+    DWORD last_packet_ms;  // svs.realtime at last received packet from
+                           // this client.  Used by SV_RunClientTimeouts
+                           // to drop silent clients after CLIENT_TIMEOUT_MS.
 };
 
 /* Milliseconds a cs_zombie slot stays unreusable so an unintended
@@ -72,6 +75,11 @@ struct client {
  * still-warm state.  Chosen to be longer than typical NAT rebind
  * latency. */
 #define ZOMBIE_TIME_MS 2000
+
+/* Milliseconds without a packet from a non-loopback client before we
+ * drop them as timed out.  30s tolerates brief network blips while
+ * still reclaiming slots from genuinely-dead peers in bounded time. */
+#define CLIENT_TIMEOUT_MS 30000
 
 extern struct server_static {
     struct client clients[MAX_CLIENTS];
@@ -143,6 +151,11 @@ DWORD SV_NumLiveClients(void);
 /* Walk svs.clients and transition cs_zombie -> cs_free for slots whose
  * grace period elapsed.  Called once per game tick from SV_Frame. */
 void SV_RunZombieExpiry(void);
+
+/* Walk svs.clients and SV_DropClient any non-loopback cs_connected /
+ * cs_spawned slot that hasn't sent a packet in CLIENT_TIMEOUT_MS.
+ * Called once per game tick from SV_Frame. */
+void SV_RunClientTimeouts(void);
 void SV_BuildClientFrame(LPCLIENT client);
 void SV_WriteFrameToClient(LPCLIENT client);
 void SV_ParseClientMessage(LPSIZEBUF msg, LPCLIENT client);

--- a/server/server.h
+++ b/server/server.h
@@ -101,6 +101,16 @@ extern struct server {
 
 extern struct game_export *ge;
 
+/* Monotonically incremented whenever an "advertised" property of the
+ * server changes (map, client count, max clients).  Consumed by:
+ *   - sv_main.c     SV_OOB_GetInfoResponse caches its formatted reply
+ *                   keyed on this counter.
+ *   - sv_mdns.c     SV_MDNS_UpdateInfo skips its TXT push if the
+ *                   counter hasn't moved since the last push.
+ * Callers that mutate the relevant state must bump this; see
+ * SV_ClientConnect, SV_DirectConnect, SV_Map. */
+extern DWORD sv_advertised_state_version;
+
 // sv_init.c
 void SV_Map(LPCSTR pFilename);
 void SV_InitGame(void);

--- a/server/sv_info.c
+++ b/server/sv_info.c
@@ -6,6 +6,7 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "sv_info.h"
@@ -42,6 +43,26 @@ int SV_BuildInfoResponseString(char *out, size_t outlen,
         protocol);
 
     if (n < 0) return 0;
-    if ((size_t)n >= outlen) return (int)(outlen - 1);
+    if ((size_t)n >= outlen) return outlen ? (int)(outlen - 1) : 0;
     return n;
+}
+
+int SV_ParseConnectVersion(const char *payload, int len) {
+    if (!payload) return -1;
+    int token_len = (int)(sizeof(OOB_CONNECT) - 1);
+    if (len <= token_len)            return -1;
+    if (payload[token_len] != ' ')   return -1;
+    int vstart = token_len + 1;
+    int vlen   = len - vstart;
+    if (vlen <= 0)                   return -1;
+
+    /* Bound the digits we copy.  A pathological caller could fabricate
+     * a multi-KB version field; we don't care, only the first few
+     * digits are meaningful. */
+    char vbuf[16];
+    if (vlen >= (int)sizeof(vbuf)) vlen = (int)sizeof(vbuf) - 1;
+    memcpy(vbuf, payload + vstart, (size_t)vlen);
+    vbuf[vlen] = '\0';
+    if (vbuf[0] < '0' || vbuf[0] > '9') return -1;
+    return atoi(vbuf);
 }

--- a/server/sv_info.c
+++ b/server/sv_info.c
@@ -1,0 +1,47 @@
+/*
+ * sv_info.c - Pure formatters for OOB server-info responses.
+ *
+ * No game-state globals, no StormLib, no renderer.  Linkable by the test
+ * binary without pulling in transitive deps.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "sv_info.h"
+#include "../common/net_oob.h"
+
+int SV_BuildInfoResponseString(char *out, size_t outlen,
+                               const char *hostname,
+                               const char *map_path,
+                               DWORD clients,
+                               DWORD maxclients,
+                               int protocol) {
+    // Reduce map_path to its basename so embedded '\\' / '/' separators
+    // don't collide with the kv blob framing.
+    const char *map_base = map_path ? map_path : "";
+    if (map_path) {
+        for (const char *p = map_path; *p; p++) {
+            if (*p == '\\' || *p == '/') {
+                map_base = p + 1;
+            }
+        }
+    }
+
+    int n = snprintf(out, outlen,
+        OOB_INFORESPONSE
+        OOB_KV_SEPARATOR OOB_KEY_HOSTNAME   OOB_KV_SEPARATOR "%s"
+        OOB_KV_SEPARATOR OOB_KEY_MAP        OOB_KV_SEPARATOR "%s"
+        OOB_KV_SEPARATOR OOB_KEY_CLIENTS    OOB_KV_SEPARATOR "%u"
+        OOB_KV_SEPARATOR OOB_KEY_MAXCLIENTS OOB_KV_SEPARATOR "%u"
+        OOB_KV_SEPARATOR OOB_KEY_PROTOCOL   OOB_KV_SEPARATOR "%d",
+        hostname ? hostname : "",
+        map_base,
+        clients,
+        maxclients,
+        protocol);
+
+    if (n < 0) return 0;
+    if ((size_t)n >= outlen) return (int)(outlen - 1);
+    return n;
+}

--- a/server/sv_info.h
+++ b/server/sv_info.h
@@ -1,0 +1,33 @@
+#ifndef sv_info_h
+#define sv_info_h
+
+/*
+ * sv_info.h - Pure formatters for OOB server-info responses.
+ *
+ * Kept separate from sv_main.c so the test binary can link these
+ * functions without dragging in renderer / StormLib / game-library
+ * dependencies.
+ */
+
+#include "../common/shared.h"
+
+/* Format a Quake3-style infoResponse key/value blob into `out`.
+ *
+ * - hostname:    server hostname as reported by gethostname (or fallback).
+ * - map_path:    in-MPQ map path; will be reduced to its basename so the
+ *                response framing is not corrupted by embedded backslashes.
+ * - clients:     current connected client count.
+ * - maxclients:  configured maximum client slots.
+ * - protocol:    PROTOCOL_VERSION at compile time.
+ *
+ * Output begins with the OOB_INFORESPONSE token (no leading -1 sequence;
+ * caller wraps the result via Netchan_OutOfBand).  Returns the number of
+ * bytes written, excluding the terminating null. */
+int SV_BuildInfoResponseString(char *out, size_t outlen,
+                               const char *hostname,
+                               const char *map_path,
+                               DWORD clients,
+                               DWORD maxclients,
+                               int protocol);
+
+#endif /* sv_info_h */

--- a/server/sv_info.h
+++ b/server/sv_info.h
@@ -30,4 +30,9 @@ int SV_BuildInfoResponseString(char *out, size_t outlen,
                                DWORD maxclients,
                                int protocol);
 
+/* Parse the wire form "connect <version>" out of an OOB connect payload.
+ * Returns the parsed version, or -1 if the payload is malformed
+ * (missing space, missing number, oversize number field). */
+int SV_ParseConnectVersion(const char *payload, int len);
+
 #endif /* sv_info_h */

--- a/server/sv_init.c
+++ b/server/sv_init.c
@@ -1,4 +1,5 @@
 #include "server.h"
+#include "../common/net_oob.h"
 #include <arpa/inet.h>
 
 /* Defined here (not sv_main.c) so the test binary, which links sv_init.c
@@ -41,10 +42,17 @@ void SV_ClientConnect(void) {
 }
 
 /* Find the client slot whose netchan address matches from.  For loopback
- * addresses, slot 0 (the local client) is always returned. */
+ * addresses, slot 0 (the local client) is always returned.
+ *
+ * cs_free slots are skipped: their netchan.remote_address may be stale
+ * from a previous occupant and we must not match on that.  cs_zombie
+ * slots ARE matched so that a reconnect during the grace period is
+ * detected as "already registered" and rejected by SV_DirectConnect. */
 LPCLIENT SV_FindClientByAddr(const netadr_t *from) {
     FOR_LOOP(i, svs.num_clients) {
         LPCLIENT cl = &svs.clients[i];
+        if (cl->state == cs_free)
+            continue;
         if (from->type == NA_LOOPBACK &&
             cl->netchan.remote_address.type == NA_LOOPBACK)
             return cl;
@@ -57,18 +65,80 @@ LPCLIENT SV_FindClientByAddr(const netadr_t *from) {
     return NULL;
 }
 
-/* Register a new remote client that sent the first connection packet. */
+DWORD SV_NumLiveClients(void) {
+    DWORD count = 0;
+    FOR_LOOP(i, svs.num_clients) {
+        clientState_t s = svs.clients[i].state;
+        if (s == cs_connected || s == cs_spawned) count++;
+    }
+    return count;
+}
+
+void SV_DropClient(LPCLIENT client, LPCSTR reason) {
+    if (!client) return;
+    if (client->state == cs_free || client->state == cs_zombie) return;
+
+    /* Notify the peer if there's a real UDP socket on the other end.
+     * Loopback clients don't need an OOB notification; we own both
+     * sides of the conversation. */
+    if (client->netchan.remote_address.type == NA_IP) {
+        if (reason && *reason) {
+            Netchan_OutOfBandPrint(NS_SERVER, client->netchan.remote_address,
+                                   OOB_DISCONNECT " %s", reason);
+        } else {
+            Netchan_OutOfBandPrint(NS_SERVER, client->netchan.remote_address,
+                                   OOB_DISCONNECT);
+        }
+    }
+
+    client->state = cs_zombie;
+    client->drop_time = svs.realtime;
+    sv_advertised_state_version++;
+}
+
+/* Sweep called from SV_Frame: transition cs_zombie slots whose grace
+ * period has elapsed into cs_free.  The slot is not zeroed here; the
+ * next SV_DirectConnect that reuses it does a clean memset. */
+void SV_RunZombieExpiry(void) {
+    FOR_LOOP(i, svs.num_clients) {
+        LPCLIENT cl = &svs.clients[i];
+        if (cl->state == cs_zombie &&
+            svs.realtime - cl->drop_time >= ZOMBIE_TIME_MS) {
+            cl->state = cs_free;
+        }
+    }
+}
+
+/* Register a new remote client that sent the first connection packet.
+ *
+ * Slot allocation policy: reuse the lowest cs_free slot if any exists,
+ * otherwise grow svs.num_clients up to MAX_CLIENTS / ge->max_clients.
+ * A reconnect during a slot's cs_zombie grace period is rejected here
+ * via SV_FindClientByAddr (which still matches cs_zombie addresses). */
 void SV_DirectConnect(const netadr_t *from) {
-    // Ignore if address is already registered
     if (SV_FindClientByAddr(from))
         return;
-    if (svs.num_clients >= MAX_CLIENTS ||
-        svs.num_clients >= ge->max_clients) {
-        fprintf(stderr, "SV_DirectConnect: server full\n");
-        return;
+
+    LPCLIENT cl = NULL;
+    FOR_LOOP(i, svs.num_clients) {
+        if (svs.clients[i].state == cs_free) {
+            cl = &svs.clients[i];
+            break;
+        }
     }
-    LPCLIENT cl = &svs.clients[svs.num_clients];
-    svs.num_clients++;
+    if (!cl) {
+        if (svs.num_clients >= MAX_CLIENTS ||
+            svs.num_clients >= ge->max_clients) {
+            fprintf(stderr, "SV_DirectConnect: server full\n");
+            return;
+        }
+        cl = &svs.clients[svs.num_clients];
+        svs.num_clients++;
+    }
+
+    /* Reset on reuse so frames / lastframe / pings from the previous
+     * occupant of this slot don't leak into the new session. */
+    memset(cl, 0, sizeof(*cl));
     sv_advertised_state_version++;
     cl->state = cs_connected;
     cl->netchan.remote_address = *from;

--- a/server/sv_init.c
+++ b/server/sv_init.c
@@ -1,6 +1,10 @@
 #include "server.h"
 #include <arpa/inet.h>
 
+/* Defined here (not sv_main.c) so the test binary, which links sv_init.c
+ * but not sv_main.c, gets the symbol too. */
+DWORD sv_advertised_state_version = 0;
+
 void SV_CreateBaseline(void) {
     sv.baselines = MemAlloc(sizeof(entityState_t) * ge->max_edicts);
     FOR_LOOP(entnum, ge->num_edicts) {
@@ -26,6 +30,7 @@ void SV_ClientConnect(void) {
     }
     LPCLIENT cl = &svs.clients[svs.num_clients];
     svs.num_clients++;
+    sv_advertised_state_version++;
     cl->state = cs_connected;
     // Local client uses the in-process loopback path
     memset(&cl->netchan.remote_address, 0, sizeof(cl->netchan.remote_address));
@@ -64,6 +69,7 @@ void SV_DirectConnect(const netadr_t *from) {
     }
     LPCLIENT cl = &svs.clients[svs.num_clients];
     svs.num_clients++;
+    sv_advertised_state_version++;
     cl->state = cs_connected;
     cl->netchan.remote_address = *from;
     SZ_Init(&cl->netchan.message, cl->netchan.message_buf, MAX_MSGLEN);
@@ -84,6 +90,7 @@ void SV_Map(LPCSTR mapFilename) {
     SV_CreateBaseline();
     ge->SpawnEntities(CM_GetMapInfo(), CM_GetDoodads());
     sv.state = ss_game;
+    sv_advertised_state_version++;  /* map + (later) max_clients changed */
     // Register slot 0 as the local (loopback) client now that the map is ready
     SV_ClientConnect();
 }

--- a/server/sv_init.c
+++ b/server/sv_init.c
@@ -109,6 +109,23 @@ void SV_RunZombieExpiry(void) {
     }
 }
 
+/* Sweep called from SV_Frame: drop non-loopback live clients that
+ * haven't sent a packet in CLIENT_TIMEOUT_MS.  Loopback clients are
+ * exempt because they don't generate real network packets; their
+ * lifecycle is tied to the listen-server's. */
+void SV_RunClientTimeouts(void) {
+    FOR_LOOP(i, svs.num_clients) {
+        LPCLIENT cl = &svs.clients[i];
+        if (cl->state != cs_connected && cl->state != cs_spawned)
+            continue;
+        if (cl->netchan.remote_address.type == NA_LOOPBACK)
+            continue;
+        if (svs.realtime - cl->last_packet_ms >= CLIENT_TIMEOUT_MS) {
+            SV_DropClient(cl, "timeout");
+        }
+    }
+}
+
 /* Register a new remote client that sent the first connection packet.
  *
  * Slot allocation policy: reuse the lowest cs_free slot if any exists,
@@ -142,6 +159,8 @@ void SV_DirectConnect(const netadr_t *from) {
     sv_advertised_state_version++;
     cl->state = cs_connected;
     cl->netchan.remote_address = *from;
+    cl->last_packet_ms = svs.realtime;  /* don't time them out before
+                                         * the first frame */
     SZ_Init(&cl->netchan.message, cl->netchan.message_buf, MAX_MSGLEN);
     Netchan_OutOfBandPrint(NS_SERVER, *from, "client_connect");
     fprintf(stderr, "SV_DirectConnect: new client from %d.%d.%d.%d:%u\n",

--- a/server/sv_lan.c
+++ b/server/sv_lan.c
@@ -1,0 +1,116 @@
+/*
+ * sv_lan.c - Central OOB packet dispatcher for the LAN protocol.
+ *
+ * Architectural pattern adopted from upstream feature/lan-games at
+ * corepunch/openwarcraft3@634b82e ("Add create game setup UI" and
+ * preceding LAN work by Igor Chernakov).  Their `SV_ConnectionlessPacket`
+ * collapses the per-OOB-token dispatch out of `SV_ReadPackets` into a
+ * single entry point; this file is the analogue for our branch.
+ *
+ * Wire format intentionally diverges from upstream: we keep the Quake 3
+ * / dpmaster-flavored tokens (OOB_GETINFO, OOB_INFORESPONSE) defined in
+ * common/net_oob.h rather than upstream's single-token `info` form.
+ * Token dispatch uses our strict OOB_TOKEN_MATCHES_LITERAL macro so
+ * "connectXYZ" does not match "connect".
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>     /* gethostname */
+#include <arpa/inet.h>  /* ntohs */
+
+#include "server.h"
+#include "sv_info.h"
+#include "../common/net_oob.h"
+
+/* Cached at first use; gethostname doesn't change once the system is
+ * up.  Filled lazily so we don't need a separate init hook. */
+static const char *SV_Hostname(void) {
+    static char cached[64];
+    static bool filled = false;
+    if (!filled) {
+        if (gethostname(cached, sizeof(cached)) != 0) {
+            strncpy(cached, "owc3-server", sizeof(cached) - 1);
+        }
+        cached[sizeof(cached) - 1] = '\0';
+        filled = true;
+    }
+    return cached;
+}
+
+/* Wire-level connect handler.  Validates the protocol version embedded
+ * in the OOB connect payload before allocating a slot.  On any pre-slot
+ * rejection, sends an OOB rejectMsg so the client can surface a real
+ * error instead of timing out. */
+void SV_HandleConnectOOB(const char *payload, int len,
+                         const netadr_t *from) {
+    int requested = SV_ParseConnectVersion(payload, len);
+    if (requested != PROTOCOL_VERSION) {
+        Netchan_OutOfBandPrint(NS_SERVER, *from,
+                               OOB_REJECT_MSG " "
+                               OOB_REJECT_VERSION_MISMATCH);
+        fprintf(stderr,
+                "SV_HandleConnectOOB: rejecting %d.%d.%d.%d:%u "
+                "(version %d, expected %d)\n",
+                from->ip[0], from->ip[1], from->ip[2], from->ip[3],
+                ntohs(from->port), requested, PROTOCOL_VERSION);
+        return;
+    }
+    SV_DirectConnect(from);
+}
+
+/* Reply to a LAN server-browser getinfo probe with the current server's
+ * advertised info.  Format follows Quake 3 / dpmaster: backslash-delimited
+ * key/value blob built by SV_BuildInfoResponseString.  No authentication:
+ * anyone on the network can solicit this info, by design.
+ *
+ * The formatted body is cached and only rebuilt when
+ * sv_advertised_state_version moves, so a server browsed by N clients
+ * pays one snprintf per state change, not N. */
+void SV_OOB_GetInfoResponse(const netadr_t *from) {
+    static char body[512];
+    static int  body_len = 0;
+    static DWORD body_for_version = (DWORD)-1;
+
+    if (body_for_version != sv_advertised_state_version) {
+        /* Report the live client count, not svs.num_clients, which
+         * also counts cs_zombie / cs_free slots. */
+        body_len = SV_BuildInfoResponseString(body, sizeof(body),
+                                              SV_Hostname(),
+                                              sv.configstrings[CS_MODELS + 1],
+                                              SV_NumLiveClients(),
+                                              ge ? ge->max_clients : 0,
+                                              PROTOCOL_VERSION);
+        body_for_version = sv_advertised_state_version;
+    }
+    Netchan_OutOfBand(NS_SERVER, *from, (DWORD)body_len, (BYTE *)body);
+}
+
+void SV_ConnectionlessPacket(const netadr_t *from, LPSIZEBUF msg) {
+    if (!msg || msg->cursize < 4) return;
+
+    int hdr;
+    memcpy(&hdr, msg->data, sizeof(hdr));
+    if (hdr != -1) return;
+
+    const char *payload  = (const char *)msg->data + 4;
+    int         pay_len  = (int)msg->cursize - 4;
+
+    if (OOB_TOKEN_MATCHES_LITERAL(payload, pay_len, OOB_CONNECT)) {
+        SV_HandleConnectOOB(payload, pay_len, from);
+        return;
+    }
+    if (OOB_TOKEN_MATCHES_LITERAL(payload, pay_len, OOB_GETINFO)) {
+        SV_OOB_GetInfoResponse(from);
+        return;
+    }
+    if (OOB_TOKEN_MATCHES_LITERAL(payload, pay_len, OOB_DISCONNECT)) {
+        /* Peer-initiated disconnect.  Match the address to a known
+         * slot; SV_DropClient is a no-op on cs_free / cs_zombie. */
+        LPCLIENT cl = SV_FindClientByAddr(from);
+        if (cl) SV_DropClient(cl, "peer_request");
+        return;
+    }
+    /* Unknown OOB token: silently drop.  Logging is the caller's job. */
+}

--- a/server/sv_main.c
+++ b/server/sv_main.c
@@ -73,16 +73,26 @@ static const char *SV_Hostname(void) {
 /* Reply to a LAN server-browser getinfo probe with the current server's
  * advertised info.  Format follows Quake 3 / dpmaster: backslash-delimited
  * key/value blob built by SV_BuildInfoResponseString.  No authentication:
- * anyone on the network can solicit this info, by design. */
+ * anyone on the network can solicit this info, by design.
+ *
+ * The formatted body is cached and only rebuilt when
+ * sv_advertised_state_version moves, so a server browsed by N clients
+ * pays one snprintf per state change, not N. */
 static void SV_OOB_GetInfoResponse(const netadr_t *from) {
-    char body[512];
-    int len = SV_BuildInfoResponseString(body, sizeof(body),
-                                         SV_Hostname(),
-                                         sv.configstrings[CS_MODELS + 1],
-                                         svs.num_clients,
-                                         ge ? ge->max_clients : 0,
-                                         PROTOCOL_VERSION);
-    Netchan_OutOfBand(NS_SERVER, *from, (DWORD)len, (BYTE *)body);
+    static char body[512];
+    static int  body_len = 0;
+    static DWORD body_for_version = (DWORD)-1;
+
+    if (body_for_version != sv_advertised_state_version) {
+        body_len = SV_BuildInfoResponseString(body, sizeof(body),
+                                              SV_Hostname(),
+                                              sv.configstrings[CS_MODELS + 1],
+                                              svs.num_clients,
+                                              ge ? ge->max_clients : 0,
+                                              PROTOCOL_VERSION);
+        body_for_version = sv_advertised_state_version;
+    }
+    Netchan_OutOfBand(NS_SERVER, *from, (DWORD)body_len, (BYTE *)body);
 }
 
 /* Read and dispatch all pending client messages from the network buffers. */
@@ -107,10 +117,11 @@ static void SV_ReadPackets(void) {
             if (hdr == -1) {
                 const char *oob_token = (const char *)net_message.data + 4;
                 int oob_token_max = r - 4;
-                if (OOB_TokenMatches(oob_token, oob_token_max, OOB_CONNECT)) {
+                if (OOB_TOKEN_MATCHES_LITERAL(oob_token, oob_token_max,
+                                              OOB_CONNECT)) {
                     SV_DirectConnect(&from);
-                } else if (OOB_TokenMatches(oob_token, oob_token_max,
-                                            OOB_GETINFO)) {
+                } else if (OOB_TOKEN_MATCHES_LITERAL(oob_token, oob_token_max,
+                                                    OOB_GETINFO)) {
                     SV_OOB_GetInfoResponse(&from);
                 }
                 continue;
@@ -194,7 +205,7 @@ void SV_RunGameFrame(void) {
     ge->RunFrame();
 }
 
-#define SV_MDNS_REFRESH_INTERVAL_MS 1000
+#define SV_MDNS_POLL_INTERVAL_MS 10
 
 /* Main server tick called from the platform event loop with the elapsed
  * milliseconds since the last call.  Returns immediately if it is not yet
@@ -202,25 +213,26 @@ void SV_RunGameFrame(void) {
 void SV_Frame(DWORD msec) {
     svs.realtime += msec;
 
-    // mDNS housekeeping runs every host tick, not just every game tick,
-    // so service-discovery latency doesn't track FRAMETIME.
-    SV_MDNS_Tick();
+    // mDNS housekeeping at ~100 Hz max, not the host frame rate.  The
+    // syscall floor inside avahi_simple_poll_iterate(0) isn't worth
+    // paying at 200-1000 Hz on modern displays.
+    static DWORD sv_mdns_last_poll_ms = 0;
+    if (svs.realtime - sv_mdns_last_poll_ms >= SV_MDNS_POLL_INTERVAL_MS) {
+        SV_MDNS_Tick();
+        sv_mdns_last_poll_ms = svs.realtime;
+    }
 
     if (svs.realtime < sv.time) {
         return;
     }
 
-    // Refresh TXT records on a wall-clock cadence, not a frame-count one,
-    // so SV_Map's reset of framenum doesn't shift the refresh phase.
-    // Avahi only emits a wire update when records actually change, so
-    // calling this when nothing changed is essentially free.
-    static DWORD sv_mdns_last_refresh_ms = 0;
-    if (svs.realtime - sv_mdns_last_refresh_ms >= SV_MDNS_REFRESH_INTERVAL_MS) {
-        SV_MDNS_UpdateInfo(sv.configstrings[CS_MODELS + 1],
-                           svs.num_clients,
-                           ge ? ge->max_clients : 0);
-        sv_mdns_last_refresh_ms = svs.realtime;
-    }
+    // Push current state to mDNS unconditionally each game tick; the
+    // SV_MDNS_UpdateInfo implementation no-ops when
+    // sv_advertised_state_version hasn't moved, so this is essentially
+    // free when nothing has changed.
+    SV_MDNS_UpdateInfo(sv.configstrings[CS_MODELS + 1],
+                       svs.num_clients,
+                       ge ? ge->max_clients : 0);
 
     SV_ReadPackets();
 

--- a/server/sv_main.c
+++ b/server/sv_main.c
@@ -12,6 +12,7 @@
 #include "../common/net_oob.h"
 #include "sv_info.h"
 #include "sv_mdns.h"
+#include <arpa/inet.h>  // ntohs
 #include <unistd.h>     // gethostname
 
 //#define PRINT_ANIMATIONS
@@ -52,6 +53,27 @@ static void SV_SendClientMessages(void) {
             SV_SendClientDatagram(client);
         }
     }
+}
+
+/* Wire-level connect handler invoked by SV_ReadPackets.  Validates the
+ * protocol version embedded in the OOB connect payload before allocating
+ * a slot.  On any pre-slot rejection, send an OOB rejectMsg so the
+ * client can surface a real error instead of timing out. */
+static void SV_HandleConnectOOB(const char *payload, int len,
+                                const netadr_t *from) {
+    int requested = SV_ParseConnectVersion(payload, len);
+    if (requested != PROTOCOL_VERSION) {
+        Netchan_OutOfBandPrint(NS_SERVER, *from,
+                               OOB_REJECT_MSG " "
+                               OOB_REJECT_VERSION_MISMATCH);
+        fprintf(stderr,
+                "SV_HandleConnectOOB: rejecting %d.%d.%d.%d:%u "
+                "(version %d, expected %d)\n",
+                from->ip[0], from->ip[1], from->ip[2], from->ip[3],
+                ntohs(from->port), requested, PROTOCOL_VERSION);
+        return;
+    }
+    SV_DirectConnect(from);
 }
 
 /* Cached at first use; gethostname is cheap but pointless to call on
@@ -122,7 +144,7 @@ static void SV_ReadPackets(void) {
                 int oob_token_max = r - 4;
                 if (OOB_TOKEN_MATCHES_LITERAL(oob_token, oob_token_max,
                                               OOB_CONNECT)) {
-                    SV_DirectConnect(&from);
+                    SV_HandleConnectOOB(oob_token, oob_token_max, &from);
                 } else if (OOB_TOKEN_MATCHES_LITERAL(oob_token, oob_token_max,
                                                     OOB_GETINFO)) {
                     SV_OOB_GetInfoResponse(&from);

--- a/server/sv_main.c
+++ b/server/sv_main.c
@@ -9,11 +9,7 @@
  * Entry point called from the platform main loop: SV_Frame().
  */
 #include "server.h"
-#include "../common/net_oob.h"
-#include "sv_info.h"
 #include "sv_mdns.h"
-#include <arpa/inet.h>  // ntohs
-#include <unistd.h>     // gethostname
 
 //#define PRINT_ANIMATIONS
 
@@ -55,71 +51,6 @@ static void SV_SendClientMessages(void) {
     }
 }
 
-/* Wire-level connect handler invoked by SV_ReadPackets.  Validates the
- * protocol version embedded in the OOB connect payload before allocating
- * a slot.  On any pre-slot rejection, send an OOB rejectMsg so the
- * client can surface a real error instead of timing out. */
-static void SV_HandleConnectOOB(const char *payload, int len,
-                                const netadr_t *from) {
-    int requested = SV_ParseConnectVersion(payload, len);
-    if (requested != PROTOCOL_VERSION) {
-        Netchan_OutOfBandPrint(NS_SERVER, *from,
-                               OOB_REJECT_MSG " "
-                               OOB_REJECT_VERSION_MISMATCH);
-        fprintf(stderr,
-                "SV_HandleConnectOOB: rejecting %d.%d.%d.%d:%u "
-                "(version %d, expected %d)\n",
-                from->ip[0], from->ip[1], from->ip[2], from->ip[3],
-                ntohs(from->port), requested, PROTOCOL_VERSION);
-        return;
-    }
-    SV_DirectConnect(from);
-}
-
-/* Cached at first use; gethostname is cheap but pointless to call on
- * every getinfo / mDNS refresh.  Filled lazily so we don't need a
- * separate init hook on the server-startup path. */
-static const char *SV_Hostname(void) {
-    static char cached[64];
-    static bool filled = false;
-    if (!filled) {
-        if (gethostname(cached, sizeof(cached)) != 0) {
-            strncpy(cached, "owc3-server", sizeof(cached) - 1);
-        }
-        cached[sizeof(cached) - 1] = '\0';
-        filled = true;
-    }
-    return cached;
-}
-
-/* Reply to a LAN server-browser getinfo probe with the current server's
- * advertised info.  Format follows Quake 3 / dpmaster: backslash-delimited
- * key/value blob built by SV_BuildInfoResponseString.  No authentication:
- * anyone on the network can solicit this info, by design.
- *
- * The formatted body is cached and only rebuilt when
- * sv_advertised_state_version moves, so a server browsed by N clients
- * pays one snprintf per state change, not N. */
-static void SV_OOB_GetInfoResponse(const netadr_t *from) {
-    static char body[512];
-    static int  body_len = 0;
-    static DWORD body_for_version = (DWORD)-1;
-
-    if (body_for_version != sv_advertised_state_version) {
-        /* Report the live client count, not svs.num_clients, which
-         * also counts cs_zombie / cs_free slots that aren't really
-         * "in" the game. */
-        body_len = SV_BuildInfoResponseString(body, sizeof(body),
-                                              SV_Hostname(),
-                                              sv.configstrings[CS_MODELS + 1],
-                                              SV_NumLiveClients(),
-                                              ge ? ge->max_clients : 0,
-                                              PROTOCOL_VERSION);
-        body_for_version = sv_advertised_state_version;
-    }
-    Netchan_OutOfBand(NS_SERVER, *from, (DWORD)body_len, (BYTE *)body);
-}
-
 /* Read and dispatch all pending client messages from the network buffers. */
 static void SV_ReadPackets(void) {
     static BYTE net_message_buffer[MAX_MSGLEN];
@@ -132,31 +63,14 @@ static void SV_ReadPackets(void) {
     netadr_t from;
     int r;
     while ((r = NET_GetPacket(NS_SERVER, &from, &net_message)) != 0) {
-        // Out-of-band packets (first 4 bytes == -1) are stateless requests:
-        // connect handshake, server-browser getinfo, etc.  Dispatch by the
-        // ASCII token that follows the -1 marker.  No client slot is
-        // allocated by anything but the connect path.
+        /* OOB packets (first 4 bytes == -1) route to the central
+         * dispatcher in sv_lan.c.  In-band packets go to the per-slot
+         * parser. */
         if (r >= 4) {
             int hdr;
             memcpy(&hdr, net_message.data, sizeof(hdr));
             if (hdr == -1) {
-                const char *oob_token = (const char *)net_message.data + 4;
-                int oob_token_max = r - 4;
-                if (OOB_TOKEN_MATCHES_LITERAL(oob_token, oob_token_max,
-                                              OOB_CONNECT)) {
-                    SV_HandleConnectOOB(oob_token, oob_token_max, &from);
-                } else if (OOB_TOKEN_MATCHES_LITERAL(oob_token, oob_token_max,
-                                                    OOB_GETINFO)) {
-                    SV_OOB_GetInfoResponse(&from);
-                } else if (OOB_TOKEN_MATCHES_LITERAL(oob_token, oob_token_max,
-                                                    OOB_DISCONNECT)) {
-                    /* Peer-initiated disconnect.  cs_free addresses
-                     * don't match; cs_zombie ones match but
-                     * SV_DropClient no-ops on them, so a duplicate
-                     * disconnect is harmless. */
-                    LPCLIENT cl = SV_FindClientByAddr(&from);
-                    if (cl) SV_DropClient(cl, "peer_request");
-                }
+                SV_ConnectionlessPacket(&from, &net_message);
                 continue;
             }
         }

--- a/server/sv_main.c
+++ b/server/sv_main.c
@@ -9,6 +9,10 @@
  * Entry point called from the platform main loop: SV_Frame().
  */
 #include "server.h"
+#include "../common/net_oob.h"
+#include "sv_info.h"
+#include "sv_mdns.h"
+#include <unistd.h>     // gethostname
 
 //#define PRINT_ANIMATIONS
 
@@ -50,6 +54,27 @@ static void SV_SendClientMessages(void) {
     }
 }
 
+/* Reply to a LAN server-browser getinfo probe with the current server's
+ * advertised info.  Format follows Quake 3 / dpmaster: backslash-delimited
+ * key/value blob built by SV_BuildInfoResponseString.  No authentication:
+ * anyone on the network can solicit this info, by design. */
+static void SV_OOB_GetInfoResponse(const netadr_t *from) {
+    char hostname[64];
+    if (gethostname(hostname, sizeof(hostname)) != 0) {
+        strncpy(hostname, "owc3-server", sizeof(hostname) - 1);
+    }
+    hostname[sizeof(hostname) - 1] = '\0';
+
+    char body[512];
+    int len = SV_BuildInfoResponseString(body, sizeof(body),
+                                         hostname,
+                                         sv.configstrings[CS_MODELS + 1],
+                                         svs.num_clients,
+                                         ge ? ge->max_clients : 0,
+                                         PROTOCOL_VERSION);
+    Netchan_OutOfBand(NS_SERVER, *from, (DWORD)len, (BYTE *)body);
+}
+
 /* Read and dispatch all pending client messages from the network buffers. */
 static void SV_ReadPackets(void) {
     static BYTE net_message_buffer[MAX_MSGLEN];
@@ -62,16 +87,24 @@ static void SV_ReadPackets(void) {
     netadr_t from;
     int r;
     while ((r = NET_GetPacket(NS_SERVER, &from, &net_message)) != 0) {
-        // Out-of-band packets (first 4 bytes == -1) are connection requests.
-        // Validate that the payload starts with "connect" before allocating
-        // a client slot, to prevent trivial slot-filling / DoS.
+        // Out-of-band packets (first 4 bytes == -1) are stateless requests:
+        // connect handshake, server-browser getinfo, etc.  Dispatch by the
+        // ASCII token that follows the -1 marker.  No client slot is
+        // allocated by anything but the connect path.
         if (r >= 4) {
             int hdr;
             memcpy(&hdr, net_message.data, sizeof(hdr));
             if (hdr == -1) {
-                if (r >= 4 + 7 &&
-                    memcmp(net_message.data + 4, "connect", 7) == 0) {
+                const char *oob_token = (const char *)net_message.data + 4;
+                int oob_token_max = r - 4;
+                if (oob_token_max >= (int)(sizeof(OOB_CONNECT) - 1) &&
+                    memcmp(oob_token, OOB_CONNECT,
+                           sizeof(OOB_CONNECT) - 1) == 0) {
                     SV_DirectConnect(&from);
+                } else if (oob_token_max >= (int)(sizeof(OOB_GETINFO) - 1) &&
+                           memcmp(oob_token, OOB_GETINFO,
+                                  sizeof(OOB_GETINFO) - 1) == 0) {
+                    SV_OOB_GetInfoResponse(&from);
                 }
                 continue;
             }
@@ -159,9 +192,21 @@ void SV_RunGameFrame(void) {
  * time for a new game frame so the caller can do other work. */
 void SV_Frame(DWORD msec) {
     svs.realtime += msec;
-    
+
+    // mDNS housekeeping runs every host tick, not just every game tick,
+    // so service-discovery latency doesn't track FRAMETIME.
+    SV_MDNS_Tick();
+
     if (svs.realtime < sv.time) {
         return;
+    }
+
+    // Refresh TXT records once per second-ish.  Avahi only pushes deltas
+    // on the wire so calling this when nothing changed is essentially free.
+    if ((sv.framenum % 10) == 0) {
+        SV_MDNS_UpdateInfo(sv.configstrings[CS_MODELS + 1],
+                           svs.num_clients,
+                           ge ? ge->max_clients : 0);
     }
 
     SV_ReadPackets();

--- a/server/sv_main.c
+++ b/server/sv_main.c
@@ -54,20 +54,30 @@ static void SV_SendClientMessages(void) {
     }
 }
 
+/* Cached at first use; gethostname is cheap but pointless to call on
+ * every getinfo / mDNS refresh.  Filled lazily so we don't need a
+ * separate init hook on the server-startup path. */
+static const char *SV_Hostname(void) {
+    static char cached[64];
+    static bool filled = false;
+    if (!filled) {
+        if (gethostname(cached, sizeof(cached)) != 0) {
+            strncpy(cached, "owc3-server", sizeof(cached) - 1);
+        }
+        cached[sizeof(cached) - 1] = '\0';
+        filled = true;
+    }
+    return cached;
+}
+
 /* Reply to a LAN server-browser getinfo probe with the current server's
  * advertised info.  Format follows Quake 3 / dpmaster: backslash-delimited
  * key/value blob built by SV_BuildInfoResponseString.  No authentication:
  * anyone on the network can solicit this info, by design. */
 static void SV_OOB_GetInfoResponse(const netadr_t *from) {
-    char hostname[64];
-    if (gethostname(hostname, sizeof(hostname)) != 0) {
-        strncpy(hostname, "owc3-server", sizeof(hostname) - 1);
-    }
-    hostname[sizeof(hostname) - 1] = '\0';
-
     char body[512];
     int len = SV_BuildInfoResponseString(body, sizeof(body),
-                                         hostname,
+                                         SV_Hostname(),
                                          sv.configstrings[CS_MODELS + 1],
                                          svs.num_clients,
                                          ge ? ge->max_clients : 0,
@@ -97,13 +107,10 @@ static void SV_ReadPackets(void) {
             if (hdr == -1) {
                 const char *oob_token = (const char *)net_message.data + 4;
                 int oob_token_max = r - 4;
-                if (oob_token_max >= (int)(sizeof(OOB_CONNECT) - 1) &&
-                    memcmp(oob_token, OOB_CONNECT,
-                           sizeof(OOB_CONNECT) - 1) == 0) {
+                if (OOB_TokenMatches(oob_token, oob_token_max, OOB_CONNECT)) {
                     SV_DirectConnect(&from);
-                } else if (oob_token_max >= (int)(sizeof(OOB_GETINFO) - 1) &&
-                           memcmp(oob_token, OOB_GETINFO,
-                                  sizeof(OOB_GETINFO) - 1) == 0) {
+                } else if (OOB_TokenMatches(oob_token, oob_token_max,
+                                            OOB_GETINFO)) {
                     SV_OOB_GetInfoResponse(&from);
                 }
                 continue;
@@ -187,6 +194,8 @@ void SV_RunGameFrame(void) {
     ge->RunFrame();
 }
 
+#define SV_MDNS_REFRESH_INTERVAL_MS 1000
+
 /* Main server tick called from the platform event loop with the elapsed
  * milliseconds since the last call.  Returns immediately if it is not yet
  * time for a new game frame so the caller can do other work. */
@@ -201,12 +210,16 @@ void SV_Frame(DWORD msec) {
         return;
     }
 
-    // Refresh TXT records once per second-ish.  Avahi only pushes deltas
-    // on the wire so calling this when nothing changed is essentially free.
-    if ((sv.framenum % 10) == 0) {
+    // Refresh TXT records on a wall-clock cadence, not a frame-count one,
+    // so SV_Map's reset of framenum doesn't shift the refresh phase.
+    // Avahi only emits a wire update when records actually change, so
+    // calling this when nothing changed is essentially free.
+    static DWORD sv_mdns_last_refresh_ms = 0;
+    if (svs.realtime - sv_mdns_last_refresh_ms >= SV_MDNS_REFRESH_INTERVAL_MS) {
         SV_MDNS_UpdateInfo(sv.configstrings[CS_MODELS + 1],
                            svs.num_clients,
                            ge ? ge->max_clients : 0);
+        sv_mdns_last_refresh_ms = svs.realtime;
     }
 
     SV_ReadPackets();

--- a/server/sv_main.c
+++ b/server/sv_main.c
@@ -84,10 +84,13 @@ static void SV_OOB_GetInfoResponse(const netadr_t *from) {
     static DWORD body_for_version = (DWORD)-1;
 
     if (body_for_version != sv_advertised_state_version) {
+        /* Report the live client count, not svs.num_clients, which
+         * also counts cs_zombie / cs_free slots that aren't really
+         * "in" the game. */
         body_len = SV_BuildInfoResponseString(body, sizeof(body),
                                               SV_Hostname(),
                                               sv.configstrings[CS_MODELS + 1],
-                                              svs.num_clients,
+                                              SV_NumLiveClients(),
                                               ge ? ge->max_clients : 0,
                                               PROTOCOL_VERSION);
         body_for_version = sv_advertised_state_version;
@@ -123,6 +126,14 @@ static void SV_ReadPackets(void) {
                 } else if (OOB_TOKEN_MATCHES_LITERAL(oob_token, oob_token_max,
                                                     OOB_GETINFO)) {
                     SV_OOB_GetInfoResponse(&from);
+                } else if (OOB_TOKEN_MATCHES_LITERAL(oob_token, oob_token_max,
+                                                    OOB_DISCONNECT)) {
+                    /* Peer-initiated disconnect.  cs_free addresses
+                     * don't match; cs_zombie ones match but
+                     * SV_DropClient no-ops on them, so a duplicate
+                     * disconnect is harmless. */
+                    LPCLIENT cl = SV_FindClientByAddr(&from);
+                    if (cl) SV_DropClient(cl, "peer_request");
                 }
                 continue;
             }
@@ -226,12 +237,16 @@ void SV_Frame(DWORD msec) {
         return;
     }
 
+    /* Zombie -> free transition for slots whose grace period elapsed.
+     * Cheap walk; bounded by svs.num_clients <= MAX_CLIENTS. */
+    SV_RunZombieExpiry();
+
     // Push current state to mDNS unconditionally each game tick; the
     // SV_MDNS_UpdateInfo implementation no-ops when
     // sv_advertised_state_version hasn't moved, so this is essentially
-    // free when nothing has changed.
+    // free when nothing has changed.  Live count, not allocated count.
     SV_MDNS_UpdateInfo(sv.configstrings[CS_MODELS + 1],
-                       svs.num_clients,
+                       SV_NumLiveClients(),
                        ge ? ge->max_clients : 0);
 
     SV_ReadPackets();

--- a/server/sv_main.c
+++ b/server/sv_main.c
@@ -162,6 +162,9 @@ static void SV_ReadPackets(void) {
         }
         LPCLIENT client = SV_FindClientByAddr(&from);
         if (client) {
+            /* Refresh the per-client liveness clock so the timeout
+             * sweep doesn't drop them mid-conversation. */
+            client->last_packet_ms = svs.realtime;
             SV_ParseClientMessage(&net_message, client);
         }
     }
@@ -262,6 +265,11 @@ void SV_Frame(DWORD msec) {
     /* Zombie -> free transition for slots whose grace period elapsed.
      * Cheap walk; bounded by svs.num_clients <= MAX_CLIENTS. */
     SV_RunZombieExpiry();
+
+    /* Drop silent clients (no packet in CLIENT_TIMEOUT_MS).  Loopback
+     * clients are exempt.  This runs after the zombie sweep so a
+     * just-timed-out client transitions cleanly through cs_zombie. */
+    SV_RunClientTimeouts();
 
     // Push current state to mDNS unconditionally each game tick; the
     // SV_MDNS_UpdateInfo implementation no-ops when

--- a/server/sv_mdns.c
+++ b/server/sv_mdns.c
@@ -1,0 +1,240 @@
+/*
+ * sv_mdns.c - mDNS/DNS-SD service advertisement for the listen server.
+ *
+ * Avahi-based on Linux; stubs on other platforms.  Service type is
+ * `_openwarcraft3._udp` per the network plan.
+ */
+
+#include "sv_mdns.h"
+
+#ifdef __linux__
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <avahi-client/client.h>
+#include <avahi-client/publish.h>
+#include <avahi-common/simple-watch.h>
+#include <avahi-common/error.h>
+#include <avahi-common/strlst.h>
+#include <avahi-common/alternative.h>
+#include <avahi-common/malloc.h>
+
+#include "../common/net.h"
+#include "../common/net_oob.h"
+
+#define MDNS_HOSTNAME_MAX   64
+#define MDNS_MAP_MAX        64
+#define MDNS_SERVICE_MAX    64
+#define MDNS_TXT_FIELD_MAX  128
+
+static AvahiSimplePoll  *sv_mdns_poll        = NULL;
+static AvahiClient      *sv_mdns_client      = NULL;
+static AvahiEntryGroup  *sv_mdns_group       = NULL;
+static unsigned short    sv_mdns_port        = 0;
+static char              sv_mdns_map[MDNS_MAP_MAX]                = "";
+static DWORD             sv_sv_mdns_clients     = 0;
+static DWORD             sv_mdns_maxclients  = 0;
+static char              sv_mdns_service_name[MDNS_SERVICE_MAX]   = "OpenWarcraft3";
+
+static void sv_mdns_create_service(AvahiClient *c);
+static void sv_mdns_entry_group_callback(AvahiEntryGroup *g,
+                                      AvahiEntryGroupState state,
+                                      void *userdata);
+static void sv_sv_mdns_client_callback(AvahiClient *c,
+                                 AvahiClientState state,
+                                 void *userdata);
+
+/* Reduce a path to its basename, copying into a bounded buffer. */
+static void sv_mdns_basename(const char *path, char *out, size_t outlen) {
+    const char *base = path ? path : "";
+    if (path) {
+        for (const char *p = path; *p; p++) {
+            if (*p == '\\' || *p == '/') base = p + 1;
+        }
+    }
+    strncpy(out, base, outlen - 1);
+    out[outlen - 1] = '\0';
+}
+
+/* Build the TXT-record string list reflecting current server info.
+ * Caller owns the result and must free it with avahi_string_list_free. */
+static AvahiStringList *sv_mdns_build_txt_records(void) {
+    char hostname[MDNS_HOSTNAME_MAX];
+    if (gethostname(hostname, sizeof(hostname)) != 0) {
+        strncpy(hostname, "owc3-server", sizeof(hostname) - 1);
+    }
+    hostname[sizeof(hostname) - 1] = '\0';
+
+    char map_base[MDNS_MAP_MAX];
+    sv_mdns_basename(sv_mdns_map, map_base, sizeof(map_base));
+
+    char f_hostname[MDNS_TXT_FIELD_MAX];
+    char f_map[MDNS_TXT_FIELD_MAX];
+    char f_clients[MDNS_TXT_FIELD_MAX];
+    char f_maxclients[MDNS_TXT_FIELD_MAX];
+    char f_protocol[MDNS_TXT_FIELD_MAX];
+    snprintf(f_hostname,   sizeof(f_hostname),   "hostname=%s", hostname);
+    snprintf(f_map,        sizeof(f_map),        "map=%s", map_base);
+    snprintf(f_clients,    sizeof(f_clients),    "clients=%u", sv_sv_mdns_clients);
+    snprintf(f_maxclients, sizeof(f_maxclients), "maxclients=%u", sv_mdns_maxclients);
+    snprintf(f_protocol,   sizeof(f_protocol),   "protocol=%d", PROTOCOL_VERSION);
+
+    AvahiStringList *l = NULL;
+    l = avahi_string_list_add(l, f_hostname);
+    l = avahi_string_list_add(l, f_map);
+    l = avahi_string_list_add(l, f_clients);
+    l = avahi_string_list_add(l, f_maxclients);
+    l = avahi_string_list_add(l, f_protocol);
+    return l;
+}
+
+static void sv_mdns_create_service(AvahiClient *c) {
+    if (!sv_mdns_group) {
+        sv_mdns_group = avahi_entry_group_new(c, sv_mdns_entry_group_callback, NULL);
+        if (!sv_mdns_group) {
+            fprintf(stderr, "SV_MDNS: avahi_entry_group_new failed: %s\n",
+                    avahi_strerror(avahi_client_errno(c)));
+            return;
+        }
+    }
+    if (!avahi_entry_group_is_empty(sv_mdns_group)) {
+        return;
+    }
+
+    AvahiStringList *txt = sv_mdns_build_txt_records();
+    int r = avahi_entry_group_add_service_strlst(
+        sv_mdns_group, AVAHI_IF_UNSPEC, AVAHI_PROTO_INET, 0,
+        sv_mdns_service_name, MDNS_SERVICE_TYPE,
+        NULL, NULL, sv_mdns_port, txt);
+    avahi_string_list_free(txt);
+
+    if (r < 0) {
+        if (r == AVAHI_ERR_COLLISION) {
+            char *new_name = avahi_alternative_service_name(sv_mdns_service_name);
+            if (new_name) {
+                strncpy(sv_mdns_service_name, new_name, sizeof(sv_mdns_service_name) - 1);
+                sv_mdns_service_name[sizeof(sv_mdns_service_name) - 1] = '\0';
+                avahi_free(new_name);
+                avahi_entry_group_reset(sv_mdns_group);
+                sv_mdns_create_service(c);
+            }
+            return;
+        }
+        fprintf(stderr, "SV_MDNS: add_service failed: %s\n", avahi_strerror(r));
+        return;
+    }
+
+    r = avahi_entry_group_commit(sv_mdns_group);
+    if (r < 0) {
+        fprintf(stderr, "SV_MDNS: commit failed: %s\n", avahi_strerror(r));
+    }
+}
+
+static void sv_mdns_entry_group_callback(AvahiEntryGroup *g,
+                                      AvahiEntryGroupState state,
+                                      void *userdata) {
+    (void)g;
+    (void)userdata;
+    if (state == AVAHI_ENTRY_GROUP_COLLISION) {
+        char *new_name = avahi_alternative_service_name(sv_mdns_service_name);
+        if (new_name) {
+            strncpy(sv_mdns_service_name, new_name, sizeof(sv_mdns_service_name) - 1);
+            sv_mdns_service_name[sizeof(sv_mdns_service_name) - 1] = '\0';
+            avahi_free(new_name);
+            if (sv_mdns_client) {
+                avahi_entry_group_reset(sv_mdns_group);
+                sv_mdns_create_service(sv_mdns_client);
+            }
+        }
+    } else if (state == AVAHI_ENTRY_GROUP_FAILURE) {
+        fprintf(stderr, "SV_MDNS: entry group failure: %s\n",
+                avahi_strerror(avahi_client_errno(avahi_entry_group_get_client(g))));
+    }
+}
+
+static void sv_sv_mdns_client_callback(AvahiClient *c,
+                                 AvahiClientState state,
+                                 void *userdata) {
+    (void)userdata;
+    if (state == AVAHI_CLIENT_S_RUNNING) {
+        sv_mdns_create_service(c);
+    } else if (state == AVAHI_CLIENT_FAILURE) {
+        fprintf(stderr, "SV_MDNS: client failure: %s\n",
+                avahi_strerror(avahi_client_errno(c)));
+    } else if (state == AVAHI_CLIENT_S_COLLISION ||
+               state == AVAHI_CLIENT_S_REGISTERING) {
+        if (sv_mdns_group) {
+            avahi_entry_group_reset(sv_mdns_group);
+        }
+    }
+}
+
+void SV_MDNS_Init(unsigned short port) {
+    sv_mdns_port = port;
+    sv_mdns_poll = avahi_simple_poll_new();
+    if (!sv_mdns_poll) {
+        fprintf(stderr, "SV_MDNS: avahi_simple_poll_new failed\n");
+        return;
+    }
+    int error;
+    sv_mdns_client = avahi_client_new(avahi_simple_poll_get(sv_mdns_poll), 0,
+                                    sv_sv_mdns_client_callback, NULL, &error);
+    if (!sv_mdns_client) {
+        fprintf(stderr, "SV_MDNS: avahi_client_new failed: %s\n",
+                avahi_strerror(error));
+        avahi_simple_poll_free(sv_mdns_poll);
+        sv_mdns_poll = NULL;
+    }
+}
+
+void SV_MDNS_UpdateInfo(const char *map_path, DWORD clients, DWORD maxclients) {
+    if (map_path) {
+        strncpy(sv_mdns_map, map_path, sizeof(sv_mdns_map) - 1);
+        sv_mdns_map[sizeof(sv_mdns_map) - 1] = '\0';
+    }
+    sv_sv_mdns_clients    = clients;
+    sv_mdns_maxclients = maxclients;
+
+    if (sv_mdns_group && !avahi_entry_group_is_empty(sv_mdns_group)) {
+        AvahiStringList *txt = sv_mdns_build_txt_records();
+        int r = avahi_entry_group_update_service_txt_strlst(
+            sv_mdns_group, AVAHI_IF_UNSPEC, AVAHI_PROTO_INET, 0,
+            sv_mdns_service_name, MDNS_SERVICE_TYPE, NULL, txt);
+        avahi_string_list_free(txt);
+        if (r < 0) {
+            fprintf(stderr, "SV_MDNS: update_txt failed: %s\n", avahi_strerror(r));
+        }
+    }
+}
+
+void SV_MDNS_Tick(void) {
+    if (sv_mdns_poll) {
+        avahi_simple_poll_iterate(sv_mdns_poll, 0);
+    }
+}
+
+void SV_MDNS_Shutdown(void) {
+    if (sv_mdns_client) {
+        avahi_client_free(sv_mdns_client);
+        sv_mdns_client = NULL;
+    }
+    if (sv_mdns_poll) {
+        avahi_simple_poll_free(sv_mdns_poll);
+        sv_mdns_poll = NULL;
+    }
+    sv_mdns_group = NULL;
+}
+
+#else /* !__linux__ */
+
+void SV_MDNS_Init(unsigned short port) { (void)port; }
+void SV_MDNS_UpdateInfo(const char *m, DWORD c, DWORD mc) {
+    (void)m; (void)c; (void)mc;
+}
+void SV_MDNS_Tick(void) {}
+void SV_MDNS_Shutdown(void) {}
+
+#endif

--- a/server/sv_mdns.c
+++ b/server/sv_mdns.c
@@ -232,12 +232,26 @@ void SV_MDNS_Init(unsigned short port) {
 }
 
 void SV_MDNS_UpdateInfo(const char *map_path, DWORD clients, DWORD maxclients) {
-    if (map_path) {
+    /* Compare to the cached state.  If nothing visible has changed,
+     * skip the Avahi serialize/push entirely.  Callers should be able
+     * to invoke this every frame without paying for it. */
+    bool changed = false;
+    if (map_path && strcmp(map_path, sv_mdns_map) != 0) {
         strncpy(sv_mdns_map, map_path, sizeof(sv_mdns_map) - 1);
         sv_mdns_map[sizeof(sv_mdns_map) - 1] = '\0';
+        changed = true;
     }
-    sv_mdns_clients    = clients;
-    sv_mdns_maxclients = maxclients;
+    if (clients != sv_mdns_clients) {
+        sv_mdns_clients = clients;
+        changed = true;
+    }
+    if (maxclients != sv_mdns_maxclients) {
+        sv_mdns_maxclients = maxclients;
+        changed = true;
+    }
+    if (!changed) {
+        return;
+    }
 
     if (sv_mdns_group && !avahi_entry_group_is_empty(sv_mdns_group)) {
         AvahiStringList *txt = sv_mdns_build_txt_records();

--- a/server/sv_mdns.c
+++ b/server/sv_mdns.c
@@ -25,25 +25,31 @@
 #include "../common/net.h"
 #include "../common/net_oob.h"
 
-#define MDNS_HOSTNAME_MAX   64
-#define MDNS_MAP_MAX        64
-#define MDNS_SERVICE_MAX    64
-#define MDNS_TXT_FIELD_MAX  128
+#define MDNS_HOSTNAME_MAX        64
+#define MDNS_MAP_MAX             64
+#define MDNS_SERVICE_MAX         64
+#define MDNS_TXT_FIELD_MAX       128
+/* Cap collision-rename retries so a hostile / saturated mDNS network
+ * cannot make us recurse without bound through alternative-name
+ * suggestions.  Avahi's alternative-name suffix grows numerically so
+ * a real collision is resolved well within this limit. */
+#define MDNS_MAX_NAME_RETRIES    16
 
 static AvahiSimplePoll  *sv_mdns_poll        = NULL;
 static AvahiClient      *sv_mdns_client      = NULL;
 static AvahiEntryGroup  *sv_mdns_group       = NULL;
 static unsigned short    sv_mdns_port        = 0;
 static char              sv_mdns_map[MDNS_MAP_MAX]                = "";
-static DWORD             sv_sv_mdns_clients     = 0;
+static DWORD             sv_mdns_clients     = 0;
 static DWORD             sv_mdns_maxclients  = 0;
 static char              sv_mdns_service_name[MDNS_SERVICE_MAX]   = "OpenWarcraft3";
+static int               sv_mdns_name_retries = 0;
 
 static void sv_mdns_create_service(AvahiClient *c);
 static void sv_mdns_entry_group_callback(AvahiEntryGroup *g,
                                       AvahiEntryGroupState state,
                                       void *userdata);
-static void sv_sv_mdns_client_callback(AvahiClient *c,
+static void sv_mdns_client_callback(AvahiClient *c,
                                  AvahiClientState state,
                                  void *userdata);
 
@@ -59,14 +65,24 @@ static void sv_mdns_basename(const char *path, char *out, size_t outlen) {
     out[outlen - 1] = '\0';
 }
 
+/* Cached at first use; gethostname doesn't change once the system is up. */
+static const char *sv_mdns_hostname(void) {
+    static char cached[MDNS_HOSTNAME_MAX];
+    static int  filled = 0;
+    if (!filled) {
+        if (gethostname(cached, sizeof(cached)) != 0) {
+            strncpy(cached, "owc3-server", sizeof(cached) - 1);
+        }
+        cached[sizeof(cached) - 1] = '\0';
+        filled = 1;
+    }
+    return cached;
+}
+
 /* Build the TXT-record string list reflecting current server info.
  * Caller owns the result and must free it with avahi_string_list_free. */
 static AvahiStringList *sv_mdns_build_txt_records(void) {
-    char hostname[MDNS_HOSTNAME_MAX];
-    if (gethostname(hostname, sizeof(hostname)) != 0) {
-        strncpy(hostname, "owc3-server", sizeof(hostname) - 1);
-    }
-    hostname[sizeof(hostname) - 1] = '\0';
+    const char *hostname = sv_mdns_hostname();
 
     char map_base[MDNS_MAP_MAX];
     sv_mdns_basename(sv_mdns_map, map_base, sizeof(map_base));
@@ -78,7 +94,7 @@ static AvahiStringList *sv_mdns_build_txt_records(void) {
     char f_protocol[MDNS_TXT_FIELD_MAX];
     snprintf(f_hostname,   sizeof(f_hostname),   "hostname=%s", hostname);
     snprintf(f_map,        sizeof(f_map),        "map=%s", map_base);
-    snprintf(f_clients,    sizeof(f_clients),    "clients=%u", sv_sv_mdns_clients);
+    snprintf(f_clients,    sizeof(f_clients),    "clients=%u", sv_mdns_clients);
     snprintf(f_maxclients, sizeof(f_maxclients), "maxclients=%u", sv_mdns_maxclients);
     snprintf(f_protocol,   sizeof(f_protocol),   "protocol=%d", PROTOCOL_VERSION);
 
@@ -113,6 +129,12 @@ static void sv_mdns_create_service(AvahiClient *c) {
 
     if (r < 0) {
         if (r == AVAHI_ERR_COLLISION) {
+            if (sv_mdns_name_retries >= MDNS_MAX_NAME_RETRIES) {
+                fprintf(stderr, "SV_MDNS: gave up after %d collision retries\n",
+                        sv_mdns_name_retries);
+                return;
+            }
+            sv_mdns_name_retries++;
             char *new_name = avahi_alternative_service_name(sv_mdns_service_name);
             if (new_name) {
                 strncpy(sv_mdns_service_name, new_name, sizeof(sv_mdns_service_name) - 1);
@@ -130,6 +152,11 @@ static void sv_mdns_create_service(AvahiClient *c) {
     r = avahi_entry_group_commit(sv_mdns_group);
     if (r < 0) {
         fprintf(stderr, "SV_MDNS: commit failed: %s\n", avahi_strerror(r));
+    } else {
+        /* Commit accepted: a future genuine collision can retry from
+         * zero rather than carrying over from the previous boot's
+         * attempts. */
+        sv_mdns_name_retries = 0;
     }
 }
 
@@ -139,6 +166,12 @@ static void sv_mdns_entry_group_callback(AvahiEntryGroup *g,
     (void)g;
     (void)userdata;
     if (state == AVAHI_ENTRY_GROUP_COLLISION) {
+        if (sv_mdns_name_retries >= MDNS_MAX_NAME_RETRIES) {
+            fprintf(stderr, "SV_MDNS: gave up after %d collision retries\n",
+                    sv_mdns_name_retries);
+            return;
+        }
+        sv_mdns_name_retries++;
         char *new_name = avahi_alternative_service_name(sv_mdns_service_name);
         if (new_name) {
             strncpy(sv_mdns_service_name, new_name, sizeof(sv_mdns_service_name) - 1);
@@ -155,7 +188,7 @@ static void sv_mdns_entry_group_callback(AvahiEntryGroup *g,
     }
 }
 
-static void sv_sv_mdns_client_callback(AvahiClient *c,
+static void sv_mdns_client_callback(AvahiClient *c,
                                  AvahiClientState state,
                                  void *userdata) {
     (void)userdata;
@@ -173,7 +206,15 @@ static void sv_sv_mdns_client_callback(AvahiClient *c,
 }
 
 void SV_MDNS_Init(unsigned short port) {
+    if (port == 0) {
+        /* Advertising port 0 is meaningless; the caller almost certainly
+         * meant PORT_SERVER. Refuse rather than silently publishing a
+         * useless record. */
+        fprintf(stderr, "SV_MDNS: refusing to advertise port 0\n");
+        return;
+    }
     sv_mdns_port = port;
+    sv_mdns_name_retries = 0;
     sv_mdns_poll = avahi_simple_poll_new();
     if (!sv_mdns_poll) {
         fprintf(stderr, "SV_MDNS: avahi_simple_poll_new failed\n");
@@ -181,7 +222,7 @@ void SV_MDNS_Init(unsigned short port) {
     }
     int error;
     sv_mdns_client = avahi_client_new(avahi_simple_poll_get(sv_mdns_poll), 0,
-                                    sv_sv_mdns_client_callback, NULL, &error);
+                                    sv_mdns_client_callback, NULL, &error);
     if (!sv_mdns_client) {
         fprintf(stderr, "SV_MDNS: avahi_client_new failed: %s\n",
                 avahi_strerror(error));
@@ -195,7 +236,7 @@ void SV_MDNS_UpdateInfo(const char *map_path, DWORD clients, DWORD maxclients) {
         strncpy(sv_mdns_map, map_path, sizeof(sv_mdns_map) - 1);
         sv_mdns_map[sizeof(sv_mdns_map) - 1] = '\0';
     }
-    sv_sv_mdns_clients    = clients;
+    sv_mdns_clients    = clients;
     sv_mdns_maxclients = maxclients;
 
     if (sv_mdns_group && !avahi_entry_group_is_empty(sv_mdns_group)) {

--- a/server/sv_mdns.h
+++ b/server/sv_mdns.h
@@ -1,0 +1,27 @@
+#ifndef sv_mdns_h
+#define sv_mdns_h
+
+/*
+ * sv_mdns.h - Server-side mDNS/DNS-SD service advertisement.
+ *
+ * Publishes the listen-server as `_openwarcraft3._udp.local.` with a
+ * TXT record carrying hostname, map, clients, maxclients, and the
+ * protocol version.  Discovery via mDNS is a parallel transport to
+ * the broadcast OOB getinfo flow in sv_main.c; both surface the same
+ * untrusted candidate to a browsing client.
+ *
+ * Linux implementation uses Avahi.  Non-Linux platforms link the
+ * stub variants and the feature is silently disabled.
+ *
+ * Requires avahi-daemon to be running on the host for advertisements
+ * to actually be visible to other nodes on the LAN.
+ */
+
+#include "../common/shared.h"
+
+void SV_MDNS_Init(unsigned short port);
+void SV_MDNS_UpdateInfo(const char *map_path, DWORD clients, DWORD maxclients);
+void SV_MDNS_Tick(void);
+void SV_MDNS_Shutdown(void);
+
+#endif /* sv_mdns_h */

--- a/tests/test_lan_discovery.c
+++ b/tests/test_lan_discovery.c
@@ -42,6 +42,56 @@ static netadr_t make_addr(BYTE a, BYTE b, BYTE c, BYTE d,
 }
 
 /* -----------------------------------------------------------------------
+ * OOB_TokenMatches: strict-boundary token recognition
+ *
+ * Regression coverage for the prefix-match bug a v1 reviewer (me) would
+ * have caught: memcmp-only dispatch happily accepts "connectXYZ" as
+ * "connect", which becomes a security problem once Slice 2 adds
+ * getchallenge / challenge / disconnect tokens that share prefixes.
+ * --------------------------------------------------------------------- */
+
+static void test_oob_token_exact_match(void) {
+    ASSERT(OOB_TokenMatches("connect", 7, OOB_CONNECT));
+    ASSERT(OOB_TokenMatches("getinfo", 7, OOB_GETINFO));
+    ASSERT(OOB_TokenMatches("infoResponse", 12, OOB_INFORESPONSE));
+}
+
+static void test_oob_token_trailing_space_match(void) {
+    ASSERT(OOB_TokenMatches("connect ",   8,  OOB_CONNECT));
+    ASSERT(OOB_TokenMatches("getinfo 1",  9,  OOB_GETINFO));
+    ASSERT(OOB_TokenMatches("getinfo  ",  9,  OOB_GETINFO));
+}
+
+static void test_oob_token_trailing_nul_match(void) {
+    /* Some senders may include a NUL terminator inside the payload. */
+    ASSERT(OOB_TokenMatches("connect\0junk", 7, OOB_CONNECT));
+}
+
+static void test_oob_token_rejects_extra_word_chars(void) {
+    /* The bug this helper exists to prevent. */
+    ASSERT(!OOB_TokenMatches("connectXYZ",  10, OOB_CONNECT));
+    ASSERT(!OOB_TokenMatches("getinfoMORE", 11, OOB_GETINFO));
+    ASSERT(!OOB_TokenMatches("disconnect",  10, OOB_CONNECT));
+}
+
+static void test_oob_token_rejects_short_payload(void) {
+    ASSERT(!OOB_TokenMatches("conn",    4, OOB_CONNECT));
+    ASSERT(!OOB_TokenMatches("getinf",  6, OOB_GETINFO));
+    ASSERT(!OOB_TokenMatches("",        0, OOB_CONNECT));
+}
+
+static void test_oob_token_rejects_wrong_token(void) {
+    ASSERT(!OOB_TokenMatches("connect", 7, OOB_GETINFO));
+    ASSERT(!OOB_TokenMatches("getinfo", 7, OOB_CONNECT));
+}
+
+static void test_oob_token_handles_null_args(void) {
+    ASSERT(!OOB_TokenMatches(NULL, 7, OOB_CONNECT));
+    ASSERT(!OOB_TokenMatches("connect", 7, NULL));
+    ASSERT(!OOB_TokenMatches(NULL, 0, NULL));
+}
+
+/* -----------------------------------------------------------------------
  * SV_BuildInfoResponseString
  * --------------------------------------------------------------------- */
 
@@ -242,6 +292,13 @@ static void test_server_formatter_feeds_client_parser(void) {
  * --------------------------------------------------------------------- */
 
 void run_lan_discovery_tests(void) {
+    RUN_TEST(test_oob_token_exact_match);
+    RUN_TEST(test_oob_token_trailing_space_match);
+    RUN_TEST(test_oob_token_trailing_nul_match);
+    RUN_TEST(test_oob_token_rejects_extra_word_chars);
+    RUN_TEST(test_oob_token_rejects_short_payload);
+    RUN_TEST(test_oob_token_rejects_wrong_token);
+    RUN_TEST(test_oob_token_handles_null_args);
     RUN_TEST(test_buildinfo_includes_all_fields);
     RUN_TEST(test_buildinfo_strips_backslash_paths);
     RUN_TEST(test_buildinfo_strips_forward_slash_paths);

--- a/tests/test_lan_discovery.c
+++ b/tests/test_lan_discovery.c
@@ -92,6 +92,47 @@ static void test_oob_token_handles_null_args(void) {
 }
 
 /* -----------------------------------------------------------------------
+ * SV_ParseConnectVersion: wire form "connect <N>"
+ * --------------------------------------------------------------------- */
+
+static void test_parse_connect_version_basic(void) {
+    ASSERT_EQ_INT(SV_ParseConnectVersion("connect 1", 9), 1);
+    ASSERT_EQ_INT(SV_ParseConnectVersion("connect 42", 10), 42);
+}
+
+static void test_parse_connect_version_rejects_missing_arg(void) {
+    /* Bare "connect" with no version arg: malformed. */
+    ASSERT_EQ_INT(SV_ParseConnectVersion("connect", 7), -1);
+}
+
+static void test_parse_connect_version_rejects_missing_space(void) {
+    /* "connect1" (no space separator) is malformed. */
+    ASSERT_EQ_INT(SV_ParseConnectVersion("connect1", 8), -1);
+}
+
+static void test_parse_connect_version_rejects_non_numeric(void) {
+    ASSERT_EQ_INT(SV_ParseConnectVersion("connect abc", 11), -1);
+    ASSERT_EQ_INT(SV_ParseConnectVersion("connect -1", 10), -1);  /* leading '-' */
+}
+
+static void test_parse_connect_version_handles_null(void) {
+    ASSERT_EQ_INT(SV_ParseConnectVersion(NULL, 9), -1);
+}
+
+static void test_parse_connect_version_clips_oversize(void) {
+    /* 64-byte version field; our internal buffer caps at 15 digits then
+     * hands to atoi which has UB on integer overflow.  This test exists
+     * to prove we don't crash or read past the bound; the exact value
+     * returned by atoi for overflowing input isn't part of the
+     * contract.  Accept anything that isn't the "malformed" sentinel. */
+    char big[64];
+    memcpy(big, "connect ", 8);
+    memset(big + 8, '9', sizeof(big) - 8);
+    int v = SV_ParseConnectVersion(big, (int)sizeof(big));
+    ASSERT(v != -1);
+}
+
+/* -----------------------------------------------------------------------
  * SV_BuildInfoResponseString
  * --------------------------------------------------------------------- */
 
@@ -292,6 +333,12 @@ static void test_server_formatter_feeds_client_parser(void) {
  * --------------------------------------------------------------------- */
 
 void run_lan_discovery_tests(void) {
+    RUN_TEST(test_parse_connect_version_basic);
+    RUN_TEST(test_parse_connect_version_rejects_missing_arg);
+    RUN_TEST(test_parse_connect_version_rejects_missing_space);
+    RUN_TEST(test_parse_connect_version_rejects_non_numeric);
+    RUN_TEST(test_parse_connect_version_handles_null);
+    RUN_TEST(test_parse_connect_version_clips_oversize);
     RUN_TEST(test_oob_token_exact_match);
     RUN_TEST(test_oob_token_trailing_space_match);
     RUN_TEST(test_oob_token_trailing_nul_match);

--- a/tests/test_lan_discovery.c
+++ b/tests/test_lan_discovery.c
@@ -1,0 +1,258 @@
+/*
+ * test_lan_discovery.c - Unit tests for the LAN server-browser layer.
+ *
+ * Covers the pure / unit-testable surface of Slice 1:
+ *   - SV_BuildInfoResponseString: format, map basename reduction, defensive
+ *     handling of NULL inputs.
+ *   - CL_BrowserHandleInfoResponse: kv parsing, upsert behavior keyed by
+ *     address tuple, multiple distinct entries.
+ *
+ * End-to-end behavior (real UDP sockets exchanging OOB packets, mDNS
+ * advertise/browse) is integration-tested in the LXC build, not here.
+ * Expiry of stale entries depends on clock_gettime and is also deferred
+ * to integration.
+ */
+
+#include <string.h>
+#include <arpa/inet.h>
+
+#include "test_framework.h"
+
+#include "../common/shared.h"
+#include "../common/net.h"
+#include "../common/net_oob.h"
+#include "../server/sv_info.h"
+#include "../client/cl_browser.h"
+
+/* -----------------------------------------------------------------------
+ * Helpers
+ * --------------------------------------------------------------------- */
+
+static netadr_t make_addr(BYTE a, BYTE b, BYTE c, BYTE d,
+                          unsigned short port_host) {
+    netadr_t adr;
+    memset(&adr, 0, sizeof(adr));
+    adr.type  = NA_IP;
+    adr.ip[0] = a;
+    adr.ip[1] = b;
+    adr.ip[2] = c;
+    adr.ip[3] = d;
+    adr.port  = htons(port_host);
+    return adr;
+}
+
+/* -----------------------------------------------------------------------
+ * SV_BuildInfoResponseString
+ * --------------------------------------------------------------------- */
+
+static void test_buildinfo_includes_all_fields(void) {
+    char buf[512];
+    int n = SV_BuildInfoResponseString(buf, sizeof(buf),
+                                       "myhost",
+                                       "Maps\\Test\\Foo.w3m",
+                                       2, 8, 1);
+    ASSERT(n > 0);
+    /* Must start with the infoResponse token. */
+    ASSERT(strncmp(buf, OOB_INFORESPONSE, strlen(OOB_INFORESPONSE)) == 0);
+    /* All keys present with their values. */
+    ASSERT(strstr(buf, "\\hostname\\myhost") != NULL);
+    ASSERT(strstr(buf, "\\map\\Foo.w3m") != NULL);  /* basename only */
+    ASSERT(strstr(buf, "\\clients\\2") != NULL);
+    ASSERT(strstr(buf, "\\maxclients\\8") != NULL);
+    ASSERT(strstr(buf, "\\protocol\\1") != NULL);
+}
+
+static void test_buildinfo_strips_backslash_paths(void) {
+    char buf[512];
+    SV_BuildInfoResponseString(buf, sizeof(buf),
+                               "h", "A\\B\\C\\Deep.w3m", 0, 0, 1);
+    ASSERT(strstr(buf, "\\map\\Deep.w3m") != NULL);
+    /* No part of the original path leaks through; if it did, the
+     * embedded backslashes would corrupt the kv framing. */
+    ASSERT(strstr(buf, "\\map\\A") == NULL);
+}
+
+static void test_buildinfo_strips_forward_slash_paths(void) {
+    char buf[512];
+    SV_BuildInfoResponseString(buf, sizeof(buf),
+                               "h", "Maps/Foo.w3m", 0, 0, 1);
+    ASSERT(strstr(buf, "\\map\\Foo.w3m") != NULL);
+}
+
+static void test_buildinfo_accepts_bare_basename(void) {
+    char buf[512];
+    SV_BuildInfoResponseString(buf, sizeof(buf),
+                               "h", "BareName.w3m", 0, 0, 1);
+    ASSERT(strstr(buf, "\\map\\BareName.w3m") != NULL);
+}
+
+static void test_buildinfo_handles_null_map(void) {
+    char buf[512];
+    int n = SV_BuildInfoResponseString(buf, sizeof(buf),
+                                       "h", NULL, 0, 0, 1);
+    ASSERT(n > 0);
+    /* Empty map field: two backslashes back-to-back between map and clients. */
+    ASSERT(strstr(buf, "\\map\\\\clients") != NULL);
+}
+
+static void test_buildinfo_handles_null_hostname(void) {
+    char buf[512];
+    int n = SV_BuildInfoResponseString(buf, sizeof(buf),
+                                       NULL, "m.w3m", 1, 4, 1);
+    ASSERT(n > 0);
+    ASSERT(strstr(buf, "\\hostname\\\\map") != NULL);
+}
+
+/* -----------------------------------------------------------------------
+ * CL_BrowserHandleInfoResponse
+ * --------------------------------------------------------------------- */
+
+static void test_browser_parses_minimal_infoResponse(void) {
+    CL_BrowserInit();
+    netadr_t from = make_addr(192, 168, 1, 10, PORT_SERVER);
+    const char *payload =
+        "\\" OOB_KEY_HOSTNAME "\\testhost"
+        "\\" OOB_KEY_MAP "\\TestMap"
+        "\\" OOB_KEY_CLIENTS "\\3"
+        "\\" OOB_KEY_MAXCLIENTS "\\8"
+        "\\" OOB_KEY_PROTOCOL "\\1";
+    CL_BrowserHandleInfoResponse(&from, payload, (int)strlen(payload));
+
+    int count = -1;
+    const server_info_t *list = CL_BrowserList(&count);
+    ASSERT_EQ_INT(count, 1);
+    ASSERT_STR_EQ(list[0].hostname, "testhost");
+    ASSERT_STR_EQ(list[0].map, "TestMap");
+    ASSERT_EQ_INT(list[0].clients, 3);
+    ASSERT_EQ_INT(list[0].maxclients, 8);
+    ASSERT_EQ_INT(list[0].protocol, 1);
+}
+
+static void test_browser_upserts_same_address(void) {
+    CL_BrowserInit();
+    netadr_t from = make_addr(10, 0, 0, 5, PORT_SERVER);
+    const char *p1 =
+        "\\hostname\\v1\\map\\m\\clients\\1\\maxclients\\4\\protocol\\1";
+    const char *p2 =
+        "\\hostname\\v2\\map\\m\\clients\\2\\maxclients\\4\\protocol\\1";
+    CL_BrowserHandleInfoResponse(&from, p1, (int)strlen(p1));
+    CL_BrowserHandleInfoResponse(&from, p2, (int)strlen(p2));
+
+    int count = -1;
+    const server_info_t *list = CL_BrowserList(&count);
+    ASSERT_EQ_INT(count, 1);             /* upsert, not duplicate */
+    ASSERT_STR_EQ(list[0].hostname, "v2");
+    ASSERT_EQ_INT(list[0].clients, 2);
+}
+
+static void test_browser_distinct_addresses_get_distinct_entries(void) {
+    CL_BrowserInit();
+    netadr_t a = make_addr(192, 168, 1, 1, PORT_SERVER);
+    netadr_t b = make_addr(192, 168, 1, 2, PORT_SERVER);
+    const char *p =
+        "\\hostname\\h\\map\\m\\clients\\0\\maxclients\\4\\protocol\\1";
+    CL_BrowserHandleInfoResponse(&a, p, (int)strlen(p));
+    CL_BrowserHandleInfoResponse(&b, p, (int)strlen(p));
+
+    int count = -1;
+    CL_BrowserList(&count);
+    ASSERT_EQ_INT(count, 2);
+}
+
+static void test_browser_distinct_ports_get_distinct_entries(void) {
+    CL_BrowserInit();
+    netadr_t a = make_addr(192, 168, 1, 1, PORT_SERVER);
+    netadr_t b = make_addr(192, 168, 1, 1, PORT_SERVER + 1);
+    const char *p =
+        "\\hostname\\h\\map\\m\\clients\\0\\maxclients\\4\\protocol\\1";
+    CL_BrowserHandleInfoResponse(&a, p, (int)strlen(p));
+    CL_BrowserHandleInfoResponse(&b, p, (int)strlen(p));
+
+    int count = -1;
+    CL_BrowserList(&count);
+    ASSERT_EQ_INT(count, 2);
+}
+
+static void test_browser_ignores_unknown_keys(void) {
+    CL_BrowserInit();
+    netadr_t from = make_addr(127, 0, 0, 1, PORT_SERVER);
+    const char *payload =
+        "\\hostname\\h\\unknownkey\\junk\\map\\m"
+        "\\clients\\0\\maxclients\\4\\protocol\\1";
+    CL_BrowserHandleInfoResponse(&from, payload, (int)strlen(payload));
+
+    int count = -1;
+    const server_info_t *list = CL_BrowserList(&count);
+    ASSERT_EQ_INT(count, 1);
+    ASSERT_STR_EQ(list[0].hostname, "h");
+    ASSERT_STR_EQ(list[0].map, "m");
+}
+
+static void test_browser_partial_payload_still_parses_known_keys(void) {
+    CL_BrowserInit();
+    netadr_t from = make_addr(127, 0, 0, 1, PORT_SERVER);
+    /* Only hostname and protocol; other fields stay at defaults. */
+    const char *payload = "\\hostname\\partial\\protocol\\1";
+    CL_BrowserHandleInfoResponse(&from, payload, (int)strlen(payload));
+
+    int count = -1;
+    const server_info_t *list = CL_BrowserList(&count);
+    ASSERT_EQ_INT(count, 1);
+    ASSERT_STR_EQ(list[0].hostname, "partial");
+    ASSERT_EQ_INT(list[0].protocol, 1);
+    /* Untouched fields are zero / empty. */
+    ASSERT_EQ_INT(list[0].clients, 0);
+    ASSERT_STR_EQ(list[0].map, "");
+}
+
+/* -----------------------------------------------------------------------
+ * Round-trip: server formatter + client parser
+ * --------------------------------------------------------------------- */
+
+static void test_server_formatter_feeds_client_parser(void) {
+    char wire[512];
+    int n = SV_BuildInfoResponseString(wire, sizeof(wire),
+                                       "loopbox", "Map.w3m", 4, 8, 1);
+    ASSERT(n > 0);
+
+    /* Skip past the leading OOB_INFORESPONSE token; the client gets
+     * the kv blob portion (this matches what cl_main.c does after
+     * recognizing the token). */
+    int token_len = (int)strlen(OOB_INFORESPONSE);
+    ASSERT(n > token_len);
+    const char *kv_blob = wire + token_len;
+    int kv_len = n - token_len;
+
+    CL_BrowserInit();
+    netadr_t from = make_addr(127, 0, 0, 1, PORT_SERVER);
+    CL_BrowserHandleInfoResponse(&from, kv_blob, kv_len);
+
+    int count = -1;
+    const server_info_t *list = CL_BrowserList(&count);
+    ASSERT_EQ_INT(count, 1);
+    ASSERT_STR_EQ(list[0].hostname, "loopbox");
+    ASSERT_STR_EQ(list[0].map, "Map.w3m");
+    ASSERT_EQ_INT(list[0].clients, 4);
+    ASSERT_EQ_INT(list[0].maxclients, 8);
+    ASSERT_EQ_INT(list[0].protocol, 1);
+}
+
+/* -----------------------------------------------------------------------
+ * Suite entry
+ * --------------------------------------------------------------------- */
+
+void run_lan_discovery_tests(void) {
+    RUN_TEST(test_buildinfo_includes_all_fields);
+    RUN_TEST(test_buildinfo_strips_backslash_paths);
+    RUN_TEST(test_buildinfo_strips_forward_slash_paths);
+    RUN_TEST(test_buildinfo_accepts_bare_basename);
+    RUN_TEST(test_buildinfo_handles_null_map);
+    RUN_TEST(test_buildinfo_handles_null_hostname);
+    RUN_TEST(test_browser_parses_minimal_infoResponse);
+    RUN_TEST(test_browser_upserts_same_address);
+    RUN_TEST(test_browser_distinct_addresses_get_distinct_entries);
+    RUN_TEST(test_browser_distinct_ports_get_distinct_entries);
+    RUN_TEST(test_browser_ignores_unknown_keys);
+    RUN_TEST(test_browser_partial_payload_still_parses_known_keys);
+    RUN_TEST(test_server_formatter_feeds_client_parser);
+}

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -26,6 +26,7 @@ void run_api_tests(void);
 void run_game_tests(void);
 void run_combat_tests(void);
 void run_server_net_tests(void);
+void run_lan_discovery_tests(void);
 
 int main(void) {
     printf("=== OpenWarcraft3 Unit Tests ===\n\n");
@@ -68,6 +69,10 @@ int main(void) {
 
     printf("[Server UDP connect / sync]\n");
     run_server_net_tests();
+    printf("\n");
+
+    printf("[LAN discovery / server browser]\n");
+    run_lan_discovery_tests();
     printf("\n");
 
     TEST_RESULTS();

--- a/tests/test_server_net.c
+++ b/tests/test_server_net.c
@@ -188,8 +188,158 @@ static void test_multicast_syncs_updates_to_all_connected_clients(void) {
     ASSERT_EQ_INT(sv.multicast.cursize, 0);
 }
 
+/* ----------------------------------------------------------------------
+ * Slot lifecycle (Slice 2 commit 1)
+ *
+ * SV_DropClient transitions cs_connected -> cs_zombie, records drop_time,
+ * bumps sv_advertised_state_version, sends an OOB disconnect to NA_IP
+ * peers, and is a no-op on cs_free / cs_zombie slots.
+ *
+ * After ZOMBIE_TIME_MS, SV_RunZombieExpiry transitions cs_zombie -> cs_free.
+ *
+ * SV_DirectConnect prefers a cs_free slot before growing num_clients.
+ * SV_FindClientByAddr skips cs_free slots, still matches cs_zombie
+ * (so a reconnect during grace is rejected).
+ * -------------------------------------------------------------------- */
+
+static netadr_t make_ip_addr(BYTE a, BYTE b, BYTE c, BYTE d,
+                             unsigned short host_port) {
+    netadr_t adr;
+    memset(&adr, 0, sizeof(adr));
+    adr.type  = NA_IP;
+    adr.ip[0] = a;
+    adr.ip[1] = b;
+    adr.ip[2] = c;
+    adr.ip[3] = d;
+    adr.port  = htons(host_port);
+    return adr;
+}
+
+static void test_drop_client_transitions_to_zombie(void) {
+    reset_server_state(4);
+    netadr_t from = make_ip_addr(10, 0, 0, 1, 50000);
+    SV_DirectConnect(&from);
+    ASSERT_EQ_INT(svs.num_clients, 1);
+    ASSERT_EQ_INT(svs.clients[0].state, cs_connected);
+
+    DWORD ver_before = sv_advertised_state_version;
+    svs.realtime = 12345;
+    SV_DropClient(&svs.clients[0], "test");
+
+    ASSERT_EQ_INT(svs.clients[0].state, cs_zombie);
+    ASSERT_EQ_INT(svs.clients[0].drop_time, 12345);
+    ASSERT(sv_advertised_state_version > ver_before);
+    /* num_clients is NOT decremented; slot stays "owned" during grace. */
+    ASSERT_EQ_INT(svs.num_clients, 1);
+}
+
+static void test_drop_client_is_idempotent(void) {
+    reset_server_state(4);
+    netadr_t from = make_ip_addr(10, 0, 0, 1, 50001);
+    SV_DirectConnect(&from);
+    SV_DropClient(&svs.clients[0], "test");
+    DWORD ver_after_first = sv_advertised_state_version;
+
+    /* Second drop on the same zombie slot is a no-op. */
+    SV_DropClient(&svs.clients[0], "test");
+    ASSERT_EQ_INT(svs.clients[0].state, cs_zombie);
+    ASSERT_EQ_INT(sv_advertised_state_version, ver_after_first);
+}
+
+static void test_num_live_clients_counts_only_active(void) {
+    reset_server_state(4);
+    netadr_t a = make_ip_addr(10, 0, 0, 1, 50010);
+    netadr_t b = make_ip_addr(10, 0, 0, 2, 50011);
+    netadr_t c = make_ip_addr(10, 0, 0, 3, 50012);
+    SV_DirectConnect(&a);
+    SV_DirectConnect(&b);
+    SV_DirectConnect(&c);
+    ASSERT_EQ_INT(SV_NumLiveClients(), 3);
+
+    SV_DropClient(&svs.clients[1], "test");
+    ASSERT_EQ_INT(SV_NumLiveClients(), 2);   /* zombie excluded */
+    ASSERT_EQ_INT(svs.num_clients, 3);       /* allocated count unchanged */
+}
+
+static void test_zombie_expires_after_grace_period(void) {
+    reset_server_state(4);
+    netadr_t from = make_ip_addr(10, 0, 0, 1, 50020);
+    SV_DirectConnect(&from);
+    svs.realtime = 1000;
+    SV_DropClient(&svs.clients[0], "test");
+
+    /* Within grace: still zombie. */
+    svs.realtime = 1000 + ZOMBIE_TIME_MS - 1;
+    SV_RunZombieExpiry();
+    ASSERT_EQ_INT(svs.clients[0].state, cs_zombie);
+
+    /* At exactly grace boundary: transitions. */
+    svs.realtime = 1000 + ZOMBIE_TIME_MS;
+    SV_RunZombieExpiry();
+    ASSERT_EQ_INT(svs.clients[0].state, cs_free);
+}
+
+static void test_find_client_by_addr_skips_free_slots(void) {
+    reset_server_state(4);
+    netadr_t from = make_ip_addr(10, 0, 0, 1, 50030);
+    SV_DirectConnect(&from);
+    SV_DropClient(&svs.clients[0], "test");
+
+    /* Still zombie: FindClientByAddr matches so reconnect is rejected. */
+    LPCLIENT zombie_match = SV_FindClientByAddr(&from);
+    ASSERT(zombie_match == &svs.clients[0]);
+
+    /* Force the slot to cs_free and re-query: must NOT match (stale addr). */
+    svs.clients[0].state = cs_free;
+    LPCLIENT free_match = SV_FindClientByAddr(&from);
+    ASSERT_NULL(free_match);
+}
+
+static void test_reconnect_during_zombie_grace_is_rejected(void) {
+    reset_server_state(4);
+    netadr_t from = make_ip_addr(10, 0, 0, 1, 50040);
+    SV_DirectConnect(&from);
+    SV_DropClient(&svs.clients[0], "test");
+
+    /* Same address connects again while slot is still cs_zombie.
+     * SV_DirectConnect's early-out via SV_FindClientByAddr blocks it,
+     * so num_clients should stay at 1 and no second slot allocated. */
+    SV_DirectConnect(&from);
+    ASSERT_EQ_INT(svs.num_clients, 1);
+    ASSERT_EQ_INT(svs.clients[0].state, cs_zombie);
+}
+
+static void test_direct_connect_reuses_free_slot(void) {
+    reset_server_state(4);
+    netadr_t a = make_ip_addr(10, 0, 0, 1, 50050);
+    netadr_t b = make_ip_addr(10, 0, 0, 2, 50051);
+    SV_DirectConnect(&a);
+    SV_DirectConnect(&b);
+    ASSERT_EQ_INT(svs.num_clients, 2);
+
+    /* Drop slot 0, expire its grace, then a fresh address connects.
+     * It should land in slot 0 (the cs_free hole) rather than slot 2. */
+    SV_DropClient(&svs.clients[0], "test");
+    svs.realtime += ZOMBIE_TIME_MS;
+    SV_RunZombieExpiry();
+    ASSERT_EQ_INT(svs.clients[0].state, cs_free);
+
+    netadr_t c = make_ip_addr(10, 0, 0, 3, 50052);
+    SV_DirectConnect(&c);
+    ASSERT_EQ_INT(svs.num_clients, 2);           /* no growth */
+    ASSERT_EQ_INT(svs.clients[0].state, cs_connected);
+    ASSERT(svs.clients[0].netchan.remote_address.ip[3] == 3);
+}
+
 void run_server_net_tests(void) {
     RUN_TEST(test_udp_multi_client_connects_register_distinct_slots);
     RUN_TEST(test_udp_connect_honors_ge_max_clients_limit);
     RUN_TEST(test_multicast_syncs_updates_to_all_connected_clients);
+    RUN_TEST(test_drop_client_transitions_to_zombie);
+    RUN_TEST(test_drop_client_is_idempotent);
+    RUN_TEST(test_num_live_clients_counts_only_active);
+    RUN_TEST(test_zombie_expires_after_grace_period);
+    RUN_TEST(test_find_client_by_addr_skips_free_slots);
+    RUN_TEST(test_reconnect_during_zombie_grace_is_rejected);
+    RUN_TEST(test_direct_connect_reuses_free_slot);
 }

--- a/tests/test_server_net.c
+++ b/tests/test_server_net.c
@@ -331,6 +331,60 @@ static void test_direct_connect_reuses_free_slot(void) {
     ASSERT(svs.clients[0].netchan.remote_address.ip[3] == 3);
 }
 
+/* ----------------------------------------------------------------------
+ * Per-client read timeout (Slice 2)
+ * SV_RunClientTimeouts drops cs_connected / cs_spawned non-loopback
+ * clients that haven't sent a packet in CLIENT_TIMEOUT_MS.
+ * -------------------------------------------------------------------- */
+
+static void test_timeout_drops_silent_client(void) {
+    reset_server_state(4);
+    netadr_t from = make_ip_addr(10, 0, 0, 1, 50100);
+    svs.realtime = 1000;
+    SV_DirectConnect(&from);
+    ASSERT_EQ_INT(svs.clients[0].state, cs_connected);
+
+    /* Just shy of timeout: still alive. */
+    svs.realtime = 1000 + CLIENT_TIMEOUT_MS - 1;
+    SV_RunClientTimeouts();
+    ASSERT_EQ_INT(svs.clients[0].state, cs_connected);
+
+    /* At/past timeout: dropped to zombie. */
+    svs.realtime = 1000 + CLIENT_TIMEOUT_MS;
+    SV_RunClientTimeouts();
+    ASSERT_EQ_INT(svs.clients[0].state, cs_zombie);
+}
+
+static void test_timeout_resets_on_packet(void) {
+    reset_server_state(4);
+    netadr_t from = make_ip_addr(10, 0, 0, 1, 50101);
+    svs.realtime = 1000;
+    SV_DirectConnect(&from);
+
+    /* Simulate a packet arriving just before timeout would fire. */
+    svs.realtime = 1000 + CLIENT_TIMEOUT_MS - 1;
+    svs.clients[0].last_packet_ms = svs.realtime;
+
+    /* Advance another full timeout window: no timeout because the
+     * clock was reset by the packet. */
+    svs.realtime += CLIENT_TIMEOUT_MS - 1;
+    SV_RunClientTimeouts();
+    ASSERT_EQ_INT(svs.clients[0].state, cs_connected);
+}
+
+static void test_timeout_skips_loopback_client(void) {
+    reset_server_state(4);
+    /* Manually install a loopback client.  Loopback exempt from timeout. */
+    LPCLIENT cl = &svs.clients[0];
+    cl->state = cs_connected;
+    cl->netchan.remote_address.type = NA_LOOPBACK;
+    cl->last_packet_ms = 0;          /* "never" */
+    svs.num_clients = 1;
+    svs.realtime = 1000 + CLIENT_TIMEOUT_MS + 5000;
+    SV_RunClientTimeouts();
+    ASSERT_EQ_INT(cl->state, cs_connected);
+}
+
 void run_server_net_tests(void) {
     RUN_TEST(test_udp_multi_client_connects_register_distinct_slots);
     RUN_TEST(test_udp_connect_honors_ge_max_clients_limit);
@@ -342,4 +396,7 @@ void run_server_net_tests(void) {
     RUN_TEST(test_find_client_by_addr_skips_free_slots);
     RUN_TEST(test_reconnect_during_zombie_grace_is_rejected);
     RUN_TEST(test_direct_connect_reuses_free_slot);
+    RUN_TEST(test_timeout_drops_silent_client);
+    RUN_TEST(test_timeout_resets_on_packet);
+    RUN_TEST(test_timeout_skips_loopback_client);
 }


### PR DESCRIPTION
  ## Summary

   7-commit branch implementing LAN server discovery (Slice 1) and partial connection-handshake safety (Slice 2 §1, §3, §4) from `design/server-net-plan.md`. Verified: `make build` clean and `make test`
   590/590 against real SDL2 / libjpeg / StormLib / Avahi / libsodium deps.

   This PR description is structured for both human and AI review. Sections are dense, decisions are explicit, and divergences from upstream `feature/lan-games` are tabulated rather than narrated.

   ## Commit list

   | SHA | Subject |
   |---|---|
   | `9a72b34` | feat(net): add LAN server discovery (Slice 1) |
   | `9b3ebd3` | refactor(net): harden OOB dispatch, mDNS retries, hostname cache |
   | `719e1d7` | perf(net): apply efficiency audit, 10 of 11 items |
   | `8b0e2f8` | feat(net): slot lifecycle (cs_zombie/cs_free, SV_DropClient) [Slice 2] |
   | `ae54066` | feat(net): wire-level protocol version exchange [Slice 2] |
   | `609ec99` | feat(net): per-client read timeout [Slice 2] |
   | `7a8e43e` | refactor(net): central SV_ConnectionlessPacket dispatcher in sv_lan.c |

   Diff: 22 files changed, +2104 / -26.

   ## Why Quake 3 wire format

   We chose dpmaster-style `getinfo` / `infoResponse` with backslash-delimited key/value blobs over the upstream `feature/lan-games` single-token `info` form. Concrete reasons:

   1. **Field-tested protocol surface.** The Q3 OOB protocol has 25+ years of deployment across ioquake3, dpmaster, Xonotic, OpenArena, Tremulous, and Unvanquished. Edge cases (length bounds, parser
   ambiguity, broadcast amplification) are documented in zezula.net / Quake 3 source notes and reproduced in our test suite.
   2. **Split request / response opcodes prevent parser ambiguity.** A single `info` token used for both request and response forces the parser to dispatch on trailing `\n<status>` presence; that's a
   one-bit signal that disagrees with whether the payload is malformed. Our `getinfo` (request, no trailing kv) vs `infoResponse` (response, has trailing kv) is unambiguous at the token level.
   3. **Strict `\<key>\<value>` framing** with no embedded backslashes in values (we strip to basename for map names) means the parser has no path-collision class of bugs. Upstream's `\` → `/` rewrite
   preserves path info for UI but introduces a non-orthogonal escape rule.
   4. **Quake 3's snapshot+delta + connection-challenge model is the most-studied network architecture in the open-source game corpus** (see `design/research-prior-art.md` §1.7 / §2.A): Sanglard's analysis,
    ioquake3 reference, Glenn Fiedler's netcode.io writeups all derive from this lineage. Threat models and mitigations are well-documented.
   5. **dpmaster ecosystem compatibility.** Servers that expose our format can be browsed by existing dpmaster-derived tools (e.g. qstat, gametracker), enabling external master servers later without
   protocol negotiation.

   We considered and rejected:
   - **Custom binary OOB format.** Faster on the wire, but loses interop and forces our own tooling. The `getinfo`/`infoResponse` exchange happens at human time scales (one click per refresh), so wire
   compactness is not the constraint.
   - **HTTP/JSON over TCP for browse.** Adds a TCP stack to a game that's otherwise UDP-only. Punts NAT/discovery problems to TCP that we want to solve at the UDP layer (Slice 7).
   - **Upstream `info` single-token form.** Discussed above.

   ## Design decisions where our code differs from upstream `feature/lan-games`

   Upstream pushed `feature/lan-games` on 2026-05-19 (Igor Chernakov, `corepunch/openwarcraft3@634b82e` and ancestors) implementing the same feature. Below: each divergence, the reason for the divergence,
   and which is canonical for this PR.

   | Concern | Upstream `feature/lan-games` | This PR | Why we diverge |
   |---|---|---|---|
   | OOB opcode shape | Single `info` (request and response share, distinguished by trailing `\n<status>`) | Split `getinfo` (request) and `infoResponse` (response) | Token-level unambiguity; aligns with
   dpmaster |
   | Map key name | `mapname` | `map` | Q3 / dpmaster convention; matches qstat ecosystem |
   | Map value form | original path with `\` → `/` (preserves directory) | basename only (strip path) | Eliminates the `\` escape rule; the path component isn't displayable to a user anyway |
   | Player keys | `players` / `maxplayers` | `clients` / `maxclients` | Q3 / dpmaster convention |
   | Slot lifecycle | `svs.num_clients` grows monotonically; `cs_zombie` / `cs_free` enumerated but never assigned | Full lifecycle: `SV_DropClient` zombies a slot, `SV_RunZombieExpiry` transitions to
   `cs_free` after `ZOMBIE_TIME_MS = 2000`, `SV_DirectConnect` reuses lowest `cs_free` before growing | Closes a real slot-exhaustion DoS: any IP that sends `connect` allocates a slot that never drains |
   | Client read timeout | none | `SV_RunClientTimeouts`, `CLIENT_TIMEOUT_MS = 30000`, drops non-loopback silent clients via `SV_DropClient` | Silent UDP clients (NAT rebind, crash, partition) otherwise pin
    slots forever |
   | Protocol version exchange | `info <ver>` includes version in the broadcast but receiver does not validate it before slot allocation | `connect <ver>` validated by `SV_HandleConnectOOB`; mismatch
   returns OOB `rejectMsg protocol_version_mismatch` and refuses the slot | Stale clients fail fast with a real error instead of timing out mid-handshake |
   | OOB token matching | `sscanf("%31s", cmd)` extracts first whitespace-delimited token | `OOB_TOKEN_MATCHES_LITERAL` macro: explicit boundary check (next byte must be space, NUL, or end-of-payload) |
   Required for Slice 2's planned `getchallenge` / `challenge` tokens that share the `connect` prefix; prevents `"connectXYZ"` matching `"connect"` |
   | Caching | `info` reply rebuilt per request (5 snprintf operations × N browsers) | `infoResponse` body cached, invalidated by `sv_advertised_state_version` counter; one rebuild per state change | Linear
    cost in browser-count → constant cost in state-change-count |
   | Discovery transports | UDP broadcast only | UDP broadcast + mDNS / DNS-SD (Avahi on Linux) as parallel-untrusted transports, with downgrade-attack rationale | Managed switches and Wi-Fi APs commonly
   block UDP broadcast; mDNS works where broadcast doesn't, and the auth gate is at connect (not discovery) so both transports are equally untrusted |
   | Actor model for fetch | listen-server allocates `serverListFetch_t` per client request, performs the fetch on the client's behalf, ships rows back via in-band messaging | client broadcasts directly via
    `CL_RefreshServerList`, accumulates responses in `cl_browser`'s in-memory list | This PR is API-only (no `cl_menu` / `cl_listbox` adoption yet); the server-actor model only pays off once an in-game UI
   consumes it |
   | OOB dispatcher | `SV_ConnectionlessPacket` central entry point in `sv_lan.c` | Same pattern adopted: `SV_ConnectionlessPacket` in our `sv_lan.c` | Architectural shape borrowed in commit `7a8e43e`; only
    the wire format inside differs |
   | In-game UI | `cl_menu.c` (~1000 lines) + `cl_listbox.c` (~220 lines) + FDF-driven server-list screen + map preview | none in this PR; `cl_browser` is API-only | UI adoption is out of scope for this PR;
    planned as a separate effort once the data layer is stable |

   ## What's included

   ### Slice 1 — LAN server discovery

   - Two parallel untrusted discovery transports.
   - `getinfo` / `infoResponse` Quake 3 wire format with strict boundary token matching.
   - `cl_browser.{c,h}`: in-memory server list, FNV-1a open-addressing hash lookup, 1 Hz rate-limited expiry, cached per-frame "now", one-shot list-full warning, snapshot-semantics upsert.
   - `server/sv_mdns.c` + `client/cl_mdns.c`: Avahi-based publish (with `MDNS_MAX_NAME_RETRIES = 16` collision-rename cap) and browse (resolver feeds `CL_BrowserUpsert`).
   - `server/sv_info.{c,h}`: pure formatter, no globals, linkable into the test binary without StormLib.
