### PR TITLE
Add SC2 directory-backed map fixture coverage

### DIFF
--- a/games/starcraft-2/common/sc2_map.c
+++ b/games/starcraft-2/common/sc2_map.c
@@ -1378,54 +1378,75 @@ static BOOL sc2_mapinfo_fourcc(sc2MapInfo_t const *mapInfo) {
          mapInfo->fourcc == MAKEFOURCC('M','a','p','I'));
 }
 
-static void sc2_parse_height_map(sc2MapSource_t *source) {
+static LPBYTE sc2_read_binary_layer(sc2MapSource_t *source,
+                                    LPCSTR filename,
+                                    DWORD min_size,
+                                    DWORD expected_fourcc,
+                                    LPDWORD out_size) {
     DWORD size = 0;
-    LPBYTE data = sc2_source_read(source, "t3HeightMap", &size);
+    DWORD fourcc = 0;
+    LPBYTE data = sc2_source_read(source, filename, &size);
+    LPBYTE copy;
 
-    sc2_map.t3HeightMap = sc2_alloc(size);
-    memcpy(sc2_map.t3HeightMap, data, size);
+    if (out_size) *out_size = 0;
+    if (!data || size < min_size || size < sizeof(fourcc)) {
+        sc2_free_file(data);
+        return NULL;
+    }
+    memcpy(&fourcc, data, sizeof(fourcc));
+    if (fourcc != expected_fourcc) {
+        sc2_free_file(data);
+        return NULL;
+    }
+    copy = sc2_alloc(size);
+    if (!copy) {
+        sc2_free_file(data);
+        return NULL;
+    }
+    memcpy(copy, data, size);
     sc2_free_file(data);
+    if (out_size) *out_size = size;
+    return copy;
+}
+
+static void sc2_parse_height_map(sc2MapSource_t *source) {
+    sc2_map.t3HeightMap = (sc2MapHeightMap_t *)sc2_read_binary_layer(source,
+                                                                     "t3HeightMap",
+                                                                     sizeof(sc2MapHeightMap_t),
+                                                                     MAKEFOURCC('H','M','A','P'),
+                                                                     NULL);
 }
 
 static void sc2_parse_sync_height_map(sc2MapSource_t *source) {
-    DWORD size = 0;
-    LPBYTE data = sc2_source_read(source, "t3SyncHeightMap", &size);
-
-    if (!data || size < sizeof(sc2MapSyncHeightMap_t)) {
-        sc2_free_file(data);
-        return;
-    }
-    sc2_map.t3SyncHeightMap = sc2_alloc(size);
-    memcpy(sc2_map.t3SyncHeightMap, data, size);
-    sc2_free_file(data);
+    sc2_map.t3SyncHeightMap = (sc2MapSyncHeightMap_t *)sc2_read_binary_layer(source,
+                                                                             "t3SyncHeightMap",
+                                                                             sizeof(sc2MapSyncHeightMap_t),
+                                                                             MAKEFOURCC('S','M','A','P'),
+                                                                             NULL);
 }
 
 static void sc2_parse_cell_flags(sc2MapSource_t *source) {
-    DWORD size = 0;
-    LPBYTE data = sc2_source_read(source, "t3CellFlags", &size);
-
-    sc2_map.t3CellFlags = sc2_alloc(size);
-    memcpy(sc2_map.t3CellFlags, data, size);
-    sc2_free_file(data);
+    sc2_map.t3CellFlags = (sc2MapCellFlags_t *)sc2_read_binary_layer(source,
+                                                                     "t3CellFlags",
+                                                                     sizeof(sc2MapCellFlags_t),
+                                                                     MAKEFOURCC('L','F','C','T'),
+                                                                     NULL);
 }
 
 static void sc2_parse_sync_cliff_level(sc2MapSource_t *source) {
-    DWORD size = 0;
-    LPBYTE data = sc2_source_read(source, "t3SyncCliffLevel", &size);
-
-    sc2_map.t3SyncCliffLevel = sc2_alloc(size);
-    memcpy(sc2_map.t3SyncCliffLevel, data, size);
-    sc2_free_file(data);
+    sc2_map.t3SyncCliffLevel = (sc2MapSyncCliffLevel_t *)sc2_read_binary_layer(source,
+                                                                               "t3SyncCliffLevel",
+                                                                               sizeof(sc2MapSyncCliffLevel_t),
+                                                                               MAKEFOURCC('C','L','I','F'),
+                                                                               NULL);
 }
 
 static void sc2_parse_texture_masks(sc2MapSource_t *source) {
-    DWORD size = 0;
-    LPBYTE data = sc2_source_read(source, "t3TextureMasks", &size);
-
-    sc2_map.t3TextureMasks = sc2_alloc(size);
-    memcpy(sc2_map.t3TextureMasks, data, size);
-    sc2_map.t3TextureMasksSize = size;
-    sc2_free_file(data);
+    sc2_map.t3TextureMasks = (sc2MapTextureMasks_t *)sc2_read_binary_layer(source,
+                                                                           "t3TextureMasks",
+                                                                           sizeof(sc2MapTextureMasks_t),
+                                                                           MAKEFOURCC('M','A','S','K'),
+                                                                           &sc2_map.t3TextureMasksSize);
 }
 
 void SC2_MapSetHost(sc2MapHost_t const *host) {

--- a/games/starcraft-2/tests/test_sc2_map.c
+++ b/games/starcraft-2/tests/test_sc2_map.c
@@ -4,6 +4,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <sys/stat.h>
 
 #include "common.h"
 #include "games/starcraft-2/common/sc2_map.h"
@@ -12,6 +13,9 @@
 #ifndef TEST_SC2_MPQ
 #define TEST_SC2_MPQ "build/tests/test-sc2.SC2Maps"
 #endif
+
+#define TEST_SC2_SRC_DIR "games/starcraft-2/tests/resources-src"
+#define TEST_SC2_TINY_DIR TEST_SC2_SRC_DIR "/Maps/Test/Tiny.SC2Map"
 
 static BOOL sc2_tests_initialized;
 static DWORD listed_count;
@@ -60,13 +64,84 @@ static void setup_sc2_tests(void) {
     LPCSTR argv[] = { "test_sc2", "-config", "" };
     Com_Init(3, argv);
     ASSERT(FS_AddArchive(TEST_SC2_MPQ) != NULL);
+    sc2_tests_initialized = true;
+}
+
+static void use_sc2_fs_host(void) {
     SC2_MapSetHost(&(sc2MapHost_t){
         .read_file = FS_ReadFile,
         .free_file = FS_FreeFile,
         .mem_alloc = MemAlloc,
         .mem_free = MemFree,
     });
-    sc2_tests_initialized = true;
+}
+
+static HANDLE read_test_disk_path(LPCSTR filename, LPDWORD size) {
+    FILE *file;
+    long file_size;
+    LPBYTE data;
+    struct stat st;
+
+    if (size) *size = 0;
+    if (!filename || !*filename)
+        return NULL;
+    if (stat(filename, &st) != 0 || !S_ISREG(st.st_mode))
+        return NULL;
+    file = fopen(filename, "rb");
+    if (!file)
+        return NULL;
+    if (fseek(file, 0, SEEK_END) != 0 || (file_size = ftell(file)) < 0 || fseek(file, 0, SEEK_SET) != 0) {
+        fclose(file);
+        return NULL;
+    }
+    data = MemAlloc(file_size ? file_size : 1);
+    if (!data) {
+        fclose(file);
+        return NULL;
+    }
+    if (file_size > 0 && fread(data, 1, file_size, file) != (size_t)file_size) {
+        MemFree(data);
+        fclose(file);
+        return NULL;
+    }
+    fclose(file);
+    if (size) *size = (DWORD)file_size;
+    return data;
+}
+
+static void normalize_disk_path(LPSTR path) {
+    if (!path) return;
+    for (LPSTR p = path; *p; p++) {
+        if (*p == '\\') *p = '/';
+    }
+}
+
+static HANDLE read_test_disk_file(LPCSTR filename, LPDWORD size) {
+    char path[MAX_PATHLEN * 2];
+    HANDLE data;
+
+    data = read_test_disk_path(filename, size);
+    if (data)
+        return data;
+
+    snprintf(path, sizeof(path), "%s", filename ? filename : "");
+    normalize_disk_path(path);
+    data = read_test_disk_path(path, size);
+    if (data)
+        return data;
+
+    snprintf(path, sizeof(path), "%s/%s", TEST_SC2_SRC_DIR, filename ? filename : "");
+    normalize_disk_path(path);
+    return read_test_disk_path(path, size);
+}
+
+static void use_sc2_disk_host(void) {
+    SC2_MapSetHost(&(sc2MapHost_t){
+        .read_file = read_test_disk_file,
+        .free_file = MemFree,
+        .mem_alloc = MemAlloc,
+        .mem_free = MemFree,
+    });
 }
 
 static void collect_map(LPCSTR path, void *userData) {
@@ -79,6 +154,7 @@ static void collect_map(LPCSTR path, void *userData) {
 
 static void test_sc2_fixture_archive_lists_map_root(void) {
     setup_sc2_tests();
+    use_sc2_fs_host();
     listed_count = 0;
     listed_map[0] = '\0';
 
@@ -91,6 +167,7 @@ static void test_sc2_fixture_short_name_resolves(void) {
     PATHSTR path;
 
     setup_sc2_tests();
+    use_sc2_fs_host();
     ASSERT_EQ_INT(FS_ResolveMapPath("Tiny", path, sizeof(path)), FS_MAP_RESOLVE_OK);
     ASSERT_STR_EQ(path, "Maps\\Test\\Tiny.SC2Map");
 }
@@ -99,6 +176,7 @@ static void test_sc2_map_loads_xml_objects_and_terrain(void) {
     sc2Map_t *map;
 
     setup_sc2_tests();
+    use_sc2_fs_host();
     ASSERT(SC2_MapLoad("Maps\\Test\\Tiny.SC2Map"));
     map = SC2_MapCurrent();
 
@@ -199,6 +277,7 @@ static void test_sc2_map_loads_binary_terrain_layers(void) {
     sc2Map_t *map;
 
     setup_sc2_tests();
+    use_sc2_fs_host();
     ASSERT(SC2_MapLoad("Maps\\Test\\Tiny.SC2Map"));
     map = SC2_MapCurrent();
 
@@ -261,11 +340,62 @@ static void test_sc2_map_loads_binary_terrain_layers(void) {
     }
 }
 
+static void test_sc2_map_loads_directory_fixture_without_generated_layers(void) {
+    sc2Map_t *map;
+
+    setup_sc2_tests();
+    use_sc2_disk_host();
+    ASSERT(SC2_MapLoad(TEST_SC2_TINY_DIR));
+    map = SC2_MapCurrent();
+
+    ASSERT_STR_EQ(map->map_name, "SC2 Tiny Fixture");
+    ASSERT_EQ_INT(map->MapInfo.fourcc, MAKEFOURCC('M','a','p','I'));
+    ASSERT_EQ_INT(map->MapInfo.width, 8);
+    ASSERT_EQ_INT(map->MapInfo.height, 6);
+    ASSERT_EQ_INT(map->num_objects, 5);
+
+    ASSERT_STR_EQ(map->objects[0].name, "StartGame02");
+    ASSERT_EQ_INT(map->objects[0].type, SC2_OBJECT_CAMERA);
+    ASSERT_EQ_FLOAT(map->objects[0].camera.distance, 34.0f, 0.001f);
+    ASSERT_STR_EQ(map->objects[1].name, "Marine");
+    ASSERT_EQ_INT(map->objects[1].type, SC2_OBJECT_UNIT);
+    ASSERT_STR_EQ(map->objects[1].model, "Assets\\Units\\Terran\\Marine\\Marine.m3");
+    ASSERT_EQ_FLOAT(map->objects[1].position.x, 3.5f, 0.001f);
+    ASSERT_EQ_INT(map->objects[1].player, 2);
+    ASSERT_STR_EQ(map->objects[4].name, "MineralField");
+    ASSERT_EQ_INT(map->objects[4].type, SC2_OBJECT_DOODAD);
+    ASSERT_STR_EQ(map->objects[4].model, "Assets\\Doodads\\Terran\\MineralField\\MineralField.m3");
+
+    ASSERT_STR_EQ(map->t3Terrain.tile_set, "Fixture");
+    ASSERT_EQ_FLOAT(map->t3Terrain.height_quantize_scale, 1.0f, 0.001f);
+    ASSERT_EQ_INT(map->t3Terrain.num_terrain_textures, 2);
+    ASSERT_STR_EQ(map->t3Terrain.terrain_textures[0].diffuse, "Assets\\Textures\\Terrain\\FixtureGrass_Diffuse.dds");
+    ASSERT_EQ_INT(map->t3Terrain.num_cliff_sets, 1);
+    ASSERT_STR_EQ(map->t3Terrain.cliff_sets[0].name, "FixtureCliff0");
+    ASSERT_STR_EQ(map->t3Terrain.cliff_sets[0].mesh, "CliffNatural0");
+    ASSERT_EQ_INT(map->t3Terrain.num_cliff_cells, 2);
+    ASSERT_EQ_INT(map->t3Terrain.cliff_cells[0].variant, 2);
+    ASSERT_EQ_INT(map->lighting.enabled, true);
+    ASSERT_STR_EQ(map->lighting.id, "Fixture");
+    ASSERT_EQ_FLOAT(map->lighting.directional[SC2_LIGHT_KEY].color_multiplier, 2.0f, 0.001f);
+
+    ASSERT_NULL(map->t3CellFlags);
+    ASSERT_NULL(map->t3SyncCliffLevel);
+    ASSERT_NULL(map->t3HeightMap);
+    ASSERT_NULL(map->t3SyncHeightMap);
+    ASSERT_NULL(map->t3TextureMasks);
+    ASSERT_EQ_INT(map->t3TextureMasksSize, 0);
+
+    SC2_MapShutdown();
+    use_sc2_fs_host();
+}
+
 void run_sc2_map_tests(void) {
     RUN_TEST(test_sc2_fixture_archive_lists_map_root);
     RUN_TEST(test_sc2_fixture_short_name_resolves);
     RUN_TEST(test_sc2_map_loads_xml_objects_and_terrain);
     RUN_TEST(test_sc2_map_loads_binary_terrain_layers);
+    RUN_TEST(test_sc2_map_loads_directory_fixture_without_generated_layers);
     SC2_MapShutdown();
     FS_Shutdown();
 }


### PR DESCRIPTION
## Summary

This adds coverage for loading the committed SC2 map fixture directly from its source directory instead of only through the generated packed test archive.

- proves `SC2_MapLoad("games/starcraft-2/tests/resources-src/Maps/Test/Tiny.SC2Map")` works with a disk-backed test host
- keeps the existing packed `.SC2Maps` fixture coverage unchanged
- treats absent optional `t3*` binary terrain layers as missing layers instead of copying from a null source
- continues validating packed binary terrain layers through the existing archive-backed tests

## CI follow-up

The previous PR hit a Linux CI segmentation fault in the new directory-backed test. The fixed branch now makes the test disk host ignore non-regular paths before calling `fopen`, so the fixture directory itself cannot be treated as file bytes.

## Validation

- `make test-sc2`
- `make test`
