### PR TITLE
Honor SC2 catalog dependency layering

### DIFF
--- a/games/starcraft-2/common/sc2_map.c
+++ b/games/starcraft-2/common/sc2_map.c
@@ -103,6 +103,15 @@ typedef struct {
 static sc2MapHost_t sc2_host;
 static sc2Map_t     sc2_map;
 
+static LPCSTR const sc2_catalog_roots[] = {
+    "Mods/Core.SC2Mod/Base.SC2Data",
+    "Mods/Liberty.SC2Mod/Base.SC2Data",
+    "Mods/LibertyMulti.SC2Mod/Base.SC2Data",
+    "Campaigns/LibertyStory.SC2Campaign/Base.SC2Data",
+    "Campaigns/Liberty.SC2Campaign/Base.SC2Data",
+    NULL,
+};
+
 static BOOL sc2_mapinfo_fourcc(sc2MapInfo_t const *mapInfo);
 static BOOL sc2_parse_xml_field(void *base, sc2XmlField_t const *fields, DWORD num_fields, LPCSTR name, LPCSTR value);
 
@@ -336,6 +345,20 @@ static xmlDocPtr sc2_read_catalog_xml(LPCSTR root, LPCSTR filename) {
         return sc2_read_catalog_xml_from_archive(path, filename);
     }
     return sc2_read_catalog_xml_from_archive(root, filename);
+}
+
+static xmlDocPtr sc2_read_map_catalog_xml(sc2MapSource_t *source, LPCSTR filename) {
+    PATHSTR path;
+    xmlDocPtr doc;
+
+    snprintf(path, sizeof(path), "Base.SC2Data/%s", filename);
+    for (char *p = path; *p; p++) if (*p == '\\') *p = '/';
+    doc = sc2_read_xml(source, path);
+    if (doc)
+        return doc;
+    snprintf(path, sizeof(path), "Base.SC2Data\\%s", filename);
+    for (char *p = path; *p; p++) if (*p == '/') *p = '\\';
+    return sc2_read_xml(source, path);
 }
 
 static BOOL sc2_xml_attr(xmlNodePtr node, LPCSTR attr_name, LPSTR buffer, DWORD size) {
@@ -714,18 +737,9 @@ static void sc2_parse_terrain_data_catalog_file(LPCSTR root_name) {
 }
 
 static void sc2_parse_terrain_data_catalogs(void) {
-    static LPCSTR const roots[] = {
-        "Mods/Core.SC2Mod/Base.SC2Data",
-        "Mods/Liberty.SC2Mod/Base.SC2Data",
-        "Mods/LibertyMulti.SC2Mod/Base.SC2Data",
-        "Campaigns/LibertyStory.SC2Campaign/Base.SC2Data",
-        "Campaigns/Liberty.SC2Campaign/Base.SC2Data",
-        NULL,
-    };
-
+    for (DWORD i = 0; sc2_catalog_roots[i]; i++)
+        sc2_parse_terrain_data_catalog_file(sc2_catalog_roots[i]);
     sc2_parse_terrain_data_catalog_file("");
-    for (DWORD i = 0; roots[i]; i++)
-        sc2_parse_terrain_data_catalog_file(roots[i]);
 }
 
 static void sc2_parse_light_data(sc2MapSource_t *source) {
@@ -744,18 +758,9 @@ static void sc2_parse_light_data_catalog_file(LPCSTR root_name) {
 }
 
 static void sc2_parse_light_data_catalogs(void) {
-    static LPCSTR const roots[] = {
-        "Mods/Core.SC2Mod/Base.SC2Data",
-        "Mods/Liberty.SC2Mod/Base.SC2Data",
-        "Mods/LibertyMulti.SC2Mod/Base.SC2Data",
-        "Campaigns/LibertyStory.SC2Campaign/Base.SC2Data",
-        "Campaigns/Liberty.SC2Campaign/Base.SC2Data",
-        NULL,
-    };
-
+    for (DWORD i = 0; sc2_catalog_roots[i]; i++)
+        sc2_parse_light_data_catalog_file(sc2_catalog_roots[i]);
     sc2_parse_light_data_catalog_file("");
-    for (DWORD i = 0; roots[i]; i++)
-        sc2_parse_light_data_catalog_file(roots[i]);
 }
 
 static void sc2_set_object_model(sc2MapObject_t *object) {
@@ -1212,8 +1217,7 @@ static BOOL sc2_terrain_texture_path_from_tileset(LPCSTR id,
     return true;
 }
 
-static void sc2_parse_model_catalog_file(sc2Catalog_t *catalog, LPCSTR root_name) {
-    xmlDocPtr doc = sc2_read_catalog_xml(root_name, "GameData\\ModelData.xml");
+static void sc2_parse_model_catalog_doc(sc2Catalog_t *catalog, xmlDocPtr doc) {
     xmlNodePtr root;
 
     if (!doc) return;
@@ -1237,11 +1241,23 @@ static void sc2_parse_model_catalog_file(sc2Catalog_t *catalog, LPCSTR root_name
         }
         sc2_catalog_add_model(catalog, id, parent, race, path);
     }
+}
+
+static void sc2_parse_model_catalog_file(sc2Catalog_t *catalog, LPCSTR root_name) {
+    xmlDocPtr doc = sc2_read_catalog_xml(root_name, "GameData\\ModelData.xml");
+
+    sc2_parse_model_catalog_doc(catalog, doc);
     xmlFreeDoc(doc);
 }
 
-static void sc2_parse_actor_catalog_file(sc2Catalog_t *catalog, LPCSTR root_name) {
-    xmlDocPtr doc = sc2_read_catalog_xml(root_name, "GameData\\ActorData.xml");
+static void sc2_parse_model_catalog_source(sc2Catalog_t *catalog, sc2MapSource_t *source) {
+    xmlDocPtr doc = sc2_read_map_catalog_xml(source, "GameData\\ModelData.xml");
+
+    sc2_parse_model_catalog_doc(catalog, doc);
+    xmlFreeDoc(doc);
+}
+
+static void sc2_parse_actor_catalog_doc(sc2Catalog_t *catalog, xmlDocPtr doc) {
     xmlNodePtr root;
 
     if (!doc) return;
@@ -1268,11 +1284,23 @@ static void sc2_parse_actor_catalog_file(sc2Catalog_t *catalog, LPCSTR root_name
         sc2_catalog_add_actor(catalog, id, model_id);
         if (unit_name[0]) sc2_catalog_add_actor(catalog, unit_name, model_id);
     }
+}
+
+static void sc2_parse_actor_catalog_file(sc2Catalog_t *catalog, LPCSTR root_name) {
+    xmlDocPtr doc = sc2_read_catalog_xml(root_name, "GameData\\ActorData.xml");
+
+    sc2_parse_actor_catalog_doc(catalog, doc);
     xmlFreeDoc(doc);
 }
 
-static void sc2_parse_unit_catalog_file(sc2Catalog_t *catalog, LPCSTR root_name) {
-    xmlDocPtr doc = sc2_read_catalog_xml(root_name, "GameData\\UnitData.xml");
+static void sc2_parse_actor_catalog_source(sc2Catalog_t *catalog, sc2MapSource_t *source) {
+    xmlDocPtr doc = sc2_read_map_catalog_xml(source, "GameData\\ActorData.xml");
+
+    sc2_parse_actor_catalog_doc(catalog, doc);
+    xmlFreeDoc(doc);
+}
+
+static void sc2_parse_unit_catalog_doc(sc2Catalog_t *catalog, xmlDocPtr doc) {
     xmlNodePtr root;
 
     if (!doc) return;
@@ -1301,11 +1329,23 @@ static void sc2_parse_unit_catalog_file(sc2Catalog_t *catalog, LPCSTR root_name)
         }
         sc2_catalog_add_unit(catalog, id, actor_id, radius, has_radius);
     }
+}
+
+static void sc2_parse_unit_catalog_file(sc2Catalog_t *catalog, LPCSTR root_name) {
+    xmlDocPtr doc = sc2_read_catalog_xml(root_name, "GameData\\UnitData.xml");
+
+    sc2_parse_unit_catalog_doc(catalog, doc);
     xmlFreeDoc(doc);
 }
 
-static void sc2_parse_terrain_tex_catalog_file(sc2Catalog_t *catalog, LPCSTR root_name) {
-    xmlDocPtr doc = sc2_read_catalog_xml(root_name, "GameData\\TerrainTexData.xml");
+static void sc2_parse_unit_catalog_source(sc2Catalog_t *catalog, sc2MapSource_t *source) {
+    xmlDocPtr doc = sc2_read_map_catalog_xml(source, "GameData\\UnitData.xml");
+
+    sc2_parse_unit_catalog_doc(catalog, doc);
+    xmlFreeDoc(doc);
+}
+
+static void sc2_parse_terrain_tex_catalog_doc(sc2Catalog_t *catalog, xmlDocPtr doc) {
     xmlNodePtr root;
 
     if (!doc) return;
@@ -1327,11 +1367,23 @@ static void sc2_parse_terrain_tex_catalog_file(sc2Catalog_t *catalog, LPCSTR roo
         }
         sc2_catalog_add_terrain_tex(catalog, id, diffuse, normal);
     }
+}
+
+static void sc2_parse_terrain_tex_catalog_file(sc2Catalog_t *catalog, LPCSTR root_name) {
+    xmlDocPtr doc = sc2_read_catalog_xml(root_name, "GameData\\TerrainTexData.xml");
+
+    sc2_parse_terrain_tex_catalog_doc(catalog, doc);
     xmlFreeDoc(doc);
 }
 
-static void sc2_parse_cliff_catalog_file(sc2Catalog_t *catalog, LPCSTR root_name) {
-    xmlDocPtr doc = sc2_read_catalog_xml(root_name, "GameData\\CliffData.xml");
+static void sc2_parse_terrain_tex_catalog_source(sc2Catalog_t *catalog, sc2MapSource_t *source) {
+    xmlDocPtr doc = sc2_read_map_catalog_xml(source, "GameData\\TerrainTexData.xml");
+
+    sc2_parse_terrain_tex_catalog_doc(catalog, doc);
+    xmlFreeDoc(doc);
+}
+
+static void sc2_parse_cliff_catalog_doc(sc2Catalog_t *catalog, xmlDocPtr doc) {
     xmlNodePtr root;
 
     if (!doc) return;
@@ -1352,31 +1404,40 @@ static void sc2_parse_cliff_catalog_file(sc2Catalog_t *catalog, LPCSTR root_name
         }
         sc2_catalog_add_cliff(catalog, id, mesh);
     }
+}
+
+static void sc2_parse_cliff_catalog_file(sc2Catalog_t *catalog, LPCSTR root_name) {
+    xmlDocPtr doc = sc2_read_catalog_xml(root_name, "GameData\\CliffData.xml");
+
+    sc2_parse_cliff_catalog_doc(catalog, doc);
     xmlFreeDoc(doc);
 }
 
-static void sc2_parse_catalogs(sc2Catalog_t *catalog) {
-    static LPCSTR const roots[] = {
-        "Mods/Core.SC2Mod/Base.SC2Data",
-        "Mods/Liberty.SC2Mod/Base.SC2Data",
-        "Mods/LibertyMulti.SC2Mod/Base.SC2Data",
-        "Campaigns/LibertyStory.SC2Campaign/Base.SC2Data",
-        "Campaigns/Liberty.SC2Campaign/Base.SC2Data",
-        NULL,
-    };
+static void sc2_parse_cliff_catalog_source(sc2Catalog_t *catalog, sc2MapSource_t *source) {
+    xmlDocPtr doc = sc2_read_map_catalog_xml(source, "GameData\\CliffData.xml");
 
+    sc2_parse_cliff_catalog_doc(catalog, doc);
+    xmlFreeDoc(doc);
+}
+
+static void sc2_parse_catalogs(sc2Catalog_t *catalog, sc2MapSource_t *source) {
+    for (DWORD i = 0; sc2_catalog_roots[i]; i++) {
+        sc2_parse_unit_catalog_file(catalog, sc2_catalog_roots[i]);
+        sc2_parse_model_catalog_file(catalog, sc2_catalog_roots[i]);
+        sc2_parse_actor_catalog_file(catalog, sc2_catalog_roots[i]);
+        sc2_parse_terrain_tex_catalog_file(catalog, sc2_catalog_roots[i]);
+        sc2_parse_cliff_catalog_file(catalog, sc2_catalog_roots[i]);
+    }
     sc2_parse_unit_catalog_file(catalog, "");
     sc2_parse_model_catalog_file(catalog, "");
     sc2_parse_actor_catalog_file(catalog, "");
     sc2_parse_terrain_tex_catalog_file(catalog, "");
     sc2_parse_cliff_catalog_file(catalog, "");
-    for (DWORD i = 0; roots[i]; i++) {
-        sc2_parse_unit_catalog_file(catalog, roots[i]);
-        sc2_parse_model_catalog_file(catalog, roots[i]);
-        sc2_parse_actor_catalog_file(catalog, roots[i]);
-        sc2_parse_terrain_tex_catalog_file(catalog, roots[i]);
-        sc2_parse_cliff_catalog_file(catalog, roots[i]);
-    }
+    sc2_parse_unit_catalog_source(catalog, source);
+    sc2_parse_model_catalog_source(catalog, source);
+    sc2_parse_actor_catalog_source(catalog, source);
+    sc2_parse_terrain_tex_catalog_source(catalog, source);
+    sc2_parse_cliff_catalog_source(catalog, source);
 }
 
 static void sc2_resolve_terrain_textures(sc2Catalog_t const *catalog) {
@@ -1525,12 +1586,12 @@ next_object:
     }
 }
 
-static void sc2_resolve_catalogs(void) {
+static void sc2_resolve_catalogs(sc2MapSource_t *source) {
     sc2Catalog_t *catalog = sc2_alloc(sizeof(*catalog));
 
     if (!catalog) return;
     memset(catalog, 0, sizeof(*catalog));
-    sc2_parse_catalogs(catalog);
+    sc2_parse_catalogs(catalog, source);
     sc2_resolve_terrain_textures(catalog);
     sc2_resolve_cliff_sets(catalog);
     sc2_resolve_object_models(catalog);
@@ -1709,8 +1770,8 @@ BOOL SC2_MapLoad(LPCSTR mapFilename) {
     sc2_parse_sync_cliff_level(&source);
     sc2_parse_texture_masks(&source);
     sc2_parse_objects(&source);
+    sc2_resolve_catalogs(&source);
     sc2_source_close(&source);
-    sc2_resolve_catalogs();
     sc2_map.origin.x = 0.0f;
     sc2_map.origin.y = 0.0f;
     fprintf(stderr, "SC2_MapLoad: %s %ux%u objects=%u\n",

--- a/games/starcraft-2/tests/resources-src/Mods/Core.SC2Mod/Base.SC2Data/GameData/ActorData.xml
+++ b/games/starcraft-2/tests/resources-src/Mods/Core.SC2Mod/Base.SC2Data/GameData/ActorData.xml
@@ -11,7 +11,7 @@
         <EditorFlags index="NoAutoRotate" value="1"/>
     </CActorDoodad>
     <CActorUnit id="MarineActor">
-        <Model value="MarineCatalogModel"/>
+        <Model value="MarineCoreModel"/>
         <DeathArray index="Normal" ModelLink="MarineDeath"/>
     </CActorUnit>
     <CActorUnit id="Civilian" unitName="Civilian">

--- a/games/starcraft-2/tests/resources-src/Mods/Core.SC2Mod/Base.SC2Data/GameData/CliffData.xml
+++ b/games/starcraft-2/tests/resources-src/Mods/Core.SC2Mod/Base.SC2Data/GameData/CliffData.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="us-ascii"?>
 <Catalog>
     <CCliff id="FixtureCliff0">
-        <CliffMesh value="CliffNatural0"/>
+        <CliffMesh value="CoreCliff0"/>
     </CCliff>
     <CCliff id="MarSaraCliff0">
         <CliffMesh value="CliffNatural0"/>

--- a/games/starcraft-2/tests/resources-src/Mods/Core.SC2Mod/Base.SC2Data/GameData/ModelData.xml
+++ b/games/starcraft-2/tests/resources-src/Mods/Core.SC2Mod/Base.SC2Data/GameData/ModelData.xml
@@ -9,6 +9,9 @@
     <CModel id="MarineCatalogModel" parent="Unit" Race="Terran">
         <Occlusion value="Show"/>
     </CModel>
+    <CModel id="MarineCoreModel" parent="Unit" Race="Protoss">
+        <Occlusion value="Hide"/>
+    </CModel>
     <CModel id="BillboardTall" parent="Doodad">
         <VariationCount value="4"/>
     </CModel>

--- a/games/starcraft-2/tests/resources-src/Mods/Core.SC2Mod/Base.SC2Data/GameData/TerrainTexData.xml
+++ b/games/starcraft-2/tests/resources-src/Mods/Core.SC2Mod/Base.SC2Data/GameData/TerrainTexData.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="us-ascii"?>
 <Catalog>
     <CTerrainTex id="FixtureGrass">
-        <Texture value="Assets\Textures\Terrain\FixtureGrass_Diffuse.dds"/>
-        <Normalmap value="Assets\Textures\Terrain\FixtureGrass_Diffuse_normal.dds"/>
+        <Texture value="Assets\Textures\Terrain\CoreGrass_Diffuse.dds"/>
+        <Normalmap value="Assets\Textures\Terrain\CoreGrass_Diffuse_normal.dds"/>
     </CTerrainTex>
     <CTerrainTex id="FixtureDirt">
         <Texture value="Assets\Textures\Terrain\FixtureDirt_Diffuse.dds"/>

--- a/games/starcraft-2/tests/resources-src/Mods/Core.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/games/starcraft-2/tests/resources-src/Mods/Core.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -2,6 +2,6 @@
 <Catalog>
     <CUnit id="Marine">
         <Actor value="MarineActor"/>
-        <Radius value="0.75"/>
+        <Radius value="0.25"/>
     </CUnit>
 </Catalog>

--- a/games/starcraft-2/tests/test_sc2_map.c
+++ b/games/starcraft-2/tests/test_sc2_map.c
@@ -294,6 +294,14 @@ static void test_sc2_fixture_short_name_resolves(void) {
     ASSERT_STR_EQ(path, "Maps\\Test\\Tiny.SC2Map");
 }
 
+static void assert_tiny_map_catalog_overrides(sc2Map_t *map) {
+    ASSERT_STR_EQ(map->objects[1].model, "Assets\\Units\\Terran\\MarineCatalogModel\\MarineCatalogModel.m3");
+    ASSERT_EQ_FLOAT(map->objects[1].radius, 0.75f, 0.001f);
+    ASSERT_STR_EQ(map->t3Terrain.terrain_textures[0].diffuse, "Assets\\Textures\\Terrain\\FixtureGrass_Diffuse.dds");
+    ASSERT_STR_EQ(map->t3Terrain.terrain_textures[0].normal, "Assets\\Textures\\Terrain\\FixtureGrass_Diffuse_normal.dds");
+    ASSERT_STR_EQ(map->t3Terrain.cliff_sets[0].mesh, "CliffNatural0");
+}
+
 static void test_sc2_map_loads_xml_objects_and_terrain(void) {
     sc2Map_t *map;
 
@@ -308,6 +316,7 @@ static void test_sc2_map_loads_xml_objects_and_terrain(void) {
     ASSERT_EQ_INT(map->MapInfo.height, 6);
     ASSERT_STR_EQ((char const *)map->MapInfo.data, "SC2 Tiny Fixture");
     ASSERT_EQ_INT(map->num_objects, 5);
+    assert_tiny_map_catalog_overrides(map);
 
     ASSERT_STR_EQ(map->objects[0].name, "StartGame02");
     ASSERT_EQ_INT(map->objects[0].id, 10);
@@ -325,9 +334,7 @@ static void test_sc2_map_loads_xml_objects_and_terrain(void) {
 
     ASSERT_STR_EQ(map->objects[1].name, "Marine");
     ASSERT_EQ_INT(map->objects[1].id, 1);
-    ASSERT_STR_EQ(map->objects[1].model, "Assets\\Units\\Terran\\MarineCatalogModel\\MarineCatalogModel.m3");
     ASSERT_EQ_INT(map->objects[1].type, SC2_OBJECT_UNIT);
-    ASSERT_EQ_FLOAT(map->objects[1].radius, 0.75f, 0.001f);
     ASSERT_EQ_FLOAT(map->objects[1].position.x, 3.5f, 0.001f);
     ASSERT_EQ_FLOAT(map->objects[1].position.y, 3.5f, 0.001f);
     ASSERT_EQ_FLOAT(map->objects[1].position.z, 0.25f, 0.001f);
@@ -361,13 +368,10 @@ static void test_sc2_map_loads_xml_objects_and_terrain(void) {
     ASSERT_EQ_INT(map->t3Terrain.fog_color.g, 20);
     ASSERT_EQ_INT(map->t3Terrain.fog_color.b, 30);
     ASSERT_EQ_INT(map->t3Terrain.num_terrain_textures, 2);
-    ASSERT_STR_EQ(map->t3Terrain.terrain_textures[0].diffuse, "Assets\\Textures\\Terrain\\FixtureGrass_Diffuse.dds");
-    ASSERT_STR_EQ(map->t3Terrain.terrain_textures[0].normal, "Assets\\Textures\\Terrain\\FixtureGrass_Diffuse_normal.dds");
     ASSERT_STR_EQ(map->t3Terrain.terrain_textures[1].diffuse, "Assets\\Textures\\Terrain\\FixtureDirt_Diffuse.dds");
 
     ASSERT_EQ_INT(map->t3Terrain.num_cliff_sets, 1);
     ASSERT_STR_EQ(map->t3Terrain.cliff_sets[0].name, "FixtureCliff0");
-    ASSERT_STR_EQ(map->t3Terrain.cliff_sets[0].mesh, "CliffNatural0");
     ASSERT_EQ_INT(map->t3Terrain.num_cliff_cells, 2);
     ASSERT_EQ_INT(map->t3Terrain.cliff_cells[0].index, 0);
     ASSERT_EQ_INT(map->t3Terrain.cliff_cells[0].flags, 1);
@@ -476,14 +480,13 @@ static void test_sc2_map_loads_directory_fixture_without_generated_layers(void) 
     ASSERT_EQ_INT(map->MapInfo.width, 8);
     ASSERT_EQ_INT(map->MapInfo.height, 6);
     ASSERT_EQ_INT(map->num_objects, 5);
+    assert_tiny_map_catalog_overrides(map);
 
     ASSERT_STR_EQ(map->objects[0].name, "StartGame02");
     ASSERT_EQ_INT(map->objects[0].type, SC2_OBJECT_CAMERA);
     ASSERT_EQ_FLOAT(map->objects[0].camera.distance, 34.0f, 0.001f);
     ASSERT_STR_EQ(map->objects[1].name, "Marine");
     ASSERT_EQ_INT(map->objects[1].type, SC2_OBJECT_UNIT);
-    ASSERT_STR_EQ(map->objects[1].model, "Assets\\Units\\Terran\\MarineCatalogModel\\MarineCatalogModel.m3");
-    ASSERT_EQ_FLOAT(map->objects[1].radius, 0.75f, 0.001f);
     ASSERT_EQ_FLOAT(map->objects[1].position.x, 3.5f, 0.001f);
     ASSERT_EQ_INT(map->objects[1].player, 2);
     ASSERT_STR_EQ(map->objects[4].name, "MineralField");
@@ -493,10 +496,8 @@ static void test_sc2_map_loads_directory_fixture_without_generated_layers(void) 
     ASSERT_STR_EQ(map->t3Terrain.tile_set, "Fixture");
     ASSERT_EQ_FLOAT(map->t3Terrain.height_quantize_scale, 1.0f, 0.001f);
     ASSERT_EQ_INT(map->t3Terrain.num_terrain_textures, 2);
-    ASSERT_STR_EQ(map->t3Terrain.terrain_textures[0].diffuse, "Assets\\Textures\\Terrain\\FixtureGrass_Diffuse.dds");
     ASSERT_EQ_INT(map->t3Terrain.num_cliff_sets, 1);
     ASSERT_STR_EQ(map->t3Terrain.cliff_sets[0].name, "FixtureCliff0");
-    ASSERT_STR_EQ(map->t3Terrain.cliff_sets[0].mesh, "CliffNatural0");
     ASSERT_EQ_INT(map->t3Terrain.num_cliff_cells, 2);
     ASSERT_EQ_INT(map->t3Terrain.cliff_cells[0].variant, 2);
     ASSERT_EQ_INT(map->lighting.enabled, true);


### PR DESCRIPTION
SC2 catalog loading now layers dependency catalog data before map-local `Base.SC2Data` catalog data, matching the parser docs and SC2 catalog override model.

This patch:
- shares the dependency catalog root list across SC2 catalog loaders
- parses dependency catalogs before loose/global and map-local catalogs
- reads map-local Unit/Actor/Model/TerrainTex/Cliff catalog XML from the open map source before closing it
- keeps the loose `GameData\*.xml` fallback, with source-local map data still winning last
- updates the Core fixture to contain different defaults from the Tiny map fixture
- asserts packed and directory-backed Tiny loads use the map-local model path, unit radius, terrain texture, and cliff mesh

Validated with:
- `git diff --check`
- `make test-sc2`
- `make test`