### PR TITLE
Expand SC2 spawn parsing and diagnostics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,6 +240,10 @@ $(BIN_DIR)/m3tool$(EXE_EXT): tools/m3tool.c $(TOOL_DEPS) $(CLIENT_HEADERS) $(COM
 	@$(CC) $(SC2_CFLAGS) -o $@ $< \
 		$(RPATH) $(LDFLAGS) -lrenderer-sc2 -lsheet -lshared $(LIBS) -lm -lz $(SC2_XML_LIBS)
 
+$(BIN_DIR)/sc2map$(EXE_EXT): tools/sc2map.c $(SC2_DIR)/common/sc2_map.c $(SC2_DIR)/common/sc2_map.h common/mpq.c | $(BIN_DIR)
+	@$(CC) $(SC2_CFLAGS) -o $@ tools/sc2map.c $(SC2_DIR)/common/sc2_map.c common/mpq.c \
+		$(RPATH) $(LDFLAGS) -lm -lz $(SC2_XML_LIBS)
+
 $(BIN_DIR)/img2sysfont$(EXE_EXT): tools/img2sysfont.c | $(BIN_DIR)
 	@$(CC) $(CFLAGS) -o $@ tools/img2sysfont.c
 
@@ -282,7 +286,7 @@ $(eval $(call test_schema,test-wow-game,,$(WOW_TEST_CFLAGS),$(BIN_DIR)/test_wow_
 $(eval $(call test_schema,test-wow-ui,test-wow-assets,$(WOW_UI_TEST_CFLAGS),$(BIN_DIR)/test_wow_ui$(EXE_EXT),$(WOW_TEST_DIR)/test_wow_ui.c $(WOW_DIR)/ui/ui_wow.c common/mpq.c,-lshared $(LUA_LIBS) -lz,))
 $(eval $(call test_schema,test-sc2,test-sc2-assets $(SHARED_LIB) $(SHEET_LIB),$(SC2_TEST_CFLAGS),$(BIN_DIR)/test_sc2$(EXE_EXT),$(SC2_TEST_DIR)/test_sc2_main.c $(SC2_TEST_DIR)/test_sc2_map.c $(SC2_DIR)/common/sc2_map.c common/common.c common/cmd.c common/cvar.c common/msg.c common/net.c common/mpq.c,-lsheet -lshared -lm -lz $(SC2_XML_LIBS),))
 
-test-sc2-assets: sc2fixturegen mpqtool | $(TESTS_DIR)
+test-sc2-assets: sc2fixturegen mpqtool sc2map | $(TESTS_DIR)
 	@echo "[test-sc2-assets] generating SC2 terrain fixtures"
 	@mkdir -p $(SC2_TEST_RES_DIR)/Maps/Test/Tiny.SC2Map
 	@$(BIN_DIR)/sc2fixturegen$(EXE_EXT) map-info $(SC2_TEST_RES_DIR)/Maps/Test/Tiny.SC2Map/MapInfo
@@ -306,6 +310,7 @@ test-sc2-assets: sc2fixturegen mpqtool | $(TESTS_DIR)
 	@$(BIN_DIR)/mpqtool$(EXE_EXT) -mpq $(SC2_TEST_MPQ) ls Maps/Test/Tiny.SC2Map | grep -q "MapInfo" && echo "  ls map OK"
 	@$(BIN_DIR)/mpqtool$(EXE_EXT) -mpq $(SC2_TEST_MPQ) cat Maps/Test/Tiny.SC2Map/Objects | grep -q "UnitType=\"Marine\"" && echo "  cat objects OK"
 	@$(BIN_DIR)/mpqtool$(EXE_EXT) -mpq $(SC2_TEST_MPQ) info Maps/Test/Tiny.SC2Map/t3CellFlags | grep -q "size=80" && echo "  binary cell flags OK"
+	@$(BIN_DIR)/sc2map$(EXE_EXT) -mpq $(SC2_TEST_MPQ) Maps/Test/Tiny.SC2Map | grep -q "Objects: units=2 doodads=2 points=1 cameras=1 total=6" && echo "  sc2map diag OK"
 
 test-wow-assets: blpgen mpqtool | $(TESTS_DIR)
 	@echo "[test-wow-assets] generating WoW UI fixtures"

--- a/games/starcraft-2/common/sc2_map.c
+++ b/games/starcraft-2/common/sc2_map.c
@@ -86,6 +86,7 @@ typedef enum {
     SC2_XML_FIELD_STRING,
     SC2_XML_FIELD_VEC3,
     SC2_XML_FIELD_COLOR_ARGB,
+    SC2_XML_FIELD_COLOR_RGBA,
 } sc2XmlFieldType_t;
 
 typedef struct {
@@ -368,14 +369,19 @@ static xmlDocPtr sc2_read_map_catalog_xml(sc2MapSource_t *source, LPCSTR filenam
 }
 
 static BOOL sc2_xml_attr(xmlNodePtr node, LPCSTR attr_name, LPSTR buffer, DWORD size) {
-    xmlChar *text;
-
     if (!node || !attr_name || !buffer || !size) return false;
-    text = xmlGetProp(node, (xmlChar const *)attr_name);
-    if (!text) return false;
-    snprintf(buffer, size, "%s", (char const *)text);
-    xmlFree(text);
-    return buffer[0] != '\0';
+    for (xmlAttrPtr attr = node->properties; attr; attr = attr->next) {
+        xmlChar *text;
+
+        if (!sc2_streqi((char const *)attr->name, attr_name))
+            continue;
+        text = xmlNodeListGetString(node->doc, attr->children, 1);
+        if (!text) return false;
+        snprintf(buffer, size, "%s", (char const *)text);
+        xmlFree(text);
+        return buffer[0] != '\0';
+    }
+    return false;
 }
 
 static LPCSTR sc2_xml_content(xmlNodePtr node, char *buffer, DWORD size) {
@@ -444,6 +450,22 @@ static BOOL sc2_parse_argb_color(LPCSTR text, LPCOLOR32 color) {
     if (!text || !color)
         return false;
     if (sscanf(text, "%u,%u,%u,%u", &a, &r, &g, &b) == 4) {
+        *color = (COLOR32){ (BYTE)r, (BYTE)g, (BYTE)b, (BYTE)a };
+        return true;
+    }
+    if (sscanf(text, "%u,%u,%u", &r, &g, &b) == 3) {
+        *color = (COLOR32){ (BYTE)r, (BYTE)g, (BYTE)b, 255 };
+        return true;
+    }
+    return false;
+}
+
+static BOOL sc2_parse_rgba_color(LPCSTR text, LPCOLOR32 color) {
+    DWORD r, g, b, a;
+
+    if (!text || !color)
+        return false;
+    if (sscanf(text, "%u,%u,%u,%u", &r, &g, &b, &a) == 4) {
         *color = (COLOR32){ (BYTE)r, (BYTE)g, (BYTE)b, (BYTE)a };
         return true;
     }
@@ -790,6 +812,10 @@ static sc2XmlField_t const sc2_object_fields[] = {
     SC2_XML_FIELD("Variation", variation, SC2_XML_FIELD_DWORD),
     SC2_XML_FIELD("Player", player, SC2_XML_FIELD_DWORD),
     SC2_XML_FIELD("Owner", player, SC2_XML_FIELD_DWORD),
+    SC2_XML_FIELD("Section", section, SC2_XML_FIELD_DWORD),
+    SC2_XML_FIELD("Resources", resources, SC2_XML_FIELD_DWORD),
+    SC2_XML_FIELD("TintColor", tint_color, SC2_XML_FIELD_COLOR_RGBA),
+    SC2_XML_FIELD("Color", color, SC2_XML_FIELD_COLOR_RGBA),
 };
 
 static sc2XmlField_t const sc2_unit_fields[] = {
@@ -800,8 +826,20 @@ static sc2XmlField_t const sc2_doodad_fields[] = {
     SC2_XML_STRING_FIELD("Type", name),
 };
 
+static sc2XmlField_t const sc2_point_fields[] = {
+    SC2_XML_STRING_FIELD("Type", type_name),
+    SC2_XML_STRING_FIELD("AnimProps", anim_props),
+    SC2_XML_STRING_FIELD("Sound", sound),
+    SC2_XML_STRING_FIELD("AttachID", attach_id),
+    SC2_XML_FIELD("ObjectID", object_id, SC2_XML_FIELD_DWORD),
+    SC2_XML_STRING_FIELD("ObjectType", object_type),
+    SC2_XML_FIELD("PathingSoftRadius", pathing_soft_radius, SC2_XML_FIELD_FLOAT),
+    SC2_XML_FIELD("PathingHardRadius", pathing_hard_radius, SC2_XML_FIELD_FLOAT),
+};
+
 static sc2XmlField_t const sc2_camera_fields[] = {
     SC2_XML_FIELD("CameraTarget", camera.target, SC2_XML_FIELD_VEC3),
+    SC2_XML_FIELD("Target", camera.target, SC2_XML_FIELD_VEC3),
 };
 
 static sc2XmlField_t const sc2_camera_value_fields[] = {
@@ -842,6 +880,8 @@ static BOOL sc2_parse_xml_field(void *base, sc2XmlField_t const *fields, DWORD n
                 return sc2_parse_vec3(value, (LPVECTOR3)out);
             case SC2_XML_FIELD_COLOR_ARGB:
                 return sc2_parse_argb_color(value, (LPCOLOR32)out);
+            case SC2_XML_FIELD_COLOR_RGBA:
+                return sc2_parse_rgba_color(value, (LPCOLOR32)out);
         }
     }
     return false;
@@ -864,6 +904,9 @@ static void sc2_parse_object_fields(sc2MapObject_t *object, sc2ObjectType_t type
         case SC2_OBJECT_DOODAD:
             sc2_parse_object_field(object, sc2_doodad_fields, SC2_ARRAY_LEN(sc2_doodad_fields), key, value, has_position);
             break;
+        case SC2_OBJECT_POINT:
+            sc2_parse_object_field(object, sc2_point_fields, SC2_ARRAY_LEN(sc2_point_fields), key, value, has_position);
+            break;
         case SC2_OBJECT_CAMERA:
             sc2_parse_object_field(object, sc2_camera_fields, SC2_ARRAY_LEN(sc2_camera_fields), key, value, has_position);
             break;
@@ -873,9 +916,10 @@ static void sc2_parse_object_fields(sc2MapObject_t *object, sc2ObjectType_t type
 static BOOL sc2_object_type(xmlNodePtr node, sc2ObjectType_t *type) {
     LPCSTR name = (char const *)node->name;
 
-    if (sc2_contains_i(name, "ObjectUnit")) *type = SC2_OBJECT_UNIT;
-    else if (sc2_contains_i(name, "ObjectDoodad")) *type = SC2_OBJECT_DOODAD;
-    else if (sc2_contains_i(name, "ObjectCamera")) *type = SC2_OBJECT_CAMERA;
+    if (sc2_contains_i(name, "ObjectUnit") || sc2_streqi(name, "Unit")) *type = SC2_OBJECT_UNIT;
+    else if (sc2_contains_i(name, "ObjectDoodad") || sc2_streqi(name, "Doodad")) *type = SC2_OBJECT_DOODAD;
+    else if (sc2_contains_i(name, "ObjectPoint") || sc2_streqi(name, "Point")) *type = SC2_OBJECT_POINT;
+    else if (sc2_contains_i(name, "ObjectCamera") || sc2_streqi(name, "Camera")) *type = SC2_OBJECT_CAMERA;
     else return false;
     return true;
 }

--- a/games/starcraft-2/common/sc2_map.c
+++ b/games/starcraft-2/common/sc2_map.c
@@ -40,6 +40,9 @@ typedef struct {
 typedef struct {
     char id[64];
     char actor[64];
+    char footprint[64];
+    char mover[64];
+    DWORD flags;
     BOOL has_radius;
     FLOAT radius;
 } sc2CatalogUnit_t;
@@ -47,7 +50,10 @@ typedef struct {
 typedef struct {
     char name[64];
     char model[256];
+    char footprint[64];
+    char mover[64];
     FLOAT radius;
+    DWORD unit_flags;
 } sc2ResolvedObjectModel_t;
 
 typedef struct {
@@ -991,14 +997,37 @@ static void sc2_catalog_add_actor(sc2Catalog_t *catalog, LPCSTR id, LPCSTR model
     snprintf(actor->model, sizeof(actor->model), "%s", model_id);
 }
 
-static void sc2_catalog_add_unit(sc2Catalog_t *catalog, LPCSTR id, LPCSTR actor_id, FLOAT radius, BOOL has_radius) {
+static DWORD sc2_unit_flag(LPCSTR name) {
+    if (!name || !*name) return 0;
+    if (sc2_streqi(name, "Movable")) return SC2_UNIT_FLAG_MOVABLE;
+    if (sc2_streqi(name, "Worker")) return SC2_UNIT_FLAG_WORKER;
+    if (sc2_streqi(name, "Resource")) return SC2_UNIT_FLAG_RESOURCE;
+    if (sc2_streqi(name, "Structure")) return SC2_UNIT_FLAG_STRUCTURE;
+    return 0;
+}
+
+static void sc2_catalog_add_unit(sc2Catalog_t *catalog,
+                                 LPCSTR id,
+                                 LPCSTR actor_id,
+                                 LPCSTR footprint,
+                                 LPCSTR mover,
+                                 DWORD flags,
+                                 FLOAT radius,
+                                 BOOL has_radius) {
     sc2CatalogUnit_t *unit;
 
-    if (!catalog || !id || !*id || ((!actor_id || !*actor_id) && !has_radius)) return;
+    if (!catalog || !id || !*id ||
+        ((!actor_id || !*actor_id) && (!footprint || !*footprint) && (!mover || !*mover) && !flags && !has_radius))
+        return;
     FOR_LOOP(i, catalog->units_count) {
         if (!strcasecmp(catalog->units[i].id, id)) {
             if (actor_id && *actor_id)
                 snprintf(catalog->units[i].actor, sizeof(catalog->units[i].actor), "%s", actor_id);
+            if (footprint && *footprint)
+                snprintf(catalog->units[i].footprint, sizeof(catalog->units[i].footprint), "%s", footprint);
+            if (mover && *mover)
+                snprintf(catalog->units[i].mover, sizeof(catalog->units[i].mover), "%s", mover);
+            catalog->units[i].flags |= flags;
             if (has_radius) {
                 catalog->units[i].has_radius = true;
                 catalog->units[i].radius = radius;
@@ -1010,6 +1039,9 @@ static void sc2_catalog_add_unit(sc2Catalog_t *catalog, LPCSTR id, LPCSTR actor_
     unit = &catalog->units[catalog->units_count++];
     snprintf(unit->id, sizeof(unit->id), "%s", id);
     snprintf(unit->actor, sizeof(unit->actor), "%s", actor_id ? actor_id : "");
+    snprintf(unit->footprint, sizeof(unit->footprint), "%s", footprint ? footprint : "");
+    snprintf(unit->mover, sizeof(unit->mover), "%s", mover ? mover : "");
+    unit->flags = flags;
     unit->has_radius = has_radius;
     unit->radius = has_radius ? radius : 0.0f;
 }
@@ -1308,6 +1340,9 @@ static void sc2_parse_unit_catalog_doc(sc2Catalog_t *catalog, xmlDocPtr doc) {
     for (xmlNodePtr node = root ? root->children : NULL; node; node = node->next) {
         char id[64];
         char actor_id[64] = "";
+        char footprint[64] = "";
+        char mover[64] = "";
+        DWORD flags = 0;
         FLOAT radius = 0.0f;
         BOOL has_radius = false;
 
@@ -1321,13 +1356,26 @@ static void sc2_parse_unit_catalog_doc(sc2Catalog_t *catalog, xmlDocPtr doc) {
                 continue;
             if (sc2_streqi((char const *)child->name, "Actor")) {
                 sc2_xml_attr(child, "value", actor_id, sizeof(actor_id));
+            } else if (sc2_streqi((char const *)child->name, "Footprint")) {
+                sc2_xml_attr(child, "value", footprint, sizeof(footprint));
+            } else if (sc2_streqi((char const *)child->name, "Mover")) {
+                sc2_xml_attr(child, "value", mover, sizeof(mover));
+            } else if (sc2_contains_i((char const *)child->name, "Flag")) {
+                char index[64];
+                if ((sc2_xml_attr(child, "index", index, sizeof(index)) ||
+                     sc2_xml_attr(child, "Index", index, sizeof(index))) &&
+                    (sc2_xml_attr(child, "value", value, sizeof(value)) ||
+                     sc2_xml_attr(child, "Value", value, sizeof(value))) &&
+                    atoi(value)) {
+                    flags |= sc2_unit_flag(index);
+                }
             } else if (sc2_streqi((char const *)child->name, "Radius") &&
                        sc2_xml_attr(child, "value", value, sizeof(value)) &&
                        sscanf(value, "%f", &radius) == 1 && radius > 0.0f) {
                 has_radius = true;
             }
         }
-        sc2_catalog_add_unit(catalog, id, actor_id, radius, has_radius);
+        sc2_catalog_add_unit(catalog, id, actor_id, footprint, mover, flags, radius, has_radius);
     }
 }
 
@@ -1557,15 +1605,23 @@ static void sc2_resolve_object_models(sc2Catalog_t const *catalog) {
         FOR_LOOP(j, resolved_count) {
             if (!strcasecmp(resolved[j].name, object->name)) {
                 snprintf(object->model, sizeof(object->model), "%s", resolved[j].model);
+                snprintf(object->footprint, sizeof(object->footprint), "%s", resolved[j].footprint);
+                snprintf(object->mover, sizeof(object->mover), "%s", resolved[j].mover);
                 object->radius = resolved[j].radius;
+                object->unit_flags = resolved[j].unit_flags;
                 goto next_object;
             }
         }
         model_id = NULL;
         if (object->type == SC2_OBJECT_UNIT) {
             sc2CatalogUnit_t const *unit = sc2_catalog_unit(catalog, object->name);
-            if (unit && unit->has_radius) object->radius = unit->radius;
-            if (unit && unit->actor[0]) model_id = sc2_catalog_actor_model(catalog, unit->actor);
+            if (unit) {
+                if (unit->has_radius) object->radius = unit->radius;
+                if (unit->footprint[0]) snprintf(object->footprint, sizeof(object->footprint), "%s", unit->footprint);
+                if (unit->mover[0]) snprintf(object->mover, sizeof(object->mover), "%s", unit->mover);
+                object->unit_flags |= unit->flags;
+                if (unit->actor[0]) model_id = sc2_catalog_actor_model(catalog, unit->actor);
+            }
         }
         if (!model_id) model_id = sc2_catalog_actor_model(catalog, object->name);
         if (!model_id) model_id = object->name;
@@ -1578,7 +1634,10 @@ static void sc2_resolve_object_models(sc2Catalog_t const *catalog) {
         if (resolved_count < SC2_MAX_MAP_OBJECTS) {
             snprintf(resolved[resolved_count].name, sizeof(resolved[resolved_count].name), "%s", object->name);
             snprintf(resolved[resolved_count].model, sizeof(resolved[resolved_count].model), "%s", object->model);
+            snprintf(resolved[resolved_count].footprint, sizeof(resolved[resolved_count].footprint), "%s", object->footprint);
+            snprintf(resolved[resolved_count].mover, sizeof(resolved[resolved_count].mover), "%s", object->mover);
             resolved[resolved_count].radius = object->radius;
+            resolved[resolved_count].unit_flags = object->unit_flags;
             resolved_count++;
         }
 next_object:

--- a/games/starcraft-2/common/sc2_map.c
+++ b/games/starcraft-2/common/sc2_map.c
@@ -1689,6 +1689,22 @@ next_object:
     }
 }
 
+static DWORD sc2_count_unresolved_models(void) {
+    DWORD count = 0;
+
+    FOR_LOOP(i, sc2_map.num_objects) {
+        sc2MapObject_t const *object = &sc2_map.objects[i];
+
+        if ((object->type == SC2_OBJECT_UNIT ||
+             object->type == SC2_OBJECT_DOODAD ||
+             object->type == SC2_OBJECT_POINT) &&
+            object->name[0] && !object->model[0]) {
+            count++;
+        }
+    }
+    return count;
+}
+
 static void sc2_resolve_catalogs(sc2MapSource_t *source) {
     sc2Catalog_t *catalog = sc2_alloc(sizeof(*catalog));
 
@@ -1698,6 +1714,10 @@ static void sc2_resolve_catalogs(sc2MapSource_t *source) {
     sc2_resolve_terrain_textures(catalog);
     sc2_resolve_cliff_sets(catalog);
     sc2_resolve_object_models(catalog);
+    sc2_map.catalog.units = catalog->units_count;
+    sc2_map.catalog.actors = catalog->actors_count;
+    sc2_map.catalog.models = catalog->models_count;
+    sc2_map.catalog.unresolved_models = sc2_count_unresolved_models();
     sc2_free(catalog);
 }
 
@@ -1705,6 +1725,130 @@ static BOOL sc2_mapinfo_fourcc(sc2MapInfo_t const *mapInfo) {
     return mapInfo &&
         (mapInfo->fourcc == MAKEFOURCC('I','p','a','M') ||
          mapInfo->fourcc == MAKEFOURCC('M','a','p','I'));
+}
+
+static LPCSTR sc2_object_type_name(sc2ObjectType_t type) {
+    switch (type) {
+        case SC2_OBJECT_UNIT: return "unit";
+        case SC2_OBJECT_DOODAD: return "doodad";
+        case SC2_OBJECT_POINT: return "point";
+        case SC2_OBJECT_CAMERA: return "camera";
+    }
+    return "unknown";
+}
+
+static void sc2_dump_cell_flags(FILE *out, sc2MapCellFlags_t const *layer) {
+    DWORD counts[4] = { 0 };
+
+    if (!out || !layer) return;
+    FOR_LOOP(i, layer->width * layer->height) {
+        if (layer->data[i] < SC2_ARRAY_LEN(counts))
+            counts[layer->data[i]]++;
+    }
+    fprintf(out,
+            "t3CellFlags: version=%u size=%ux%u counts[00]=%u counts[01]=%u counts[02]=%u counts[03]=%u\n",
+            (unsigned)layer->version,
+            (unsigned)layer->width,
+            (unsigned)layer->height,
+            (unsigned)counts[0],
+            (unsigned)counts[1],
+            (unsigned)counts[2],
+            (unsigned)counts[3]);
+}
+
+static void sc2_dump_height_map(FILE *out, sc2MapHeightMap_t const *layer) {
+    FLOAT min_height = 0.0f;
+    FLOAT max_height = 0.0f;
+    BOOL have_height = false;
+
+    if (!out || !layer) return;
+    FOR_LOOP(y, layer->height) {
+        FOR_LOOP(x, layer->width) {
+            FLOAT height = sc2_map_height_at_grid(&sc2_map, x, y);
+
+            if (!have_height || height < min_height) min_height = height;
+            if (!have_height || height > max_height) max_height = height;
+            have_height = true;
+        }
+    }
+    fprintf(out,
+            "t3HeightMap: version=%u size=%ux%u min=%.3f max=%.3f\n",
+            (unsigned)layer->version,
+            (unsigned)layer->width,
+            (unsigned)layer->height,
+            min_height,
+            max_height);
+}
+
+void SC2_MapDump(FILE *out, LPCSTR filename) {
+    DWORD object_counts[4] = { 0 };
+
+    if (!out) out = stdout;
+    FOR_LOOP(i, sc2_map.num_objects) {
+        if ((DWORD)sc2_map.objects[i].type < SC2_ARRAY_LEN(object_counts))
+            object_counts[sc2_map.objects[i].type]++;
+    }
+    fprintf(out, "sc2map: file=%s\n", filename && *filename ? filename : "(current)");
+    fprintf(out,
+            "MapInfo: version=%u size=%ux%u name=\"%s\"\n",
+            (unsigned)sc2_map.MapInfo.version,
+            (unsigned)sc2_map.MapInfo.width,
+            (unsigned)sc2_map.MapInfo.height,
+            sc2_map.map_name);
+    if (sc2_map.t3CellFlags)
+        sc2_dump_cell_flags(out, sc2_map.t3CellFlags);
+    if (sc2_map.t3HeightMap)
+        sc2_dump_height_map(out, sc2_map.t3HeightMap);
+    if (sc2_map.t3SyncHeightMap) {
+        fprintf(out,
+                "t3SyncHeightMap: version=%u size=%ux%u\n",
+                (unsigned)sc2_map.t3SyncHeightMap->version,
+                (unsigned)sc2_map.t3SyncHeightMap->width,
+                (unsigned)sc2_map.t3SyncHeightMap->height);
+    }
+    if (sc2_map.t3SyncCliffLevel) {
+        fprintf(out,
+                "t3SyncCliffLevel: version=%u size=%ux%u\n",
+                (unsigned)sc2_map.t3SyncCliffLevel->version,
+                (unsigned)sc2_map.t3SyncCliffLevel->width,
+                (unsigned)sc2_map.t3SyncCliffLevel->height);
+    }
+    if (sc2_map.t3TextureMasks) {
+        fprintf(out,
+                "t3TextureMasks: version=%u size=%ux%u bytes=%u\n",
+                (unsigned)sc2_map.t3TextureMasks->version,
+                (unsigned)sc2_map.t3TextureMasks->width,
+                (unsigned)sc2_map.t3TextureMasks->height,
+                (unsigned)sc2_map.t3TextureMasksSize);
+    }
+    fprintf(out,
+            "Objects: units=%u doodads=%u points=%u cameras=%u total=%u\n",
+            (unsigned)object_counts[SC2_OBJECT_UNIT],
+            (unsigned)object_counts[SC2_OBJECT_DOODAD],
+            (unsigned)object_counts[SC2_OBJECT_POINT],
+            (unsigned)object_counts[SC2_OBJECT_CAMERA],
+            (unsigned)sc2_map.num_objects);
+    fprintf(out,
+            "Catalog: units=%u actors=%u models=%u unresolvedModels=%u\n",
+            (unsigned)sc2_map.catalog.units,
+            (unsigned)sc2_map.catalog.actors,
+            (unsigned)sc2_map.catalog.models,
+            (unsigned)sc2_map.catalog.unresolved_models);
+    FOR_LOOP(i, sc2_map.num_objects) {
+        sc2MapObject_t const *object = &sc2_map.objects[i];
+
+        fprintf(out,
+                "Object[%u]: type=%s id=%u name=%s model=%s pos=%.3f,%.3f,%.3f radius=%.3f\n",
+                (unsigned)i,
+                sc2_object_type_name(object->type),
+                (unsigned)object->id,
+                object->name,
+                object->model,
+                object->position.x,
+                object->position.y,
+                object->position.z,
+                object->radius);
+    }
 }
 
 static LPBYTE sc2_read_binary_layer(sc2MapSource_t *source,

--- a/games/starcraft-2/common/sc2_map.h
+++ b/games/starcraft-2/common/sc2_map.h
@@ -12,6 +12,10 @@
 #define SC2_OBJECT_HEIGHT_ABSOLUTE 0x00000001
 #define SC2_OBJECT_HEIGHT_OFFSET   0x00000002
 #define SC2_OBJECT_FORCE_PLACEMENT 0x00000004
+#define SC2_UNIT_FLAG_MOVABLE      0x00000001
+#define SC2_UNIT_FLAG_WORKER       0x00000002
+#define SC2_UNIT_FLAG_RESOURCE     0x00000004
+#define SC2_UNIT_FLAG_STRUCTURE    0x00000008
 #define SC2_LIGHT_KEY              0
 #define SC2_LIGHT_FILL             1
 #define SC2_LIGHT_BACK             2
@@ -39,6 +43,8 @@ typedef struct {
     DWORD           id;
     char            name[64];
     char            model[256];
+    char            footprint[64];
+    char            mover[64];
     VECTOR3         position;
     FLOAT           angle;
     FLOAT           scale;
@@ -46,6 +52,7 @@ typedef struct {
     DWORD           variation;
     DWORD           player;
     DWORD           flags;
+    DWORD           unit_flags;
     sc2MapCamera_t  camera;
 } sc2MapObject_t;
 

--- a/games/starcraft-2/common/sc2_map.h
+++ b/games/starcraft-2/common/sc2_map.h
@@ -2,6 +2,7 @@
 #define SC2_MAP_H
 
 #include "common/common.h"
+#include <stdio.h>
 
 #define SC2_MAX_MAP_OBJECTS 1024
 #define SC2_CELL_SIZE          1.0f
@@ -187,6 +188,13 @@ typedef struct {
 } sc2MapInfo_t;
 
 typedef struct {
+    DWORD          units;
+    DWORD          actors;
+    DWORD          models;
+    DWORD          unresolved_models;
+} sc2CatalogStats_t;
+
+typedef struct {
     char           map_name[128];
     VECTOR2        origin;
     FLOAT          cell_size;
@@ -201,6 +209,7 @@ typedef struct {
     sc2MapHeightMap_t *t3HeightMap;
     sc2MapSyncHeightMap_t *t3SyncHeightMap;
     sc2MapLighting_t lighting;
+    sc2CatalogStats_t catalog;
 } sc2Map_t;
 
 typedef struct {
@@ -319,5 +328,6 @@ VECTOR2       SC2_MapNormalizedPosition(FLOAT x, FLOAT y);
 VECTOR2       SC2_MapDenormalizedPosition(FLOAT x, FLOAT y);
 DWORD         SC2_MapObjectClassId(sc2MapObject_t const *object);
 BOOL          SC2_MapDefaultCamera(sc2MapCamera_t *camera);
+void          SC2_MapDump(FILE *out, LPCSTR filename);
 
 #endif

--- a/games/starcraft-2/common/sc2_map.h
+++ b/games/starcraft-2/common/sc2_map.h
@@ -24,6 +24,7 @@
 typedef enum {
     SC2_OBJECT_UNIT,
     SC2_OBJECT_DOODAD,
+    SC2_OBJECT_POINT,
     SC2_OBJECT_CAMERA,
 } sc2ObjectType_t;
 
@@ -45,14 +46,26 @@ typedef struct {
     char            model[256];
     char            footprint[64];
     char            mover[64];
+    char            type_name[64];
+    char            anim_props[64];
+    char            sound[256];
+    char            attach_id[64];
+    char            object_type[64];
     VECTOR3         position;
     FLOAT           angle;
     FLOAT           scale;
     FLOAT           radius;
+    FLOAT           pathing_soft_radius;
+    FLOAT           pathing_hard_radius;
     DWORD           variation;
     DWORD           player;
+    DWORD           section;
+    DWORD           resources;
+    DWORD           object_id;
     DWORD           flags;
     DWORD           unit_flags;
+    COLOR32         color;
+    COLOR32         tint_color;
     sc2MapCamera_t  camera;
 } sc2MapObject_t;
 

--- a/games/starcraft-2/game/g_sc2.c
+++ b/games/starcraft-2/game/g_sc2.c
@@ -2,6 +2,7 @@
 #include "games/starcraft-2/common/sc2_map.h"
 #include <stdio.h>
 #include <string.h>
+#include <strings.h>
 
 #define SC2_MOVE_SPEED  6.0f
 #define SC2_MOVE_CLOSE  4.0f
@@ -28,6 +29,13 @@ static sc2MoveState_t sc2_move[SC2_MAX_EDICTS];
 static BOOL SC2_ObjectIsMobile(sc2MapObject_t const *object) {
     if (!object || object->type != SC2_OBJECT_UNIT) {
         return false;
+    }
+    if (object->mover[0]) {
+        return strcasecmp(object->mover, "None") &&
+               strcasecmp(object->mover, "Stationary");
+    }
+    if (object->unit_flags & SC2_UNIT_FLAG_MOVABLE) {
+        return true;
     }
     if (strstr(object->name, "CommandCenter") || strstr(object->model, "CommandCenter")) {
         return false;

--- a/games/starcraft-2/tests/resources-src/Maps/Test/Tiny.SC2Map/Base.SC2Data/GameData/UnitData.xml
+++ b/games/starcraft-2/tests/resources-src/Maps/Test/Tiny.SC2Map/Base.SC2Data/GameData/UnitData.xml
@@ -2,6 +2,9 @@
 <Catalog>
     <CUnit id="Marine">
         <Actor value="MarineActor"/>
+        <Footprint value="FootprintMarine"/>
+        <Mover value="Ground"/>
+        <Flag index="Movable" value="1"/>
         <Radius value="0.75"/>
     </CUnit>
 </Catalog>

--- a/games/starcraft-2/tests/resources-src/Maps/Test/Tiny.SC2Map/Objects
+++ b/games/starcraft-2/tests/resources-src/Maps/Test/Tiny.SC2Map/Objects
@@ -7,11 +7,12 @@
         <CameraValue Index="Pitch" Value="56"/>
         <CameraValue Index="Yaw" Value="179.9584"/>
     </ObjectCamera>
-    <ObjectUnit Id="1" UnitType="Marine" Position="3.5,3.5,0.25" Rotation="0.75" Scale="1,1,1" Player="2"/>
+    <ObjectUnit Id="1" UnitType="Marine" Position="3.5,3.5,0.25" Rotation="0.75" Scale="1,1,1" Player="2" Section="7" Resources="50"/>
     <ObjectUnit Id="2" UnitType="SCV" Position="5.0,5.0,0" Rotation="1.25" Scale="1,1,1" Player="2"/>
-    <ObjectDoodad Id="3" Type="BillboardTall" Position="7.0,2.0,8.0" Rotation="2.5" Scale="1,1,1">
+    <ObjectDoodad Id="3" Type="BillboardTall" Position="7.0,2.0,8.0" Rotation="2.5" Scale="1,1,1" TintColor="10,20,30,128">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="4" Type="MineralField" Model="Assets\Doodads\Terran\MineralField\MineralField.m3" x="4" y="3" z="0" Angle="0" Scale="1" Player="15" />
+    <ObjectPoint id="5" type="StartLocation" name="StartPoint01" position="2.0,6.0,0.0" rotation="0.5" scale="1,1,1" section="9" color="200,180,160,255" model="Assets\Editor\StartLocation\StartLocation.m3" animProps="Stand" sound="Assets\Sounds\StartLocation.ogg" attachID="StartAttach" objectID="1" objectType="Unit" PathingSoftRadius="1.5" PathingHardRadius="0.75"/>
 </PlacedObjects>

--- a/games/starcraft-2/tests/resources-src/Mods/Core.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/games/starcraft-2/tests/resources-src/Mods/Core.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -2,6 +2,8 @@
 <Catalog>
     <CUnit id="Marine">
         <Actor value="MarineActor"/>
+        <Footprint value="FootprintCoreMarine"/>
+        <Mover value="None"/>
         <Radius value="0.25"/>
     </CUnit>
 </Catalog>

--- a/games/starcraft-2/tests/test_sc2_map.c
+++ b/games/starcraft-2/tests/test_sc2_map.c
@@ -296,6 +296,9 @@ static void test_sc2_fixture_short_name_resolves(void) {
 
 static void assert_tiny_map_catalog_overrides(sc2Map_t *map) {
     ASSERT_STR_EQ(map->objects[1].model, "Assets\\Units\\Terran\\MarineCatalogModel\\MarineCatalogModel.m3");
+    ASSERT_STR_EQ(map->objects[1].footprint, "FootprintMarine");
+    ASSERT_STR_EQ(map->objects[1].mover, "Ground");
+    ASSERT_EQ_INT(map->objects[1].unit_flags, SC2_UNIT_FLAG_MOVABLE);
     ASSERT_EQ_FLOAT(map->objects[1].radius, 0.75f, 0.001f);
     ASSERT_STR_EQ(map->t3Terrain.terrain_textures[0].diffuse, "Assets\\Textures\\Terrain\\FixtureGrass_Diffuse.dds");
     ASSERT_STR_EQ(map->t3Terrain.terrain_textures[0].normal, "Assets\\Textures\\Terrain\\FixtureGrass_Diffuse_normal.dds");

--- a/games/starcraft-2/tests/test_sc2_map.c
+++ b/games/starcraft-2/tests/test_sc2_map.c
@@ -318,7 +318,7 @@ static void test_sc2_map_loads_xml_objects_and_terrain(void) {
     ASSERT_EQ_INT(map->MapInfo.width, 8);
     ASSERT_EQ_INT(map->MapInfo.height, 6);
     ASSERT_STR_EQ((char const *)map->MapInfo.data, "SC2 Tiny Fixture");
-    ASSERT_EQ_INT(map->num_objects, 5);
+    ASSERT_EQ_INT(map->num_objects, 6);
     assert_tiny_map_catalog_overrides(map);
 
     ASSERT_STR_EQ(map->objects[0].name, "StartGame02");
@@ -343,6 +343,8 @@ static void test_sc2_map_loads_xml_objects_and_terrain(void) {
     ASSERT_EQ_FLOAT(map->objects[1].position.z, 0.25f, 0.001f);
     ASSERT_EQ_FLOAT(map->objects[1].angle, 0.75f, 0.001f);
     ASSERT_EQ_INT(map->objects[1].player, 2);
+    ASSERT_EQ_INT(map->objects[1].section, 7);
+    ASSERT_EQ_INT(map->objects[1].resources, 50);
 
     ASSERT_STR_EQ(map->objects[3].name, "BillboardTall");
     ASSERT_EQ_INT(map->objects[3].id, 3);
@@ -350,6 +352,10 @@ static void test_sc2_map_loads_xml_objects_and_terrain(void) {
     ASSERT_STR_EQ(map->objects[3].model, "Assets\\Doodads\\BillboardTall\\BillboardTall.m3");
     ASSERT_EQ_FLOAT(map->objects[3].position.z, 8.0f, 0.001f);
     ASSERT_EQ_INT(map->objects[3].flags, SC2_OBJECT_HEIGHT_ABSOLUTE | SC2_OBJECT_FORCE_PLACEMENT);
+    ASSERT_EQ_INT(map->objects[3].tint_color.r, 10);
+    ASSERT_EQ_INT(map->objects[3].tint_color.g, 20);
+    ASSERT_EQ_INT(map->objects[3].tint_color.b, 30);
+    ASSERT_EQ_INT(map->objects[3].tint_color.a, 128);
 
     ASSERT_STR_EQ(map->objects[4].name, "MineralField");
     ASSERT_EQ_INT(map->objects[4].type, SC2_OBJECT_DOODAD);
@@ -357,6 +363,26 @@ static void test_sc2_map_loads_xml_objects_and_terrain(void) {
     ASSERT_EQ_FLOAT(map->objects[4].position.x, 4.0f, 0.001f);
     ASSERT_EQ_FLOAT(map->objects[4].position.y, 3.0f, 0.001f);
     ASSERT_EQ_FLOAT(map->objects[4].position.z, 0.0f, 0.001f);
+
+    ASSERT_STR_EQ(map->objects[5].name, "StartPoint01");
+    ASSERT_EQ_INT(map->objects[5].id, 5);
+    ASSERT_EQ_INT(map->objects[5].type, SC2_OBJECT_POINT);
+    ASSERT_STR_EQ(map->objects[5].type_name, "StartLocation");
+    ASSERT_STR_EQ(map->objects[5].model, "Assets\\Editor\\StartLocation\\StartLocation.m3");
+    ASSERT_STR_EQ(map->objects[5].anim_props, "Stand");
+    ASSERT_STR_EQ(map->objects[5].sound, "Assets\\Sounds\\StartLocation.ogg");
+    ASSERT_STR_EQ(map->objects[5].attach_id, "StartAttach");
+    ASSERT_EQ_INT(map->objects[5].object_id, 1);
+    ASSERT_STR_EQ(map->objects[5].object_type, "Unit");
+    ASSERT_EQ_FLOAT(map->objects[5].pathing_soft_radius, 1.5f, 0.001f);
+    ASSERT_EQ_FLOAT(map->objects[5].pathing_hard_radius, 0.75f, 0.001f);
+    ASSERT_EQ_FLOAT(map->objects[5].position.x, 2.0f, 0.001f);
+    ASSERT_EQ_FLOAT(map->objects[5].angle, 0.5f, 0.001f);
+    ASSERT_EQ_INT(map->objects[5].section, 9);
+    ASSERT_EQ_INT(map->objects[5].color.r, 200);
+    ASSERT_EQ_INT(map->objects[5].color.g, 180);
+    ASSERT_EQ_INT(map->objects[5].color.b, 160);
+    ASSERT_EQ_INT(map->objects[5].color.a, 255);
 
     ASSERT_STR_EQ(map->t3Terrain.tile_set, "Fixture");
     ASSERT_EQ_FLOAT(map->t3Terrain.height_quantize_bias, 0.0f, 0.001f);
@@ -482,7 +508,7 @@ static void test_sc2_map_loads_directory_fixture_without_generated_layers(void) 
     ASSERT_EQ_INT(map->MapInfo.fourcc, MAKEFOURCC('M','a','p','I'));
     ASSERT_EQ_INT(map->MapInfo.width, 8);
     ASSERT_EQ_INT(map->MapInfo.height, 6);
-    ASSERT_EQ_INT(map->num_objects, 5);
+    ASSERT_EQ_INT(map->num_objects, 6);
     assert_tiny_map_catalog_overrides(map);
 
     ASSERT_STR_EQ(map->objects[0].name, "StartGame02");
@@ -522,7 +548,7 @@ static void assert_tiny_map_loaded_without_binary_terrain_layers(sc2Map_t *map) 
     ASSERT_STR_EQ(map->map_name, "SC2 Tiny Fixture");
     ASSERT_EQ_INT(map->MapInfo.width, 8);
     ASSERT_EQ_INT(map->MapInfo.height, 6);
-    ASSERT_EQ_INT(map->num_objects, 5);
+    ASSERT_EQ_INT(map->num_objects, 6);
     ASSERT_STR_EQ(map->objects[1].name, "Marine");
     ASSERT_STR_EQ(map->t3Terrain.tile_set, "Fixture");
 

--- a/tools/sc2map.c
+++ b/tools/sc2map.c
@@ -1,0 +1,196 @@
+#include "common/mpq.h"
+#include "games/starcraft-2/common/sc2_map.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+#define SC2MAP_MAX_ARCHIVES 16
+
+static HANDLE sc2map_archives[SC2MAP_MAX_ARCHIVES];
+static LPCSTR sc2map_data_dir = "";
+
+static void usage(void) {
+    fprintf(stderr,
+            "Usage:\n"
+            "  sc2map [-data <StarCraft2-data-dir>] [-mpq <archive>]... <map.SC2Map|map-dir>\n"
+            "  sc2map [-data <StarCraft2-data-dir>] [-mpq <archive>]... -map <map.SC2Map|map-dir>\n"
+            "\n"
+            "Examples:\n"
+            "  sc2map -mpq build/tests/test-sc2.SC2Maps Maps/Test/Tiny.SC2Map\n"
+            "  sc2map -data data/StarCraft2 Maps/Campaign/TRaynor01.SC2Map\n"
+            "  sc2map games/starcraft-2/tests/resources-src/Maps/Test/Tiny.SC2Map\n");
+}
+
+static HANDLE sc2map_mem_alloc(long size) {
+    void *mem = calloc(1, (size_t)(size ? size : 1));
+
+    if (!mem) {
+        fprintf(stderr, "sc2map: out of memory allocating %ld bytes\n", size);
+        exit(1);
+    }
+    return mem;
+}
+
+static void sc2map_mem_free(HANDLE mem) {
+    free(mem);
+}
+
+static HANDLE sc2map_read_disk_file(LPCSTR filename, LPDWORD size) {
+    FILE *file;
+    long file_size;
+    LPBYTE data;
+    struct stat st;
+
+    if (size) *size = 0;
+    if (!filename || !*filename)
+        return NULL;
+    if (stat(filename, &st) != 0 || !S_ISREG(st.st_mode))
+        return NULL;
+    file = fopen(filename, "rb");
+    if (!file)
+        return NULL;
+    if (fseek(file, 0, SEEK_END) != 0 || (file_size = ftell(file)) < 0 || fseek(file, 0, SEEK_SET) != 0) {
+        fclose(file);
+        return NULL;
+    }
+    data = sc2map_mem_alloc(file_size ? file_size : 1);
+    if (file_size > 0 && fread(data, 1, file_size, file) != (size_t)file_size) {
+        fclose(file);
+        sc2map_mem_free(data);
+        return NULL;
+    }
+    fclose(file);
+    if (size) *size = (DWORD)file_size;
+    return data;
+}
+
+static HANDLE sc2map_read_archive_file(LPCSTR filename, LPDWORD size) {
+    char path[MAX_PATHLEN];
+
+    if (size) *size = 0;
+    if (!filename || !*filename)
+        return NULL;
+    FOR_LOOP(i, SC2MAP_MAX_ARCHIVES) {
+        HANDLE file;
+        DWORD file_size;
+        LPBYTE data;
+
+        if (!sc2map_archives[i])
+            continue;
+        snprintf(path, sizeof(path), "%s", filename);
+        for (char *p = path; *p; p++) if (*p == '/') *p = '\\';
+        if (!SFileOpenFileEx(sc2map_archives[i], path, SFILE_OPEN_FROM_MPQ, &file)) {
+            snprintf(path, sizeof(path), "%s", filename);
+            for (char *p = path; *p; p++) if (*p == '\\') *p = '/';
+            if (!SFileOpenFileEx(sc2map_archives[i], path, SFILE_OPEN_FROM_MPQ, &file))
+                continue;
+        }
+        file_size = SFileGetFileSize(file, NULL);
+        data = sc2map_mem_alloc(file_size + 1);
+        if (!SFileReadFile(file, data, file_size, NULL, NULL)) {
+            SFileCloseFile(file);
+            sc2map_mem_free(data);
+            return NULL;
+        }
+        SFileCloseFile(file);
+        data[file_size] = 0;
+        if (size) *size = file_size;
+        return data;
+    }
+    return NULL;
+}
+
+static HANDLE sc2map_read_file(LPCSTR filename, LPDWORD size) {
+    HANDLE data = sc2map_read_archive_file(filename, size);
+
+    if (data)
+        return data;
+    return sc2map_read_disk_file(filename, size);
+}
+
+static BOOL sc2map_add_archive(LPCSTR filename) {
+    FOR_LOOP(i, SC2MAP_MAX_ARCHIVES) {
+        if (sc2map_archives[i])
+            continue;
+        if (!SFileOpenArchive(filename, 0, 0, &sc2map_archives[i])) {
+            fprintf(stderr, "sc2map: cannot open archive %s\n", filename);
+            return false;
+        }
+        return true;
+    }
+    fprintf(stderr, "sc2map: too many archives\n");
+    return false;
+}
+
+static LPCSTR sc2map_cvar_string(LPCSTR name, LPCSTR fallback) {
+    if (name && !strcmp(name, "data"))
+        return sc2map_data_dir && *sc2map_data_dir ? sc2map_data_dir : fallback;
+    return fallback;
+}
+
+static void sc2map_close_archives(void) {
+    FOR_LOOP(i, SC2MAP_MAX_ARCHIVES) {
+        if (sc2map_archives[i]) {
+            SFileCloseArchive(sc2map_archives[i]);
+            sc2map_archives[i] = NULL;
+        }
+    }
+}
+
+int main(int argc, char **argv) {
+    LPCSTR map = NULL;
+
+    for (int i = 1; i < argc; i++) {
+        if (!strcmp(argv[i], "-mpq")) {
+            if (++i >= argc || !sc2map_add_archive(argv[i])) {
+                usage();
+                sc2map_close_archives();
+                return 1;
+            }
+        } else if (!strcmp(argv[i], "-data")) {
+            if (++i >= argc) {
+                usage();
+                sc2map_close_archives();
+                return 1;
+            }
+            sc2map_data_dir = argv[i];
+        } else if (!strcmp(argv[i], "-map")) {
+            if (++i >= argc) {
+                usage();
+                sc2map_close_archives();
+                return 1;
+            }
+            map = argv[i];
+        } else if (argv[i][0] != '-' && !map) {
+            map = argv[i];
+        } else {
+            usage();
+            sc2map_close_archives();
+            return 1;
+        }
+    }
+    if (!map) {
+        usage();
+        sc2map_close_archives();
+        return 1;
+    }
+
+    SC2_MapSetHost(&(sc2MapHost_t){
+        .read_file = sc2map_read_file,
+        .free_file = sc2map_mem_free,
+        .mem_alloc = sc2map_mem_alloc,
+        .mem_free = sc2map_mem_free,
+        .cvar_string = sc2map_cvar_string,
+    });
+    if (!SC2_MapLoad(map)) {
+        fprintf(stderr, "sc2map: failed to load %s\n", map);
+        sc2map_close_archives();
+        return 1;
+    }
+    SC2_MapDump(stdout, map);
+    SC2_MapShutdown();
+    sc2map_close_archives();
+    return 0;
+}


### PR DESCRIPTION
This expands the SC2 map-to-spawn pipeline in three reviewable commits.

Commit 1: parse more `CUnit` physical/spawn fields
- stores `Footprint`, `Mover`, and known `Flag` bits on parsed `CUnit` catalog entries
- propagates those fields onto resolved SC2 map objects
- uses mover/`Movable` catalog data for SC2 spawn mobility before falling back to the previous string heuristic
- keeps radius behavior from the prior UnitData PR intact

Commit 2: parse more documented `Objects` data
- adds `ObjectPoint` support
- accepts both `ObjectUnit`/`ObjectDoodad`/`ObjectPoint`/`ObjectCamera` and bare `Unit`/`Doodad`/`Point`/`Camera` object names
- parses additional object attributes including section/resources/colors and point metadata such as type, anim props, sound, attach id, object id, object type, and pathing radii
- extends the Tiny fixture so packed and directory-backed tests cover the new fields

Commit 3: add SC2 map diagnostics
- adds `SC2_MapDump()` for MapInfo, terrain layer sizes, object counts, catalog counts, unresolved model count, and per-object summaries
- adds a small `sc2map` CLI using the normal `SC2_MapLoad()` host path
- wires a `test-sc2-assets` smoke check through `sc2map` so fixture diagnostics stay exercised

Validated with:
- `git diff --check`
- `make test-sc2`
- `make game-sc2`
- `make test`
