### PR TITLE
Resolve SC2 footprints into spawn collision

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -310,7 +310,10 @@ test-sc2-assets: sc2fixturegen mpqtool sc2map | $(TESTS_DIR)
 	@$(BIN_DIR)/mpqtool$(EXE_EXT) -mpq $(SC2_TEST_MPQ) ls Maps/Test/Tiny.SC2Map | grep -q "MapInfo" && echo "  ls map OK"
 	@$(BIN_DIR)/mpqtool$(EXE_EXT) -mpq $(SC2_TEST_MPQ) cat Maps/Test/Tiny.SC2Map/Objects | grep -q "UnitType=\"Marine\"" && echo "  cat objects OK"
 	@$(BIN_DIR)/mpqtool$(EXE_EXT) -mpq $(SC2_TEST_MPQ) info Maps/Test/Tiny.SC2Map/t3CellFlags | grep -q "size=80" && echo "  binary cell flags OK"
-	@$(BIN_DIR)/sc2map$(EXE_EXT) -mpq $(SC2_TEST_MPQ) Maps/Test/Tiny.SC2Map | grep -q "Objects: units=2 doodads=2 points=1 cameras=1 total=6" && echo "  sc2map diag OK"
+	@diag="$$( $(BIN_DIR)/sc2map$(EXE_EXT) -mpq $(SC2_TEST_MPQ) Maps/Test/Tiny.SC2Map )"; \
+	echo "$$diag" | grep -q "Objects: units=3 doodads=2 points=1 cameras=1 total=7" && \
+	echo "$$diag" | grep -q "footprint=Footprint2x2 size=2.000x2.000 fpRadius=1.414" && \
+	echo "  sc2map diag OK"
 
 test-wow-assets: blpgen mpqtool | $(TESTS_DIR)
 	@echo "[test-wow-assets] generating WoW UI fixtures"

--- a/games/starcraft-2/common/sc2_map.c
+++ b/games/starcraft-2/common/sc2_map.c
@@ -2018,21 +2018,28 @@ void SC2_MapDump(FILE *out, LPCSTR filename) {
             (unsigned)object_counts[SC2_OBJECT_CAMERA],
             (unsigned)sc2_map.num_objects);
     fprintf(out,
-            "Catalog: units=%u actors=%u models=%u unresolvedModels=%u\n",
+            "Catalog: units=%u actors=%u models=%u footprints=%u unresolvedModels=%u\n",
             (unsigned)sc2_map.catalog.units,
             (unsigned)sc2_map.catalog.actors,
             (unsigned)sc2_map.catalog.models,
+            (unsigned)sc2_map.catalog.footprints,
             (unsigned)sc2_map.catalog.unresolved_models);
     FOR_LOOP(i, sc2_map.num_objects) {
         sc2MapObject_t const *object = &sc2_map.objects[i];
 
         fprintf(out,
-                "Object[%u]: type=%s id=%u name=%s model=%s pos=%.3f,%.3f,%.3f radius=%.3f\n",
+                "Object[%u]: type=%s id=%u name=%s model=%s footprint=%s size=%.3fx%.3f fpRadius=%.3f mover=%s unitFlags=0x%08x pos=%.3f,%.3f,%.3f radius=%.3f\n",
                 (unsigned)i,
                 sc2_object_type_name(object->type),
                 (unsigned)object->id,
                 object->name,
                 object->model,
+                object->footprint,
+                object->footprint_width,
+                object->footprint_height,
+                object->footprint_radius,
+                object->mover,
+                (unsigned)object->unit_flags,
                 object->position.x,
                 object->position.y,
                 object->position.z,

--- a/games/starcraft-2/common/sc2_map.c
+++ b/games/starcraft-2/common/sc2_map.c
@@ -8,6 +8,7 @@
 #define SC2_MAX_CATALOG_MODELS       8192
 #define SC2_MAX_CATALOG_ACTORS       8192
 #define SC2_MAX_CATALOG_UNITS        8192
+#define SC2_MAX_CATALOG_FOOTPRINTS   1024
 #define SC2_MAX_CATALOG_TERRAIN_TEX  512
 #define SC2_MAX_CATALOG_CLIFFS       256
 #define SC2_MAX_CATALOG_PARENT_DEPTH 8
@@ -35,6 +36,7 @@ typedef struct {
 typedef struct {
     char id[64];
     char model[64];
+    char footprint[64];
 } sc2CatalogActor_t;
 
 typedef struct {
@@ -53,8 +55,18 @@ typedef struct {
     char footprint[64];
     char mover[64];
     FLOAT radius;
+    FLOAT footprint_width;
+    FLOAT footprint_height;
+    FLOAT footprint_radius;
     DWORD unit_flags;
 } sc2ResolvedObjectModel_t;
+
+typedef struct {
+    char id[64];
+    FLOAT width;
+    FLOAT height;
+    FLOAT radius;
+} sc2CatalogFootprint_t;
 
 typedef struct {
     char id[64];
@@ -71,11 +83,13 @@ typedef struct {
     DWORD models_count;
     DWORD actors_count;
     DWORD units_count;
+    DWORD footprints_count;
     DWORD terrain_tex_count;
     DWORD cliffs_count;
     sc2CatalogModel_t models[SC2_MAX_CATALOG_MODELS];
     sc2CatalogActor_t actors[SC2_MAX_CATALOG_ACTORS];
     sc2CatalogUnit_t units[SC2_MAX_CATALOG_UNITS];
+    sc2CatalogFootprint_t footprints[SC2_MAX_CATALOG_FOOTPRINTS];
     sc2CatalogTerrainTex_t terrain_tex[SC2_MAX_CATALOG_TERRAIN_TEX];
     sc2CatalogCliff_t cliffs[SC2_MAX_CATALOG_CLIFFS];
 } sc2Catalog_t;
@@ -474,6 +488,30 @@ static BOOL sc2_parse_rgba_color(LPCSTR text, LPCOLOR32 color) {
         return true;
     }
     return false;
+}
+
+static FLOAT sc2_abs_float(FLOAT value) {
+    return value < 0.0f ? -value : value;
+}
+
+static BOOL sc2_parse_float_pair(LPCSTR text, FLOAT *x, FLOAT *y) {
+    FLOAT a, b;
+
+    if (!text || !x || !y) return false;
+    if (sscanf(text, "%f,%f", &a, &b) != 2) return false;
+    *x = a;
+    *y = b;
+    return true;
+}
+
+static BOOL sc2_parse_footprint_area(LPCSTR text, FLOAT *width, FLOAT *height) {
+    FLOAT x0, y0, x1, y1;
+
+    if (!text || !width || !height) return false;
+    if (sscanf(text, "%f,%f,%f,%f", &x0, &y0, &x1, &y1) != 4) return false;
+    *width = sc2_abs_float(x1 - x0);
+    *height = sc2_abs_float(y1 - y0);
+    return *width > 0.0f && *height > 0.0f;
 }
 
 static sc2XmlField_t const sc2_terrain_data_fields[] = {
@@ -1025,20 +1063,24 @@ static void sc2_catalog_add_model(sc2Catalog_t *catalog, LPCSTR id, LPCSTR paren
     sc2_normalize_slashes(model->path);
 }
 
-static void sc2_catalog_add_actor(sc2Catalog_t *catalog, LPCSTR id, LPCSTR model_id) {
+static void sc2_catalog_add_actor(sc2Catalog_t *catalog, LPCSTR id, LPCSTR model_id, LPCSTR footprint) {
     sc2CatalogActor_t *actor;
 
-    if (!catalog || !id || !*id || !model_id || !*model_id) return;
+    if (!catalog || !id || !*id || ((!model_id || !*model_id) && (!footprint || !*footprint))) return;
     FOR_LOOP(i, catalog->actors_count) {
         if (!strcasecmp(catalog->actors[i].id, id)) {
-            snprintf(catalog->actors[i].model, sizeof(catalog->actors[i].model), "%s", model_id);
+            if (model_id && *model_id)
+                snprintf(catalog->actors[i].model, sizeof(catalog->actors[i].model), "%s", model_id);
+            if (footprint && *footprint)
+                snprintf(catalog->actors[i].footprint, sizeof(catalog->actors[i].footprint), "%s", footprint);
             return;
         }
     }
     if (catalog->actors_count >= SC2_MAX_CATALOG_ACTORS) return;
     actor = &catalog->actors[catalog->actors_count++];
     snprintf(actor->id, sizeof(actor->id), "%s", id);
-    snprintf(actor->model, sizeof(actor->model), "%s", model_id);
+    snprintf(actor->model, sizeof(actor->model), "%s", model_id ? model_id : "");
+    snprintf(actor->footprint, sizeof(actor->footprint), "%s", footprint ? footprint : "");
 }
 
 static DWORD sc2_unit_flag(LPCSTR name) {
@@ -1126,6 +1168,37 @@ static void sc2_catalog_add_cliff(sc2Catalog_t *catalog, LPCSTR id, LPCSTR mesh)
     cliff = &catalog->cliffs[catalog->cliffs_count++];
     snprintf(cliff->id, sizeof(cliff->id), "%s", id);
     snprintf(cliff->mesh, sizeof(cliff->mesh), "%s", mesh);
+}
+
+static void sc2_catalog_add_footprint(sc2Catalog_t *catalog,
+                                      LPCSTR id,
+                                      FLOAT width,
+                                      FLOAT height,
+                                      FLOAT radius) {
+    sc2CatalogFootprint_t *footprint;
+
+    if (!catalog || !id || !*id || (width <= 0.0f && height <= 0.0f && radius <= 0.0f))
+        return;
+    if (radius <= 0.0f)
+        radius = MAX(width, height) * 0.5f;
+    if (width <= 0.0f)
+        width = radius * 2.0f;
+    if (height <= 0.0f)
+        height = radius * 2.0f;
+    FOR_LOOP(i, catalog->footprints_count) {
+        if (!strcasecmp(catalog->footprints[i].id, id)) {
+            catalog->footprints[i].width = width;
+            catalog->footprints[i].height = height;
+            catalog->footprints[i].radius = radius;
+            return;
+        }
+    }
+    if (catalog->footprints_count >= SC2_MAX_CATALOG_FOOTPRINTS) return;
+    footprint = &catalog->footprints[catalog->footprints_count++];
+    snprintf(footprint->id, sizeof(footprint->id), "%s", id);
+    footprint->width = width;
+    footprint->height = height;
+    footprint->radius = radius;
 }
 
 static sc2CatalogModel_t const *sc2_catalog_model(sc2Catalog_t const *catalog, LPCSTR id) {
@@ -1234,18 +1307,36 @@ static LPCSTR sc2_cliff_mesh_fallback(LPCSTR name) {
     return NULL;
 }
 
-static LPCSTR sc2_catalog_actor_model(sc2Catalog_t const *catalog, LPCSTR id) {
+static sc2CatalogActor_t const *sc2_catalog_actor(sc2Catalog_t const *catalog, LPCSTR id) {
     if (!catalog || !id || !*id) return NULL;
     FOR_LOOP(i, catalog->actors_count) {
-        if (!strcasecmp(catalog->actors[i].id, id)) return catalog->actors[i].model;
+        if (!strcasecmp(catalog->actors[i].id, id)) return &catalog->actors[i];
     }
     return NULL;
+}
+
+static LPCSTR sc2_catalog_actor_model(sc2Catalog_t const *catalog, LPCSTR id) {
+    sc2CatalogActor_t const *actor = sc2_catalog_actor(catalog, id);
+    return actor && actor->model[0] ? actor->model : NULL;
+}
+
+static LPCSTR sc2_catalog_actor_footprint(sc2Catalog_t const *catalog, LPCSTR id) {
+    sc2CatalogActor_t const *actor = sc2_catalog_actor(catalog, id);
+    return actor && actor->footprint[0] ? actor->footprint : NULL;
 }
 
 static sc2CatalogUnit_t const *sc2_catalog_unit(sc2Catalog_t const *catalog, LPCSTR id) {
     if (!catalog || !id || !*id) return NULL;
     FOR_LOOP(i, catalog->units_count) {
         if (!strcasecmp(catalog->units[i].id, id)) return &catalog->units[i];
+    }
+    return NULL;
+}
+
+static sc2CatalogFootprint_t const *sc2_catalog_footprint(sc2Catalog_t const *catalog, LPCSTR id) {
+    if (!catalog || !id || !*id) return NULL;
+    FOR_LOOP(i, catalog->footprints_count) {
+        if (!strcasecmp(catalog->footprints[i].id, id)) return &catalog->footprints[i];
     }
     return NULL;
 }
@@ -1342,6 +1433,7 @@ static void sc2_parse_actor_catalog_doc(sc2Catalog_t *catalog, xmlDocPtr doc) {
         char id[64];
         char unit_name[64] = "";
         char model_id[64] = "";
+        char footprint[64] = "";
         BOOL actor_node;
 
         if (node->type != XML_ELEMENT_NODE) continue;
@@ -1353,12 +1445,13 @@ static void sc2_parse_actor_catalog_doc(sc2Catalog_t *catalog, xmlDocPtr doc) {
             if (child->type != XML_ELEMENT_NODE) continue;
             if (sc2_streqi((char const *)child->name, "Model")) {
                 sc2_xml_attr(child, "value", model_id, sizeof(model_id));
-                break;
+            } else if (sc2_streqi((char const *)child->name, "Footprint")) {
+                sc2_xml_attr(child, "value", footprint, sizeof(footprint));
             }
         }
         if (!model_id[0]) snprintf(model_id, sizeof(model_id), "%s", id);
-        sc2_catalog_add_actor(catalog, id, model_id);
-        if (unit_name[0]) sc2_catalog_add_actor(catalog, unit_name, model_id);
+        sc2_catalog_add_actor(catalog, id, model_id, footprint);
+        if (unit_name[0]) sc2_catalog_add_actor(catalog, unit_name, model_id, footprint);
     }
 }
 
@@ -1434,6 +1527,70 @@ static void sc2_parse_unit_catalog_source(sc2Catalog_t *catalog, sc2MapSource_t 
     xmlDocPtr doc = sc2_read_map_catalog_xml(source, "GameData\\UnitData.xml");
 
     sc2_parse_unit_catalog_doc(catalog, doc);
+    xmlFreeDoc(doc);
+}
+
+static void sc2_parse_footprint_catalog_doc(sc2Catalog_t *catalog, xmlDocPtr doc) {
+    xmlNodePtr root;
+
+    if (!doc) return;
+    root = xmlDocGetRootElement(doc);
+    for (xmlNodePtr node = root ? root->children : NULL; node; node = node->next) {
+        char id[64];
+        FLOAT width = 0.0f;
+        FLOAT height = 0.0f;
+        FLOAT radius = 0.0f;
+
+        if (node->type != XML_ELEMENT_NODE || !sc2_contains_i((char const *)node->name, "CFootprint"))
+            continue;
+        if (!sc2_xml_attr(node, "id", id, sizeof(id))) continue;
+        for (xmlNodePtr child = node->children; child; child = child->next) {
+            char value[64];
+            FLOAT child_width;
+            FLOAT child_height;
+
+            if (child->type != XML_ELEMENT_NODE) continue;
+            if (sc2_streqi((char const *)child->name, "Layers") &&
+                sc2_xml_attr(child, "Area", value, sizeof(value)) &&
+                sc2_parse_footprint_area(value, &child_width, &child_height) &&
+                child_width * child_height >= width * height) {
+                width = child_width;
+                height = child_height;
+            } else if (sc2_streqi((char const *)child->name, "Size") &&
+                       sc2_xml_attr(child, "value", value, sizeof(value)) &&
+                       sc2_parse_float_pair(value, &child_width, &child_height) &&
+                       child_width > 0.0f && child_height > 0.0f) {
+                width = child_width;
+                height = child_height;
+            } else if (sc2_streqi((char const *)child->name, "Shape")) {
+                if (sc2_xml_attr(child, "Radius", value, sizeof(value)) ||
+                    sc2_xml_attr(child, "radius", value, sizeof(value))) {
+                    sscanf(value, "%f", &radius);
+                }
+                for (xmlNodePtr shape = child->children; shape; shape = shape->next) {
+                    if (shape->type == XML_ELEMENT_NODE &&
+                        sc2_streqi((char const *)shape->name, "Radius") &&
+                        sc2_xml_attr(shape, "value", value, sizeof(value))) {
+                        sscanf(value, "%f", &radius);
+                    }
+                }
+            }
+        }
+        sc2_catalog_add_footprint(catalog, id, width, height, radius);
+    }
+}
+
+static void sc2_parse_footprint_catalog_file(sc2Catalog_t *catalog, LPCSTR root_name) {
+    xmlDocPtr doc = sc2_read_catalog_xml(root_name, "GameData\\FootprintData.xml");
+
+    sc2_parse_footprint_catalog_doc(catalog, doc);
+    xmlFreeDoc(doc);
+}
+
+static void sc2_parse_footprint_catalog_source(sc2Catalog_t *catalog, sc2MapSource_t *source) {
+    xmlDocPtr doc = sc2_read_map_catalog_xml(source, "GameData\\FootprintData.xml");
+
+    sc2_parse_footprint_catalog_doc(catalog, doc);
     xmlFreeDoc(doc);
 }
 
@@ -1517,17 +1674,20 @@ static void sc2_parse_catalogs(sc2Catalog_t *catalog, sc2MapSource_t *source) {
         sc2_parse_unit_catalog_file(catalog, sc2_catalog_roots[i]);
         sc2_parse_model_catalog_file(catalog, sc2_catalog_roots[i]);
         sc2_parse_actor_catalog_file(catalog, sc2_catalog_roots[i]);
+        sc2_parse_footprint_catalog_file(catalog, sc2_catalog_roots[i]);
         sc2_parse_terrain_tex_catalog_file(catalog, sc2_catalog_roots[i]);
         sc2_parse_cliff_catalog_file(catalog, sc2_catalog_roots[i]);
     }
     sc2_parse_unit_catalog_file(catalog, "");
     sc2_parse_model_catalog_file(catalog, "");
     sc2_parse_actor_catalog_file(catalog, "");
+    sc2_parse_footprint_catalog_file(catalog, "");
     sc2_parse_terrain_tex_catalog_file(catalog, "");
     sc2_parse_cliff_catalog_file(catalog, "");
     sc2_parse_unit_catalog_source(catalog, source);
     sc2_parse_model_catalog_source(catalog, source);
     sc2_parse_actor_catalog_source(catalog, source);
+    sc2_parse_footprint_catalog_source(catalog, source);
     sc2_parse_terrain_tex_catalog_source(catalog, source);
     sc2_parse_cliff_catalog_source(catalog, source);
 }
@@ -1635,6 +1795,17 @@ static void sc2_resolve_object_model_candidates(sc2MapObject_t *object) {
     }
 }
 
+static void sc2_resolve_object_footprint(sc2Catalog_t const *catalog, sc2MapObject_t *object) {
+    sc2CatalogFootprint_t const *footprint;
+
+    if (!catalog || !object || !object->footprint[0]) return;
+    footprint = sc2_catalog_footprint(catalog, object->footprint);
+    if (!footprint) return;
+    object->footprint_width = footprint->width;
+    object->footprint_height = footprint->height;
+    object->footprint_radius = footprint->radius;
+}
+
 static void sc2_resolve_object_models(sc2Catalog_t const *catalog) {
     sc2ResolvedObjectModel_t resolved[SC2_MAX_MAP_OBJECTS];
     DWORD resolved_count = 0;
@@ -1652,6 +1823,9 @@ static void sc2_resolve_object_models(sc2Catalog_t const *catalog) {
                 snprintf(object->footprint, sizeof(object->footprint), "%s", resolved[j].footprint);
                 snprintf(object->mover, sizeof(object->mover), "%s", resolved[j].mover);
                 object->radius = resolved[j].radius;
+                object->footprint_width = resolved[j].footprint_width;
+                object->footprint_height = resolved[j].footprint_height;
+                object->footprint_radius = resolved[j].footprint_radius;
                 object->unit_flags = resolved[j].unit_flags;
                 goto next_object;
             }
@@ -1664,9 +1838,20 @@ static void sc2_resolve_object_models(sc2Catalog_t const *catalog) {
                 if (unit->footprint[0]) snprintf(object->footprint, sizeof(object->footprint), "%s", unit->footprint);
                 if (unit->mover[0]) snprintf(object->mover, sizeof(object->mover), "%s", unit->mover);
                 object->unit_flags |= unit->flags;
-                if (unit->actor[0]) model_id = sc2_catalog_actor_model(catalog, unit->actor);
+                if (unit->actor[0]) {
+                    LPCSTR actor_footprint = sc2_catalog_actor_footprint(catalog, unit->actor);
+                    if (!object->footprint[0] && actor_footprint)
+                        snprintf(object->footprint, sizeof(object->footprint), "%s", actor_footprint);
+                    model_id = sc2_catalog_actor_model(catalog, unit->actor);
+                }
             }
         }
+        if (!object->footprint[0]) {
+            LPCSTR actor_footprint = sc2_catalog_actor_footprint(catalog, object->name);
+            if (actor_footprint)
+                snprintf(object->footprint, sizeof(object->footprint), "%s", actor_footprint);
+        }
+        sc2_resolve_object_footprint(catalog, object);
         if (!model_id) model_id = sc2_catalog_actor_model(catalog, object->name);
         if (!model_id) model_id = object->name;
         path[0] = '\0';
@@ -1681,6 +1866,9 @@ static void sc2_resolve_object_models(sc2Catalog_t const *catalog) {
             snprintf(resolved[resolved_count].footprint, sizeof(resolved[resolved_count].footprint), "%s", object->footprint);
             snprintf(resolved[resolved_count].mover, sizeof(resolved[resolved_count].mover), "%s", object->mover);
             resolved[resolved_count].radius = object->radius;
+            resolved[resolved_count].footprint_width = object->footprint_width;
+            resolved[resolved_count].footprint_height = object->footprint_height;
+            resolved[resolved_count].footprint_radius = object->footprint_radius;
             resolved[resolved_count].unit_flags = object->unit_flags;
             resolved_count++;
         }
@@ -1717,6 +1905,7 @@ static void sc2_resolve_catalogs(sc2MapSource_t *source) {
     sc2_map.catalog.units = catalog->units_count;
     sc2_map.catalog.actors = catalog->actors_count;
     sc2_map.catalog.models = catalog->models_count;
+    sc2_map.catalog.footprints = catalog->footprints_count;
     sc2_map.catalog.unresolved_models = sc2_count_unresolved_models();
     sc2_free(catalog);
 }

--- a/games/starcraft-2/common/sc2_map.h
+++ b/games/starcraft-2/common/sc2_map.h
@@ -56,6 +56,9 @@ typedef struct {
     FLOAT           angle;
     FLOAT           scale;
     FLOAT           radius;
+    FLOAT           footprint_width;
+    FLOAT           footprint_height;
+    FLOAT           footprint_radius;
     FLOAT           pathing_soft_radius;
     FLOAT           pathing_hard_radius;
     DWORD           variation;
@@ -191,6 +194,7 @@ typedef struct {
     DWORD          units;
     DWORD          actors;
     DWORD          models;
+    DWORD          footprints;
     DWORD          unresolved_models;
 } sc2CatalogStats_t;
 

--- a/games/starcraft-2/game/g_sc2.c
+++ b/games/starcraft-2/game/g_sc2.c
@@ -63,6 +63,16 @@ static FLOAT SC2_ObjectRadius(sc2MapObject_t const *object) {
     return object->type == SC2_OBJECT_UNIT ? 1.0f : 0.5f;
 }
 
+static FLOAT SC2_ObjectCollisionRadius(sc2MapObject_t const *object, FLOAT radius) {
+    if (!object) {
+        return radius;
+    }
+    if (!SC2_ObjectIsMobile(object) && object->footprint_radius > 0.0f) {
+        return object->footprint_radius;
+    }
+    return radius;
+}
+
 static void SC2_LinkAtGround(LPEDICT ent) {
     ent->s.origin.x = ent->s.origin2.x;
     ent->s.origin.y = ent->s.origin2.y;
@@ -343,7 +353,7 @@ static void SC2_SpawnEntities(void) {
         ent->s.radius = SC2_ObjectRadius(object);
         ent->s.player = object->player;
         ent->s.model = G_RegisterModel(object->model);
-        ent->collision = ent->s.radius;
+        ent->collision = SC2_ObjectCollisionRadius(object, ent->s.radius);
         if (SC2_ObjectIsMobile(object)) {
             ent->svflags |= SVF_MONSTER;
         }

--- a/games/starcraft-2/tests/resources-src/Maps/Test/Tiny.SC2Map/Base.SC2Data/GameData/ActorData.xml
+++ b/games/starcraft-2/tests/resources-src/Maps/Test/Tiny.SC2Map/Base.SC2Data/GameData/ActorData.xml
@@ -14,6 +14,9 @@
         <Model value="MarineCatalogModel"/>
         <DeathArray index="Normal" ModelLink="MarineDeath"/>
     </CActorUnit>
+    <CActorUnit id="SupplyDepotActor">
+        <Model value="SupplyDepotCatalogModel"/>
+    </CActorUnit>
     <CActorUnit id="Civilian" unitName="Civilian">
         <PortraitModel value="CivilianPortrait"/>
     </CActorUnit>

--- a/games/starcraft-2/tests/resources-src/Maps/Test/Tiny.SC2Map/Base.SC2Data/GameData/FootprintData.xml
+++ b/games/starcraft-2/tests/resources-src/Maps/Test/Tiny.SC2Map/Base.SC2Data/GameData/FootprintData.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="us-ascii"?>
+<Catalog>
+    <CFootprint id="FootprintMarine">
+        <Layers index="Check" Area="0,0,1,1">
+            <Rows value="x"/>
+        </Layers>
+    </CFootprint>
+    <CFootprint id="FootprintDoodad1x1">
+        <Layers index="Check" Area="0,0,1,1">
+            <Rows value="x"/>
+        </Layers>
+        <Shape>
+            <Radius value="0.7072"/>
+        </Shape>
+    </CFootprint>
+    <CFootprint id="Footprint2x2">
+        <Layers index="Check" Area="-1,-1,1,1">
+            <Rows value="xx"/>
+            <Rows value="xx"/>
+        </Layers>
+        <Shape>
+            <Radius value="1.4143"/>
+        </Shape>
+    </CFootprint>
+</Catalog>

--- a/games/starcraft-2/tests/resources-src/Maps/Test/Tiny.SC2Map/Base.SC2Data/GameData/ModelData.xml
+++ b/games/starcraft-2/tests/resources-src/Maps/Test/Tiny.SC2Map/Base.SC2Data/GameData/ModelData.xml
@@ -9,6 +9,9 @@
     <CModel id="MarineCatalogModel" parent="Unit" Race="Terran">
         <Occlusion value="Show"/>
     </CModel>
+    <CModel id="SupplyDepotCatalogModel" Race="Terran">
+        <Model value="Assets\Buildings\Terran\SupplyDepotCatalogModel\SupplyDepotCatalogModel.m3"/>
+    </CModel>
     <CModel id="BillboardTall" parent="Doodad">
         <VariationCount value="4"/>
     </CModel>

--- a/games/starcraft-2/tests/resources-src/Maps/Test/Tiny.SC2Map/Base.SC2Data/GameData/UnitData.xml
+++ b/games/starcraft-2/tests/resources-src/Maps/Test/Tiny.SC2Map/Base.SC2Data/GameData/UnitData.xml
@@ -7,4 +7,10 @@
         <Flag index="Movable" value="1"/>
         <Radius value="0.75"/>
     </CUnit>
+    <CUnit id="SupplyDepot">
+        <Actor value="SupplyDepotActor"/>
+        <Footprint value="Footprint2x2"/>
+        <Mover value="None"/>
+        <Flag index="Structure" value="1"/>
+    </CUnit>
 </Catalog>

--- a/games/starcraft-2/tests/resources-src/Maps/Test/Tiny.SC2Map/Objects
+++ b/games/starcraft-2/tests/resources-src/Maps/Test/Tiny.SC2Map/Objects
@@ -15,4 +15,5 @@
     </ObjectDoodad>
     <ObjectDoodad Id="4" Type="MineralField" Model="Assets\Doodads\Terran\MineralField\MineralField.m3" x="4" y="3" z="0" Angle="0" Scale="1" Player="15" />
     <ObjectPoint id="5" type="StartLocation" name="StartPoint01" position="2.0,6.0,0.0" rotation="0.5" scale="1,1,1" section="9" color="200,180,160,255" model="Assets\Editor\StartLocation\StartLocation.m3" animProps="Stand" sound="Assets\Sounds\StartLocation.ogg" attachID="StartAttach" objectID="1" objectType="Unit" PathingSoftRadius="1.5" PathingHardRadius="0.75"/>
+    <ObjectUnit Id="6" UnitType="SupplyDepot" Position="6.0,1.0,0.0" Rotation="0" Scale="1,1,1" Player="2"/>
 </PlacedObjects>

--- a/games/starcraft-2/tests/resources-src/Mods/Core.SC2Mod/Base.SC2Data/GameData/ActorData.xml
+++ b/games/starcraft-2/tests/resources-src/Mods/Core.SC2Mod/Base.SC2Data/GameData/ActorData.xml
@@ -14,6 +14,9 @@
         <Model value="MarineCoreModel"/>
         <DeathArray index="Normal" ModelLink="MarineDeath"/>
     </CActorUnit>
+    <CActorUnit id="SupplyDepotActor">
+        <Model value="SupplyDepotCoreModel"/>
+    </CActorUnit>
     <CActorUnit id="Civilian" unitName="Civilian">
         <PortraitModel value="CivilianPortrait"/>
     </CActorUnit>

--- a/games/starcraft-2/tests/resources-src/Mods/Core.SC2Mod/Base.SC2Data/GameData/FootprintData.xml
+++ b/games/starcraft-2/tests/resources-src/Mods/Core.SC2Mod/Base.SC2Data/GameData/FootprintData.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="us-ascii"?>
+<Catalog>
+    <CFootprint id="FootprintMarine">
+        <Layers index="Check" Area="0,0,4,4">
+            <Rows value="xxxx"/>
+            <Rows value="xxxx"/>
+            <Rows value="xxxx"/>
+            <Rows value="xxxx"/>
+        </Layers>
+        <Shape>
+            <Radius value="4.0"/>
+        </Shape>
+    </CFootprint>
+    <CFootprint id="FootprintDoodad1x1">
+        <Layers index="Check" Area="0,0,3,1">
+            <Rows value="xxx"/>
+        </Layers>
+        <Shape>
+            <Radius value="3.0"/>
+        </Shape>
+    </CFootprint>
+    <CFootprint id="Footprint2x2">
+        <Layers index="Check" Area="0,0,5,5">
+            <Rows value="xxxxx"/>
+            <Rows value="xxxxx"/>
+            <Rows value="xxxxx"/>
+            <Rows value="xxxxx"/>
+            <Rows value="xxxxx"/>
+        </Layers>
+        <Shape>
+            <Radius value="5.0"/>
+        </Shape>
+    </CFootprint>
+</Catalog>

--- a/games/starcraft-2/tests/resources-src/Mods/Core.SC2Mod/Base.SC2Data/GameData/ModelData.xml
+++ b/games/starcraft-2/tests/resources-src/Mods/Core.SC2Mod/Base.SC2Data/GameData/ModelData.xml
@@ -12,6 +12,9 @@
     <CModel id="MarineCoreModel" parent="Unit" Race="Protoss">
         <Occlusion value="Hide"/>
     </CModel>
+    <CModel id="SupplyDepotCoreModel" Race="Protoss">
+        <Model value="Assets\Buildings\Protoss\SupplyDepotCoreModel\SupplyDepotCoreModel.m3"/>
+    </CModel>
     <CModel id="BillboardTall" parent="Doodad">
         <VariationCount value="4"/>
     </CModel>

--- a/games/starcraft-2/tests/resources-src/Mods/Core.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/games/starcraft-2/tests/resources-src/Mods/Core.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -6,4 +6,9 @@
         <Mover value="None"/>
         <Radius value="0.25"/>
     </CUnit>
+    <CUnit id="SupplyDepot">
+        <Actor value="SupplyDepotActor"/>
+        <Footprint value="Footprint2x2"/>
+        <Mover value="Ground"/>
+    </CUnit>
 </Catalog>

--- a/games/starcraft-2/tests/test_sc2_map.c
+++ b/games/starcraft-2/tests/test_sc2_map.c
@@ -295,11 +295,26 @@ static void test_sc2_fixture_short_name_resolves(void) {
 }
 
 static void assert_tiny_map_catalog_overrides(sc2Map_t *map) {
+    ASSERT_EQ_INT(map->catalog.footprints, 3);
     ASSERT_STR_EQ(map->objects[1].model, "Assets\\Units\\Terran\\MarineCatalogModel\\MarineCatalogModel.m3");
     ASSERT_STR_EQ(map->objects[1].footprint, "FootprintMarine");
     ASSERT_STR_EQ(map->objects[1].mover, "Ground");
     ASSERT_EQ_INT(map->objects[1].unit_flags, SC2_UNIT_FLAG_MOVABLE);
     ASSERT_EQ_FLOAT(map->objects[1].radius, 0.75f, 0.001f);
+    ASSERT_EQ_FLOAT(map->objects[1].footprint_width, 1.0f, 0.001f);
+    ASSERT_EQ_FLOAT(map->objects[1].footprint_height, 1.0f, 0.001f);
+    ASSERT_EQ_FLOAT(map->objects[1].footprint_radius, 0.5f, 0.001f);
+    ASSERT_STR_EQ(map->objects[3].footprint, "FootprintDoodad1x1");
+    ASSERT_EQ_FLOAT(map->objects[3].footprint_width, 1.0f, 0.001f);
+    ASSERT_EQ_FLOAT(map->objects[3].footprint_height, 1.0f, 0.001f);
+    ASSERT_EQ_FLOAT(map->objects[3].footprint_radius, 0.7072f, 0.001f);
+    ASSERT_STR_EQ(map->objects[6].model, "Assets\\Buildings\\Terran\\SupplyDepotCatalogModel\\SupplyDepotCatalogModel.m3");
+    ASSERT_STR_EQ(map->objects[6].footprint, "Footprint2x2");
+    ASSERT_STR_EQ(map->objects[6].mover, "None");
+    ASSERT_EQ_INT(map->objects[6].unit_flags, SC2_UNIT_FLAG_STRUCTURE);
+    ASSERT_EQ_FLOAT(map->objects[6].footprint_width, 2.0f, 0.001f);
+    ASSERT_EQ_FLOAT(map->objects[6].footprint_height, 2.0f, 0.001f);
+    ASSERT_EQ_FLOAT(map->objects[6].footprint_radius, 1.4143f, 0.001f);
     ASSERT_STR_EQ(map->t3Terrain.terrain_textures[0].diffuse, "Assets\\Textures\\Terrain\\FixtureGrass_Diffuse.dds");
     ASSERT_STR_EQ(map->t3Terrain.terrain_textures[0].normal, "Assets\\Textures\\Terrain\\FixtureGrass_Diffuse_normal.dds");
     ASSERT_STR_EQ(map->t3Terrain.cliff_sets[0].mesh, "CliffNatural0");
@@ -318,7 +333,7 @@ static void test_sc2_map_loads_xml_objects_and_terrain(void) {
     ASSERT_EQ_INT(map->MapInfo.width, 8);
     ASSERT_EQ_INT(map->MapInfo.height, 6);
     ASSERT_STR_EQ((char const *)map->MapInfo.data, "SC2 Tiny Fixture");
-    ASSERT_EQ_INT(map->num_objects, 6);
+    ASSERT_EQ_INT(map->num_objects, 7);
     assert_tiny_map_catalog_overrides(map);
 
     ASSERT_STR_EQ(map->objects[0].name, "StartGame02");
@@ -383,6 +398,13 @@ static void test_sc2_map_loads_xml_objects_and_terrain(void) {
     ASSERT_EQ_INT(map->objects[5].color.g, 180);
     ASSERT_EQ_INT(map->objects[5].color.b, 160);
     ASSERT_EQ_INT(map->objects[5].color.a, 255);
+
+    ASSERT_STR_EQ(map->objects[6].name, "SupplyDepot");
+    ASSERT_EQ_INT(map->objects[6].id, 6);
+    ASSERT_EQ_INT(map->objects[6].type, SC2_OBJECT_UNIT);
+    ASSERT_EQ_FLOAT(map->objects[6].position.x, 6.0f, 0.001f);
+    ASSERT_EQ_FLOAT(map->objects[6].position.y, 1.0f, 0.001f);
+    ASSERT_EQ_INT(map->objects[6].player, 2);
 
     ASSERT_STR_EQ(map->t3Terrain.tile_set, "Fixture");
     ASSERT_EQ_FLOAT(map->t3Terrain.height_quantize_bias, 0.0f, 0.001f);
@@ -508,7 +530,7 @@ static void test_sc2_map_loads_directory_fixture_without_generated_layers(void) 
     ASSERT_EQ_INT(map->MapInfo.fourcc, MAKEFOURCC('M','a','p','I'));
     ASSERT_EQ_INT(map->MapInfo.width, 8);
     ASSERT_EQ_INT(map->MapInfo.height, 6);
-    ASSERT_EQ_INT(map->num_objects, 6);
+    ASSERT_EQ_INT(map->num_objects, 7);
     assert_tiny_map_catalog_overrides(map);
 
     ASSERT_STR_EQ(map->objects[0].name, "StartGame02");
@@ -521,6 +543,9 @@ static void test_sc2_map_loads_directory_fixture_without_generated_layers(void) 
     ASSERT_STR_EQ(map->objects[4].name, "MineralField");
     ASSERT_EQ_INT(map->objects[4].type, SC2_OBJECT_DOODAD);
     ASSERT_STR_EQ(map->objects[4].model, "Assets\\Doodads\\Terran\\MineralField\\MineralField.m3");
+    ASSERT_STR_EQ(map->objects[6].name, "SupplyDepot");
+    ASSERT_STR_EQ(map->objects[6].mover, "None");
+    ASSERT_EQ_FLOAT(map->objects[6].footprint_radius, 1.4143f, 0.001f);
 
     ASSERT_STR_EQ(map->t3Terrain.tile_set, "Fixture");
     ASSERT_EQ_FLOAT(map->t3Terrain.height_quantize_scale, 1.0f, 0.001f);
@@ -548,7 +573,7 @@ static void assert_tiny_map_loaded_without_binary_terrain_layers(sc2Map_t *map) 
     ASSERT_STR_EQ(map->map_name, "SC2 Tiny Fixture");
     ASSERT_EQ_INT(map->MapInfo.width, 8);
     ASSERT_EQ_INT(map->MapInfo.height, 6);
-    ASSERT_EQ_INT(map->num_objects, 6);
+    ASSERT_EQ_INT(map->num_objects, 7);
     ASSERT_STR_EQ(map->objects[1].name, "Marine");
     ASSERT_STR_EQ(map->t3Terrain.tile_set, "Fixture");
 


### PR DESCRIPTION
This extends the SC2 map/catalog pipeline so footprint catalog data reaches resolved map objects and static spawn collision.

This PR:
- parses real CFootprint catalog data from FootprintData.xml using Layers Area and Shape/Radius
- preserves actor footprint references so doodads can resolve footprints too
- resolves footprint dimensions/radius onto sc2MapObject_t and catalog diagnostics
- uses resolved footprint radius for non-mobile/static SC2 spawn collision
- adds Tiny/Core fixture coverage proving map-local footprint overrides dependency data
- extends sc2map output with footprint id, dimensions, radius, mover, and unit flags

Not included:
- arbitrary GameData.xml include-manifest loading
- expanding the hardcoded dependency root universe
- full footprint layer masks, placement rules, or t3SyncPathingInfo

Validated with:
- git diff --check
- make sc2map
- make test-sc2
- make game-sc2
- make test