### PR TITLE
Load SC2 catalog include manifests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -312,6 +312,7 @@ test-sc2-assets: sc2fixturegen mpqtool sc2map | $(TESTS_DIR)
 	@$(BIN_DIR)/mpqtool$(EXE_EXT) -mpq $(SC2_TEST_MPQ) info Maps/Test/Tiny.SC2Map/t3CellFlags | grep -q "size=80" && echo "  binary cell flags OK"
 	@diag="$$( $(BIN_DIR)/sc2map$(EXE_EXT) -mpq $(SC2_TEST_MPQ) Maps/Test/Tiny.SC2Map )"; \
 	echo "$$diag" | grep -q "Objects: units=3 doodads=2 points=1 cameras=1 total=7" && \
+	echo "$$diag" | grep -q "MarineManifestModel" && \
 	echo "$$diag" | grep -q "footprint=Footprint2x2 size=2.000x2.000 fpRadius=1.414" && \
 	echo "  sc2map diag OK"
 

--- a/games/starcraft-2/common/sc2_map.c
+++ b/games/starcraft-2/common/sc2_map.c
@@ -12,6 +12,7 @@
 #define SC2_MAX_CATALOG_TERRAIN_TEX  512
 #define SC2_MAX_CATALOG_CLIFFS       256
 #define SC2_MAX_CATALOG_PARENT_DEPTH 8
+#define SC2_MAX_CATALOG_INCLUDE_DEPTH 8
 #define SC2_ARRAY_LEN(x)             ((DWORD)(sizeof(x) / sizeof((x)[0])))
 #define SC2_XML_STRING_FIELD(name, field) { name, offsetof(sc2MapObject_t, field), SC2_XML_FIELD_STRING, sizeof(((sc2MapObject_t *)0)->field) }
 #define SC2_XML_FIELD(name, field, type)  { name, offsetof(sc2MapObject_t, field), type, 0 }
@@ -130,6 +131,16 @@ static LPCSTR const sc2_catalog_roots[] = {
     "Mods/LibertyMulti.SC2Mod/Base.SC2Data",
     "Campaigns/LibertyStory.SC2Campaign/Base.SC2Data",
     "Campaigns/Liberty.SC2Campaign/Base.SC2Data",
+    NULL,
+};
+
+static LPCSTR const sc2_catalog_known_files[] = {
+    "GameData\\UnitData.xml",
+    "GameData\\ModelData.xml",
+    "GameData\\ActorData.xml",
+    "GameData\\FootprintData.xml",
+    "GameData\\TerrainTexData.xml",
+    "GameData\\CliffData.xml",
     NULL,
 };
 
@@ -380,6 +391,39 @@ static xmlDocPtr sc2_read_map_catalog_xml(sc2MapSource_t *source, LPCSTR filenam
     snprintf(path, sizeof(path), "Base.SC2Data\\%s", filename);
     for (char *p = path; *p; p++) if (*p == '/') *p = '\\';
     return sc2_read_xml(source, path);
+}
+
+static BOOL sc2_catalog_include_path(LPCSTR in, LPSTR out, DWORD out_size) {
+    char path[MAX_PATHLEN];
+    DWORD len;
+
+    if (!in || !*in || !out || !out_size)
+        return false;
+    if (strlen(in) >= sizeof(path) || strlen(in) >= out_size)
+        return false;
+    if (in[0] == '/' || in[0] == '\\' || strchr(in, ':'))
+        return false;
+    snprintf(path, sizeof(path), "%s", in);
+    for (char *p = path; *p; p++) if (*p == '\\') *p = '/';
+    len = (DWORD)strlen(path);
+    if (!len)
+        return false;
+    for (DWORD i = 0; i <= len; ) {
+        DWORD start = i;
+
+        while (i < len && path[i] != '/') i++;
+        if (i == start || (i == start + 1 && path[start] == '.') ||
+            (i == start + 2 && path[start] == '.' && path[start + 1] == '.'))
+            return false;
+        i++;
+    }
+    snprintf(out, out_size, "%s", path);
+    for (char *p = out; *p; p++) if (*p == '/') *p = '\\';
+    return true;
+}
+
+static xmlDocPtr sc2_read_layer_catalog_xml(sc2MapSource_t *source, LPCSTR root_name, LPCSTR filename) {
+    return source ? sc2_read_map_catalog_xml(source, filename) : sc2_read_catalog_xml(root_name, filename);
 }
 
 static BOOL sc2_xml_attr(xmlNodePtr node, LPCSTR attr_name, LPSTR buffer, DWORD size) {
@@ -1669,27 +1713,83 @@ static void sc2_parse_cliff_catalog_source(sc2Catalog_t *catalog, sc2MapSource_t
     xmlFreeDoc(doc);
 }
 
-static void sc2_parse_catalogs(sc2Catalog_t *catalog, sc2MapSource_t *source) {
-    for (DWORD i = 0; sc2_catalog_roots[i]; i++) {
-        sc2_parse_unit_catalog_file(catalog, sc2_catalog_roots[i]);
-        sc2_parse_model_catalog_file(catalog, sc2_catalog_roots[i]);
-        sc2_parse_actor_catalog_file(catalog, sc2_catalog_roots[i]);
-        sc2_parse_footprint_catalog_file(catalog, sc2_catalog_roots[i]);
-        sc2_parse_terrain_tex_catalog_file(catalog, sc2_catalog_roots[i]);
-        sc2_parse_cliff_catalog_file(catalog, sc2_catalog_roots[i]);
+static void sc2_parse_catalog_doc(sc2Catalog_t *catalog, xmlDocPtr doc) {
+    sc2_parse_unit_catalog_doc(catalog, doc);
+    sc2_parse_model_catalog_doc(catalog, doc);
+    sc2_parse_actor_catalog_doc(catalog, doc);
+    sc2_parse_footprint_catalog_doc(catalog, doc);
+    sc2_parse_terrain_tex_catalog_doc(catalog, doc);
+    sc2_parse_cliff_catalog_doc(catalog, doc);
+}
+
+static void sc2_parse_catalog_layer_doc(sc2Catalog_t *catalog,
+                                        sc2MapSource_t *source,
+                                        LPCSTR root_name,
+                                        xmlDocPtr doc,
+                                        DWORD depth) {
+    xmlNodePtr root;
+
+    if (!catalog || !doc)
+        return;
+    root = xmlDocGetRootElement(doc);
+    if (!root || root->type != XML_ELEMENT_NODE)
+        return;
+    if (sc2_streqi((char const *)root->name, "Catalog")) {
+        sc2_parse_catalog_doc(catalog, doc);
+        return;
     }
-    sc2_parse_unit_catalog_file(catalog, "");
-    sc2_parse_model_catalog_file(catalog, "");
-    sc2_parse_actor_catalog_file(catalog, "");
-    sc2_parse_footprint_catalog_file(catalog, "");
-    sc2_parse_terrain_tex_catalog_file(catalog, "");
-    sc2_parse_cliff_catalog_file(catalog, "");
-    sc2_parse_unit_catalog_source(catalog, source);
-    sc2_parse_model_catalog_source(catalog, source);
-    sc2_parse_actor_catalog_source(catalog, source);
-    sc2_parse_footprint_catalog_source(catalog, source);
-    sc2_parse_terrain_tex_catalog_source(catalog, source);
-    sc2_parse_cliff_catalog_source(catalog, source);
+    if (!sc2_streqi((char const *)root->name, "Includes") ||
+        depth >= SC2_MAX_CATALOG_INCLUDE_DEPTH)
+        return;
+    for (xmlNodePtr node = root->children; node; node = node->next) {
+        char include_path[MAX_PATHLEN];
+        char path[MAX_PATHLEN];
+        xmlDocPtr include_doc;
+
+        if (node->type != XML_ELEMENT_NODE || !sc2_streqi((char const *)node->name, "Catalog"))
+            continue;
+        if (!sc2_xml_attr(node, "path", include_path, sizeof(include_path)) &&
+            !sc2_xml_attr(node, "Path", include_path, sizeof(include_path)))
+            continue;
+        if (!sc2_catalog_include_path(include_path, path, sizeof(path)))
+            continue;
+        include_doc = sc2_read_layer_catalog_xml(source, root_name, path);
+        if (!include_doc)
+            continue;
+        sc2_parse_catalog_layer_doc(catalog, source, root_name, include_doc, depth + 1);
+        xmlFreeDoc(include_doc);
+    }
+}
+
+static void sc2_parse_catalog_layer_fallback(sc2Catalog_t *catalog,
+                                             sc2MapSource_t *source,
+                                             LPCSTR root_name) {
+    for (DWORD i = 0; sc2_catalog_known_files[i]; i++) {
+        xmlDocPtr doc = sc2_read_layer_catalog_xml(source, root_name, sc2_catalog_known_files[i]);
+
+        sc2_parse_catalog_doc(catalog, doc);
+        xmlFreeDoc(doc);
+    }
+}
+
+static void sc2_parse_catalog_layer(sc2Catalog_t *catalog,
+                                    sc2MapSource_t *source,
+                                    LPCSTR root_name) {
+    xmlDocPtr manifest = sc2_read_layer_catalog_xml(source, root_name, "GameData.xml");
+
+    if (manifest) {
+        sc2_parse_catalog_layer_doc(catalog, source, root_name, manifest, 0);
+        xmlFreeDoc(manifest);
+        return;
+    }
+    sc2_parse_catalog_layer_fallback(catalog, source, root_name);
+}
+
+static void sc2_parse_catalogs(sc2Catalog_t *catalog, sc2MapSource_t *source) {
+    for (DWORD i = 0; sc2_catalog_roots[i]; i++)
+        sc2_parse_catalog_layer(catalog, NULL, sc2_catalog_roots[i]);
+    sc2_parse_catalog_layer(catalog, NULL, "");
+    sc2_parse_catalog_layer(catalog, source, NULL);
 }
 
 static void sc2_resolve_terrain_textures(sc2Catalog_t const *catalog) {

--- a/games/starcraft-2/tests/resources-src/Maps/Test/Tiny.SC2Map/Base.SC2Data/GameData.xml
+++ b/games/starcraft-2/tests/resources-src/Maps/Test/Tiny.SC2Map/Base.SC2Data/GameData.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="us-ascii"?>
+<Includes>
+    <Catalog path="GameData/UnitData.xml"/>
+    <Catalog path="GameData/ModelData.xml"/>
+    <Catalog path="GameData/ActorData.xml"/>
+    <Catalog path="GameData/FootprintData.xml"/>
+    <Catalog path="GameData/TerrainTexData.xml"/>
+    <Catalog path="GameData/CliffData.xml"/>
+    <Catalog path="GameData/Overrides/TinyManifest.xml"/>
+</Includes>

--- a/games/starcraft-2/tests/resources-src/Maps/Test/Tiny.SC2Map/Base.SC2Data/GameData/Overrides/TinyManifest.xml
+++ b/games/starcraft-2/tests/resources-src/Maps/Test/Tiny.SC2Map/Base.SC2Data/GameData/Overrides/TinyManifest.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="us-ascii"?>
+<Catalog>
+    <CUnit id="Marine">
+        <Radius value="0.875"/>
+    </CUnit>
+    <CModel id="MarineManifestModel" parent="Unit" Race="Terran">
+        <Occlusion value="Show"/>
+    </CModel>
+    <CActorUnit id="MarineActor">
+        <Model value="MarineManifestModel"/>
+    </CActorUnit>
+</Catalog>

--- a/games/starcraft-2/tests/resources-src/Mods/Core.SC2Mod/Base.SC2Data/GameData.xml
+++ b/games/starcraft-2/tests/resources-src/Mods/Core.SC2Mod/Base.SC2Data/GameData.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="us-ascii"?>
+<Includes>
+    <Catalog path="GameData/UnitData.xml"/>
+    <Catalog path="GameData/ModelData.xml"/>
+    <Catalog path="GameData/ActorData.xml"/>
+    <Catalog path="GameData/FootprintData.xml"/>
+    <Catalog path="GameData/TerrainTexData.xml"/>
+    <Catalog path="GameData/CliffData.xml"/>
+    <Catalog path="GameData/Overrides/CoreManifest.xml"/>
+</Includes>

--- a/games/starcraft-2/tests/resources-src/Mods/Core.SC2Mod/Base.SC2Data/GameData/Overrides/CoreManifest.xml
+++ b/games/starcraft-2/tests/resources-src/Mods/Core.SC2Mod/Base.SC2Data/GameData/Overrides/CoreManifest.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="us-ascii"?>
+<Catalog>
+    <CUnit id="Marine">
+        <Radius value="0.5"/>
+    </CUnit>
+    <CModel id="MarineCoreManifestModel" parent="Unit" Race="Protoss">
+        <Occlusion value="Hide"/>
+    </CModel>
+    <CActorUnit id="MarineActor">
+        <Model value="MarineCoreManifestModel"/>
+    </CActorUnit>
+</Catalog>

--- a/games/starcraft-2/tests/test_sc2_map.c
+++ b/games/starcraft-2/tests/test_sc2_map.c
@@ -160,6 +160,23 @@ static BOOL test_path_leaf_is(LPCSTR filename, LPCSTR leaf) {
     return !strcmp(base, leaf);
 }
 
+static HANDLE read_test_no_manifest_file(LPCSTR filename, LPDWORD size) {
+    if (test_path_leaf_is(filename, "GameData.xml")) {
+        if (size) *size = 0;
+        return NULL;
+    }
+    return read_test_disk_file(filename, size);
+}
+
+static void use_sc2_no_manifest_disk_host(void) {
+    SC2_MapSetHost(&(sc2MapHost_t){
+        .read_file = read_test_no_manifest_file,
+        .free_file = MemFree,
+        .mem_alloc = MemAlloc,
+        .mem_free = MemFree,
+    });
+}
+
 static DWORD short_terrain_width(DWORD width) {
     if (short_terrain_dimensions == TEST_SC2_ZERO_TERRAIN_DIMENSIONS)
         return 0;
@@ -296,11 +313,11 @@ static void test_sc2_fixture_short_name_resolves(void) {
 
 static void assert_tiny_map_catalog_overrides(sc2Map_t *map) {
     ASSERT_EQ_INT(map->catalog.footprints, 3);
-    ASSERT_STR_EQ(map->objects[1].model, "Assets\\Units\\Terran\\MarineCatalogModel\\MarineCatalogModel.m3");
+    ASSERT_STR_EQ(map->objects[1].model, "Assets\\Units\\Terran\\MarineManifestModel\\MarineManifestModel.m3");
     ASSERT_STR_EQ(map->objects[1].footprint, "FootprintMarine");
     ASSERT_STR_EQ(map->objects[1].mover, "Ground");
     ASSERT_EQ_INT(map->objects[1].unit_flags, SC2_UNIT_FLAG_MOVABLE);
-    ASSERT_EQ_FLOAT(map->objects[1].radius, 0.75f, 0.001f);
+    ASSERT_EQ_FLOAT(map->objects[1].radius, 0.875f, 0.001f);
     ASSERT_EQ_FLOAT(map->objects[1].footprint_width, 1.0f, 0.001f);
     ASSERT_EQ_FLOAT(map->objects[1].footprint_height, 1.0f, 0.001f);
     ASSERT_EQ_FLOAT(map->objects[1].footprint_radius, 0.5f, 0.001f);
@@ -317,6 +334,18 @@ static void assert_tiny_map_catalog_overrides(sc2Map_t *map) {
     ASSERT_EQ_FLOAT(map->objects[6].footprint_radius, 1.4143f, 0.001f);
     ASSERT_STR_EQ(map->t3Terrain.terrain_textures[0].diffuse, "Assets\\Textures\\Terrain\\FixtureGrass_Diffuse.dds");
     ASSERT_STR_EQ(map->t3Terrain.terrain_textures[0].normal, "Assets\\Textures\\Terrain\\FixtureGrass_Diffuse_normal.dds");
+    ASSERT_STR_EQ(map->t3Terrain.cliff_sets[0].mesh, "CliffNatural0");
+}
+
+static void assert_tiny_map_known_file_catalog_fallback(sc2Map_t *map) {
+    ASSERT_EQ_INT(map->catalog.footprints, 3);
+    ASSERT_STR_EQ(map->objects[1].model, "Assets\\Units\\Terran\\MarineCatalogModel\\MarineCatalogModel.m3");
+    ASSERT_STR_EQ(map->objects[1].footprint, "FootprintMarine");
+    ASSERT_STR_EQ(map->objects[1].mover, "Ground");
+    ASSERT_EQ_FLOAT(map->objects[1].radius, 0.75f, 0.001f);
+    ASSERT_STR_EQ(map->objects[6].model, "Assets\\Buildings\\Terran\\SupplyDepotCatalogModel\\SupplyDepotCatalogModel.m3");
+    ASSERT_EQ_FLOAT(map->objects[6].footprint_radius, 1.4143f, 0.001f);
+    ASSERT_STR_EQ(map->t3Terrain.terrain_textures[0].diffuse, "Assets\\Textures\\Terrain\\FixtureGrass_Diffuse.dds");
     ASSERT_STR_EQ(map->t3Terrain.cliff_sets[0].mesh, "CliffNatural0");
 }
 
@@ -569,6 +598,22 @@ static void test_sc2_map_loads_directory_fixture_without_generated_layers(void) 
     use_sc2_fs_host();
 }
 
+static void test_sc2_map_catalog_known_files_fallback_without_manifest(void) {
+    sc2Map_t *map;
+
+    setup_sc2_tests();
+    use_sc2_no_manifest_disk_host();
+    ASSERT(SC2_MapLoad(TEST_SC2_TINY_DIR));
+    map = SC2_MapCurrent();
+
+    ASSERT_STR_EQ(map->map_name, "SC2 Tiny Fixture");
+    ASSERT_EQ_INT(map->num_objects, 7);
+    assert_tiny_map_known_file_catalog_fallback(map);
+
+    SC2_MapShutdown();
+    use_sc2_fs_host();
+}
+
 static void assert_tiny_map_loaded_without_binary_terrain_layers(sc2Map_t *map) {
     ASSERT_STR_EQ(map->map_name, "SC2 Tiny Fixture");
     ASSERT_EQ_INT(map->MapInfo.width, 8);
@@ -633,6 +678,7 @@ void run_sc2_map_tests(void) {
     RUN_TEST(test_sc2_map_loads_xml_objects_and_terrain);
     RUN_TEST(test_sc2_map_loads_binary_terrain_layers);
     RUN_TEST(test_sc2_map_loads_directory_fixture_without_generated_layers);
+    RUN_TEST(test_sc2_map_catalog_known_files_fallback_without_manifest);
     RUN_TEST(test_sc2_map_rejects_short_binary_terrain_layers);
     RUN_TEST(test_sc2_map_rejects_zero_dimension_binary_terrain_layers);
     RUN_TEST(test_sc2_map_rejects_huge_dimension_binary_terrain_layers);


### PR DESCRIPTION
Refs #101.

This teaches the SC2 catalog loader to honor `Base.SC2Data/GameData.xml` include manifests while keeping the existing known-file fallback for layers without a manifest.

This PR:
- loads `<Includes><Catalog path="..."/></Includes>` in dependency/global/map-local order
- parses direct `<Catalog>` `GameData.xml` files too
- reuses the existing Unit/Model/Actor/Footprint/TerrainTex/Cliff doc parsers
- rejects unsafe manifest paths and bounds recursive includes
- treats an existing `GameData.xml` as authoritative for that layer
- adds Core and Tiny fixture manifests with nonstandard override files proving manifest order and map-local precedence
- adds a no-manifest fallback regression test for the old known-file path

Not included:
- HotS/LotV dependency root expansion
- `DocumentHeader` dependency discovery
- localization/GameStrings
- abilities/effects/weapons/movers/validators/upgrades
- terrain/light manifest loading
- UI layout include handling (#83/#80/#82 are separate)

Validated with:
- `git diff --check`
- `make sc2map`
- `make test-sc2`
- `make game-sc2`
- `make test`