### PR TITLE
feat: SC2 layout parser — XML to uiBaseFrame_t with templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ WOW_UI_CFLAGS := $(WOW_CFLAGS) $(LUA_CFLAGS) $(WOW_XML_CFLAGS)
 SC2_XML_CFLAGS := $(shell pkg-config --cflags libxml-2.0 2>/dev/null || xml2-config --cflags 2>/dev/null) -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/libxml2
 SC2_XML_LIBS := $(shell pkg-config --libs libxml-2.0 2>/dev/null || xml2-config --libs 2>/dev/null)
 SC2_CFLAGS   := $(CFLAGS) -I$(SC2_DIR) -DSC2 -DOW3_LOAD_ALL_MPQS -Wno-unused-function $(SC2_XML_CFLAGS)
-SC2_TEST_CFLAGS := $(SC2_CFLAGS) -Itests -Icommon -DTEST_SC2_MPQ=\"build/tests/test-sc2.SC2Maps\"
+SC2_TEST_CFLAGS := $(SC2_CFLAGS) -I. -Itests -Icommon -DTEST_SC2_MPQ=\"build/tests/test-sc2.SC2Maps\"
 
 TOOL_SRCS := $(shell find tools -maxdepth 1 -name '*.c' ! -name 'jass.c' | sort)
 TOOL_NAMES := $(patsubst tools/%.c,%,$(TOOL_SRCS))
@@ -273,7 +273,7 @@ $(eval $(call unity_lib_schema,$(GAME_WOW_LIB),$(GAME_BASE_DEPS) common/world.c 
 $(eval $(call unity_lib_schema,$(GAME_SC2_LIB),$(GAME_BASE_DEPS) $(WORLD_CORE_SRCS) $(SC2_COMMON_SRCS) $(call CSRC,$(SC2_DIR)/game),game-sc2,$(SC2_DIR)/game,,$(SC2_CFLAGS),common/mpq.c,-lshared $(LIBS) -lm -lz $(SC2_XML_LIBS)))
 
 $(eval $(call unity_lib_schema,$(UI_WOW_LIB),$(UI_BASE_DEPS) client/ui.h $(call CSRC,$(WOW_DIR)/ui),ui-wow,$(WOW_DIR)/ui,,$(WOW_UI_CFLAGS),,-lshared $(LUA_LIBS) $(WOW_XML_LIBS)))
-$(eval $(call unity_lib_schema,$(UI_SC2_LIB),$(UI_BASE_DEPS) client/ui.h $(call CSRC,$(SC2_DIR)/ui),ui-sc2,$(SC2_DIR)/ui,,$(SC2_CFLAGS),,-lshared))
+$(eval $(call unity_lib_schema,$(UI_SC2_LIB),$(UI_BASE_DEPS) client/ui.h $(call CSRC,$(SC2_DIR)/ui),ui-sc2,$(SC2_DIR)/ui,,$(SC2_CFLAGS),,-lshared $(SC2_XML_LIBS)))
 
 $(eval $(call app_schema,$(WOW_BINARY),$(SHARED_LIB) $(SHEET_LIB) $(GAME_WOW_LIB) $(RENDERER_WOW_LIB) $(UI_WOW_LIB) $(APP_SRCS) $(CLIENT_HEADERS) $(COMMON_HEADERS),openwow,$(WOW_CFLAGS),-lsheet -lshared -lgame-wow -lrenderer-wow -lui-wow $(LIBS) -lz))
 $(eval $(call app_schema,$(SC2_BINARY),$(SHARED_LIB) $(SHEET_LIB) $(GAME_SC2_LIB) $(RENDERER_SC2_LIB) $(UI_SC2_LIB) $(APP_SRCS) $(CLIENT_HEADERS),opensc2,$(SC2_CFLAGS),-lsheet -lshared -lgame-sc2 -lrenderer-sc2 -lui-sc2 $(LIBS) -lz))
@@ -292,7 +292,7 @@ $(eval $(call test_schema,test-wow-appearance,,$(WOW_TEST_CFLAGS),$(BIN_DIR)/tes
 $(eval $(call test_schema,test-wow-combat,,$(WOW_TEST_CFLAGS),$(BIN_DIR)/test_wow_combat$(EXE_EXT),$(WOW_TEST_DIR)/test_wow_combat.c $(WOW_DIR)/game/g_ai.c $(call CSRC,shared),-lm,))
 $(eval $(call test_schema,test-wow-game,,$(WOW_TEST_CFLAGS),$(BIN_DIR)/test_wow_game$(EXE_EXT),$(WOW_TEST_DIR)/test_wow_game.c $(WOW_DIR)/game/g_wow.c $(WOW_DIR)/game/g_world.c $(WOW_DIR)/game/g_ai.c $(WOW_DIR)/game/m_creature.c common/mpq.c $(call CSRC,shared),-lm -lz,))
 $(eval $(call test_schema,test-wow-ui,test-wow-assets,$(WOW_UI_TEST_CFLAGS),$(BIN_DIR)/test_wow_ui$(EXE_EXT),$(WOW_TEST_DIR)/test_wow_ui.c $(WOW_DIR)/ui/ui_main.c $(WOW_DIR)/ui/ui_lua.c $(WOW_DIR)/ui/ui_dbc.c $(WOW_DIR)/ui/ui_loading.c $(WOW_DIR)/ui/ui_xml.c common/mpq.c,-lshared $(LUA_LIBS) $(WOW_XML_LIBS) -lz,))
-$(eval $(call test_schema,test-sc2,test-sc2-assets $(SHARED_LIB) $(SHEET_LIB),$(SC2_TEST_CFLAGS),$(BIN_DIR)/test_sc2$(EXE_EXT),$(SC2_TEST_DIR)/test_sc2_main.c $(SC2_TEST_DIR)/test_sc2_map.c $(SC2_DIR)/common/sc2_map.c common/common.c common/cmd.c common/cvar.c common/msg.c common/net.c common/mpq.c,-lsheet -lshared -lm -lz $(SC2_XML_LIBS),))
+$(eval $(call test_schema,test-sc2,test-sc2-assets $(SHARED_LIB) $(SHEET_LIB),$(SC2_TEST_CFLAGS),$(BIN_DIR)/test_sc2$(EXE_EXT),$(SC2_TEST_DIR)/test_sc2_main.c $(SC2_TEST_DIR)/test_sc2_map.c $(SC2_TEST_DIR)/test_sc2_layout.c $(SC2_TEST_DIR)/test_sc2_consoleui.c $(SC2_DIR)/common/sc2_map.c $(SC2_DIR)/ui/sc2_layout.c common/common.c common/cmd.c common/cvar.c common/msg.c common/net.c common/mpq.c,-lsheet -lshared -lm -lz $(SC2_XML_LIBS),))
 
 test-sc2-assets: sc2fixturegen mpqtool sc2map | $(TESTS_DIR)
 	@echo "[test-sc2-assets] generating SC2 terrain fixtures"

--- a/client/cl_input_w3.c
+++ b/client/cl_input_w3.c
@@ -258,6 +258,7 @@ void CL_InputModeFrame(void) {
     }
 
     /* Screen-edge scrolling (only while the cursor is inside the window). */
+#ifndef SC2
     size2_t win = re.GetWindowSize();
     float mx = mouse.origin.x, my = mouse.origin.y;
     if (win.width > 0 && win.height > 0 &&
@@ -267,6 +268,7 @@ void CL_InputModeFrame(void) {
         if (my <= CL_CAMERA_EDGE_MARGIN)               dy += 1.0f; /* top of screen = north */
         if (my >= (float)win.height - 1 - CL_CAMERA_EDGE_MARGIN) dy -= 1.0f;
     }
+#endif
 
     if (dx == 0.0f && dy == 0.0f) {
         return;

--- a/games/starcraft-2/common/sc2_map.c
+++ b/games/starcraft-2/common/sc2_map.c
@@ -256,7 +256,7 @@ static HANDLE sc2_source_read(sc2MapSource_t *source, LPCSTR filename, LPDWORD s
     data = sc2_read_file(wide_path, size);
     if (!data) {
         snprintf(wide_path, sizeof(wide_path), "%s\\%s", source->base, filename);
-        data = sc2_read_file(path, size);
+        data = sc2_read_file(wide_path, size);
     }
     return data;
 }
@@ -366,20 +366,23 @@ static xmlDocPtr sc2_read_catalog_xml_from_archive(LPCSTR archive_name, LPCSTR f
 
 static xmlDocPtr sc2_read_catalog_xml(LPCSTR root, LPCSTR filename) {
     PATHSTR path;
+    PATHSTR archive_path;
     xmlDocPtr doc;
     LPCSTR data_dir;
 
     if (!root || !*root) return sc2_read_global_xml(filename);
-    snprintf(path, sizeof(path), "%s/%s", root, filename);
+    /* All catalog game data files live under Base.SC2Data/ inside each mod/archive */
+    snprintf(path, sizeof(path), "%s/Base.SC2Data/%s", root, filename);
     doc = sc2_read_global_xml(path);
     if (doc)
         return doc;
     data_dir = sc2_host.cvar_string ? sc2_host.cvar_string("data", "") : "";
     if (data_dir && *data_dir) {
-        snprintf(path, sizeof(path), "%s/%s", data_dir, root);
-        return sc2_read_catalog_xml_from_archive(path, filename);
+        snprintf(archive_path, sizeof(archive_path), "%s/%s/Base.SC2Data", data_dir, root);
+        return sc2_read_catalog_xml_from_archive(archive_path, filename);
     }
-    return sc2_read_catalog_xml_from_archive(root, filename);
+    snprintf(archive_path, sizeof(archive_path), "%s/Base.SC2Data", root);
+    return sc2_read_catalog_xml_from_archive(archive_path, filename);
 }
 
 static xmlDocPtr sc2_read_map_catalog_xml(sc2MapSource_t *source, LPCSTR filename) {

--- a/games/starcraft-2/tests/resources-src/UI/Layout/TestAdapter.SC2Layout
+++ b/games/starcraft-2/tests/resources-src/UI/Layout/TestAdapter.SC2Layout
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<Desc>
+    <!-- Constants for offset/size testing -->
+    <Constant name="HUDMargin" val="8"/>
+    <Constant name="PanelWidth" val="200"/>
+
+    <!-- Root container with all 4 anchor sides -->
+    <Frame type="GameUI" name="ConsoleUI">
+        <Anchor relative="$parent"/>
+
+        <!-- Bottom-left panel: tests Left+Bottom anchors -->
+        <Frame type="Frame" name="ResourcePanel">
+            <Width val="200"/>
+            <Height val="40"/>
+            <Anchor side="Left" relative="$parent" pos="Min" offset="#HUDMargin"/>
+            <Anchor side="Bottom" relative="$parent" pos="Max" offset="-40"/>
+            <Anchor side="Top" relative="$parent" pos="Max" offset="-80"/>
+            <Visible val="true"/>
+            <Color val="255,255,255,200"/>
+
+            <Frame type="Image" name="MineralIcon">
+                <Width val="32"/>
+                <Height val="32"/>
+                <Anchor side="Left" relative="$parent" pos="Min" offset="4"/>
+                <Anchor side="Top" relative="$parent" pos="Min" offset="4"/>
+                <Texture val="@@UI/MineralIcon" layer="0"/>
+            </Frame>
+
+            <Frame type="Label" name="MineralCount">
+                <Width val="80"/>
+                <Height val="20"/>
+                <Anchor side="Left" relative="$parent/MineralIcon" pos="Max" offset="4"/>
+                <Anchor side="Top" relative="$parent" pos="Min" offset="8"/>
+                <Visible val="true"/>
+            </Frame>
+        </Frame>
+
+        <!-- Top-right panel: tests Right+Top anchors with stretch -->
+        <Frame type="Frame" name="InfoPanel">
+            <Width val="250"/>
+            <Height val="120"/>
+            <Anchor side="Right" relative="$parent" pos="Max" offset="-8"/>
+            <Anchor side="Top" relative="$parent" pos="Min" offset="8"/>
+            <Visible val="true"/>
+
+            <Frame type="Label" name="UnitName">
+                <Width val="200"/>
+                <Height val="20"/>
+                <Anchor side="Left" relative="$parent" pos="Min" offset="8"/>
+                <Anchor side="Top" relative="$parent" pos="Min" offset="8"/>
+            </Frame>
+
+            <Frame type="Image" name="Portrait">
+                <Width val="96"/>
+                <Height val="96"/>
+                <Anchor side="Right" relative="$parent" pos="Max" offset="-8"/>
+                <Anchor side="Top" relative="$parent" pos="Min" offset="32"/>
+                <Texture val="@@UI/Portrait" layer="0"/>
+            </Frame>
+        </Frame>
+
+        <!-- Command grid: tests Right+Bottom with child grid layout -->
+        <Frame type="Frame" name="CommandArea">
+            <Width val="308"/>
+            <Height val="154"/>
+            <Anchor side="Right" relative="$parent" pos="Max" offset="0"/>
+            <Anchor side="Bottom" relative="$parent" pos="Max" offset="0"/>
+
+            <Frame type="CommandButton" name="Cmd01">
+                <Width val="76"/>
+                <Height val="76"/>
+                <Anchor side="Left" relative="$parent" pos="Min" offset="0"/>
+                <Anchor side="Top" relative="$parent" pos="Min" offset="0"/>
+                <Texture val="@@UI/ButtonNormal" layer="0"/>
+            </Frame>
+
+            <Frame type="CommandButton" name="Cmd02">
+                <Width val="76"/>
+                <Height val="76"/>
+                <Anchor side="Left" relative="$parent/Cmd01" pos="Max" offset="0"/>
+                <Anchor side="Top" relative="$parent" pos="Min" offset="0"/>
+            </Frame>
+
+            <Frame type="CommandButton" name="Cmd03">
+                <Width val="76"/>
+                <Height val="76"/>
+                <Anchor side="Left" relative="$parent/Cmd02" pos="Max" offset="0"/>
+                <Anchor side="Top" relative="$parent" pos="Min" offset="0"/>
+            </Frame>
+        </Frame>
+
+        <!-- Center label: tests Mid anchor -->
+        <Frame type="Label" name="CenterAlert">
+            <Width val="300"/>
+            <Height val="40"/>
+            <Anchor side="Left" relative="$parent" pos="Mid" offset="0"/>
+            <Anchor side="Top" relative="$parent" pos="Mid" offset="0"/>
+            <Visible val="false"/>
+        </Frame>
+
+        <!-- Hidden panel: tests visibility in hierarchy -->
+        <Frame type="Frame" name="HiddenPanel">
+            <Width val="100"/>
+            <Height val="100"/>
+            <Anchor side="Left" relative="$parent" pos="Min" offset="0"/>
+            <Anchor side="Top" relative="$parent" pos="Min" offset="0"/>
+            <Visible val="false"/>
+
+            <Frame type="Label" name="HiddenChild">
+                <Width val="50"/>
+                <Height val="20"/>
+                <Anchor side="Left" relative="$parent" pos="Min" offset="0"/>
+                <Anchor side="Top" relative="$parent" pos="Min" offset="0"/>
+            </Frame>
+        </Frame>
+    </Frame>
+</Desc>

--- a/games/starcraft-2/tests/resources-src/UI/Layout/TestConstants.SC2Layout
+++ b/games/starcraft-2/tests/resources-src/UI/Layout/TestConstants.SC2Layout
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<Desc>
+    <Constant name="TestColorRed" val="255,0,0"/>
+    <Constant name="TestColorGreen" val="0,255,0"/>
+    <Constant name="TestColorBlue" val="0,0,255"/>
+    <Constant name="TestGap" val="4"/>
+</Desc>

--- a/games/starcraft-2/tests/resources-src/UI/Layout/TestGameUI.SC2Layout
+++ b/games/starcraft-2/tests/resources-src/UI/Layout/TestGameUI.SC2Layout
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<Desc>
+    <Include path="UI/Layout/TestConstants.SC2Layout"/>
+    <Include path="UI/Layout/TestIncluded.SC2Layout"/>
+    <Include path="UI/Layout/TestTemplates.SC2Layout"/>
+
+    <!-- Root game UI frame -->
+    <Frame type="GameUI" name="TestGameUI">
+        <Anchor relative="$parent"/>
+
+        <!-- Test included frame -->
+        <Frame type="Frame" name="IncludedPanel" template="TestIncluded/IncludedFrame">
+            <Anchor side="Bottom" relative="$parent" pos="Max" offset="0"/>
+        </Frame>
+
+        <!-- Test template inheritance with override -->
+        <Frame type="Button" name="ActionButton01" template="TestTemplates/TestButtonTemplate">
+            <Anchor side="Top" relative="$parent" pos="Min" offset="#TestGap"/>
+            <Anchor side="Left" relative="$parent" pos="Min" offset="#TestGap"/>
+        </Frame>
+
+        <!-- Test template with nested children -->
+        <Frame type="Frame" name="InfoPanel" template="TestTemplates/TestContainerTemplate">
+            <Anchor side="Left" relative="$parent" pos="Min" offset="0"/>
+            <Anchor side="Bottom" relative="$parent" pos="Max" offset="-200"/>
+        </Frame>
+
+        <!-- Test deeply nested inline children -->
+        <Frame type="Frame" name="CommandArea">
+            <Width val="450"/>
+            <Height val="300"/>
+            <Anchor side="Bottom" relative="$parent" pos="Max" offset="0"/>
+            <Anchor side="Right" relative="$parent" pos="Max" offset="0"/>
+
+            <Frame type="Image" name="CommandBackground">
+                <Anchor relative="$parent"/>
+                <Texture val="@@Test/CommandBG" layer="0"/>
+            </Frame>
+
+            <Frame type="Button" name="Cmd01">
+                <Width val="76"/>
+                <Height val="76"/>
+                <Anchor side="Top" relative="$parent" pos="Min" offset="4"/>
+                <Anchor side="Left" relative="$parent" pos="Min" offset="4"/>
+            </Frame>
+
+            <Frame type="Button" name="Cmd02">
+                <Width val="76"/>
+                <Height val="76"/>
+                <Anchor side="Top" relative="$parent/Cmd01" pos="Min" offset="0"/>
+                <Anchor side="Left" relative="$parent/Cmd01" pos="Max" offset="1"/>
+            </Frame>
+
+            <Frame type="Label" name="UnitName">
+                <Width val="200"/>
+                <Height val="20"/>
+                <Anchor side="Top" relative="$parent" pos="Min" offset="84"/>
+                <Anchor side="Left" relative="$parent" pos="Min" offset="4"/>
+            </Frame>
+        </Frame>
+    </Frame>
+</Desc>

--- a/games/starcraft-2/tests/resources-src/UI/Layout/TestIncluded.SC2Layout
+++ b/games/starcraft-2/tests/resources-src/UI/Layout/TestIncluded.SC2Layout
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<Desc>
+    <Frame type="Frame" name="IncludedFrame">
+        <Width val="100"/>
+        <Height val="50"/>
+        <Visible val="true"/>
+    </Frame>
+</Desc>

--- a/games/starcraft-2/tests/resources-src/UI/Layout/TestTemplates.SC2Layout
+++ b/games/starcraft-2/tests/resources-src/UI/Layout/TestTemplates.SC2Layout
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<Desc>
+    <!-- Base template: a simple 200x100 frame -->
+    <Frame type="Frame" name="TestBaseTemplate">
+        <Width val="200"/>
+        <Height val="100"/>
+        <Visible val="true"/>
+        <Anchor side="Top" relative="$parent" pos="Min" offset="0"/>
+        <Anchor side="Left" relative="$parent" pos="Min" offset="0"/>
+    </Frame>
+
+    <!-- Template that inherits from TestBaseTemplate and overrides size -->
+    <Frame type="Button" name="TestButtonTemplate" template="TestTemplates/TestBaseTemplate">
+        <Width val="300"/>
+        <Height val="75"/>
+        <Anchor side="Right" relative="$parent" pos="Max" offset="-10"/>
+    </Frame>
+
+    <!-- Template with nested children -->
+    <Frame type="Frame" name="TestContainerTemplate">
+        <Width val="400"/>
+        <Height val="300"/>
+        <Frame type="Image" name="Background">
+            <Anchor relative="$parent"/>
+            <Texture val="@@Test/Background" layer="0"/>
+        </Frame>
+        <Frame type="Label" name="TitleLabel">
+            <Anchor side="Top" relative="$parent" pos="Min" offset="10"/>
+            <Anchor side="Left" relative="$parent" pos="Min" offset="10"/>
+            <Width val="380"/>
+            <Height val="30"/>
+        </Frame>
+    </Frame>
+
+    <!-- Template with constants -->
+    <Frame type="Image" name="TestColorBox">
+        <Width val="32"/>
+        <Height val="32"/>
+    </Frame>
+</Desc>

--- a/games/starcraft-2/tests/test_sc2_consoleui.c
+++ b/games/starcraft-2/tests/test_sc2_consoleui.c
@@ -1,0 +1,465 @@
+/*
+ * test_sc2_consoleui.c — SC2 ConsoleUI adapter tests.
+ *
+ * Tests the adapter layer that maps SC2 parsed frame data (sc2Frame_t)
+ * into sc2BaseFrame_t arrays: anchor resolution, frame type mapping,
+ * visibility flags, color/alpha population, and flatten correctness.
+ *
+ * Also serves as regression tests for the 4 parser bugs fixed in this change.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "common.h"
+#include "games/starcraft-2/ui/sc2_layout.h"
+#include "test_framework.h"
+
+/* Define the uiimport global that sc2_layout.c references via extern */
+extern uiImport_t uiimport;
+
+#ifndef TEST_SC2_MPQ
+#define TEST_SC2_MPQ "build/tests/test-sc2.SC2Maps"
+#endif
+
+static BOOL sc2_consoleui_tests_initialized;
+
+static void setup_sc2_consoleui_tests(void) {
+    if (sc2_consoleui_tests_initialized) return;
+
+    LPCSTR argv[] = { "test_sc2_consoleui", "-config", "" };
+    Com_Init(3, argv);
+    ASSERT(FS_AddArchive(TEST_SC2_MPQ) != NULL);
+
+    memset(&uiimport, 0, sizeof(uiimport));
+    uiimport.FS_ReadFile = FS_ReadFileQ3;
+    uiimport.FS_FreeFile = FS_FreeFile;
+    uiimport.Printf = (void (*)(LPCSTR, ...))printf;
+
+    sc2_consoleui_tests_initialized = true;
+}
+
+/* Helper: find a frame in the flat array by name */
+static sc2BaseFrame_t *find_frame(sc2BaseFrame_t *frames, DWORD count, LPCSTR name) {
+    for (DWORD i = 0; i < count; i++) {
+        for (int j = 0; j < SC2_LayoutNumTemplates(); j++) {
+            sc2Frame_t *tmpl = SC2_LayoutGetTemplate(j);
+            if (tmpl && tmpl->resolved_index == (int)i && !strcasecmp(tmpl->name, name))
+                return &frames[i];
+        }
+    }
+    return NULL;
+}
+
+/* Helper: find template by name (wraps internal lookup) */
+static sc2Frame_t *find_template(LPCSTR name) {
+    return SC2_LayoutFindTemplate(name);
+}
+
+/* =====================================================================
+ * Group 1: Parser Bug Regression Tests
+ * ===================================================================== */
+
+/* Bug 1: ## constant hash stripping */
+static void test_adapter_constant_hash_stripping(void) {
+    setup_sc2_consoleui_tests();
+    SC2_LayoutInit();
+    ASSERT(SC2_LayoutParseFile("UI/Layout/TestAdapter.SC2Layout"));
+    ASSERT(SC2_LayoutFlatten("ConsoleUI"));
+
+    LPCSTR margin = SC2_LayoutResolveConstant("##HUDMargin");
+    ASSERT_NOT_NULL(margin);
+    ASSERT_STR_EQ(margin, "8");
+
+    LPCSTR width = SC2_LayoutResolveConstant("##PanelWidth");
+    ASSERT_NOT_NULL(width);
+    ASSERT_STR_EQ(width, "200");
+
+    /* Also verify the old TestConstants fixture still works */
+    ASSERT(SC2_LayoutParseFile("UI/Layout/TestConstants.SC2Layout"));
+    LPCSTR red = SC2_LayoutResolveConstant("##TestColorRed");
+    ASSERT_NOT_NULL(red);
+    ASSERT_STR_EQ(red, "255,0,0");
+
+    SC2_LayoutShutdown();
+}
+
+/* Bug 3: Constant resolution in anchor offsets */
+static void test_adapter_constant_offset_resolves(void) {
+    setup_sc2_consoleui_tests();
+    SC2_LayoutInit();
+    ASSERT(SC2_LayoutParseFile("UI/Layout/TestAdapter.SC2Layout"));
+    ASSERT(SC2_LayoutFlatten("ConsoleUI"));
+
+    sc2Frame_t *panel = find_template("ResourcePanel");
+    ASSERT_NOT_NULL(panel);
+
+    /* ResourcePanel's Left anchor has offset="#HUDMargin" which should resolve to 8 */
+    ASSERT(panel->num_anchors > 0);
+    BOOL found_left = false;
+    for (int i = 0; i < panel->num_anchors; i++) {
+        if (panel->anchors[i].side == SC2_SIDE_LEFT) {
+            ASSERT_EQ_INT(panel->anchors[i].offset, 8);
+            found_left = true;
+            break;
+        }
+    }
+    ASSERT(found_left);
+
+    SC2_LayoutShutdown();
+}
+
+/* Bug 2: Template inheritance ordering (same-file templates) */
+static void test_adapter_template_inheritance_ordering(void) {
+    setup_sc2_consoleui_tests();
+    SC2_LayoutInit();
+    ASSERT(SC2_LayoutParseFile("UI/Layout/TestGameUI.SC2Layout"));
+
+    /* ActionButton01 inherits from TestButtonTemplate (300x75).
+     * TestButtonTemplate has 3 anchors (Top+Min, Left+Min from base, Right+Max own).
+     * ActionButton01 has 2 inline anchors (Top+Min, Left+Min) which override
+     * the same sides from the template. Result: 3 anchors total. */
+    sc2Frame_t *button = find_template("ActionButton01");
+    ASSERT_NOT_NULL(button);
+    ASSERT(button->flags & SC2_FRAME_HAS_WIDTH);
+    ASSERT_EQ_FLOAT(button->width, 300.0f, 0.01f);
+    ASSERT(button->flags & SC2_FRAME_HAS_HEIGHT);
+    ASSERT_EQ_FLOAT(button->height, 75.0f, 0.01f);
+
+    /* Should have 3 anchors (2 template sides overridden + 1 template side kept) */
+    ASSERT_EQ_INT(button->num_anchors, 3);
+
+    SC2_LayoutShutdown();
+}
+
+/* Bug 4: Cross-file template inheritance */
+static void test_adapter_cross_file_template_inheritance(void) {
+    setup_sc2_consoleui_tests();
+    SC2_LayoutInit();
+    ASSERT(SC2_LayoutParseFile("UI/Layout/TestGameUI.SC2Layout"));
+
+    /* IncludedPanel inherits from IncludedFrame in TestIncluded.SC2Layout */
+    sc2Frame_t *panel = find_template("IncludedPanel");
+    ASSERT_NOT_NULL(panel);
+    ASSERT(panel->flags & SC2_FRAME_HAS_WIDTH);
+    ASSERT_EQ_FLOAT(panel->width, 100.0f, 0.01f);
+    ASSERT(panel->flags & SC2_FRAME_HAS_HEIGHT);
+    ASSERT_EQ_FLOAT(panel->height, 50.0f, 0.01f);
+    ASSERT(panel->flags & SC2_FRAME_HAS_VISIBLE);
+    ASSERT(panel->flags & SC2_FRAME_VISIBLE);
+
+    SC2_LayoutShutdown();
+}
+
+/* =====================================================================
+ * Group 2: Anchor Resolution Tests
+ * ===================================================================== */
+
+static void test_adapter_single_anchor_left_min(void) {
+    setup_sc2_consoleui_tests();
+    SC2_LayoutInit();
+    ASSERT(SC2_LayoutParseFile("UI/Layout/TestAdapter.SC2Layout"));
+    ASSERT(SC2_LayoutFlatten("ConsoleUI"));
+    ASSERT(SC2_LayoutFlatten("ConsoleUI"));
+
+    DWORD count = 0;
+    sc2BaseFrame_t *frames = SC2_LayoutGetFrames(&count);
+    ASSERT(count > 0);
+
+    /* MineralIcon has Left+Min anchor */
+    sc2BaseFrame_t *icon = find_frame(frames, count, "MineralIcon");
+    ASSERT_NOT_NULL(icon);
+    ASSERT(icon->points.x[FPP_MIN].used);
+    ASSERT_EQ_INT(icon->points.x[FPP_MIN].targetPos, FPP_MIN);
+
+    SC2_LayoutShutdown();
+}
+
+static void test_adapter_single_anchor_top_min(void) {
+    setup_sc2_consoleui_tests();
+    SC2_LayoutInit();
+    ASSERT(SC2_LayoutParseFile("UI/Layout/TestAdapter.SC2Layout"));
+    ASSERT(SC2_LayoutFlatten("ConsoleUI"));
+    ASSERT(SC2_LayoutFlatten("ConsoleUI"));
+
+    DWORD count = 0;
+    sc2BaseFrame_t *frames = SC2_LayoutGetFrames(&count);
+
+    /* MineralIcon has Top+Min anchor */
+    sc2BaseFrame_t *icon = find_frame(frames, count, "MineralIcon");
+    ASSERT_NOT_NULL(icon);
+    ASSERT(icon->points.y[FPP_MIN].used);
+    ASSERT_EQ_INT(icon->points.y[FPP_MIN].targetPos, FPP_MIN);
+
+    SC2_LayoutShutdown();
+}
+
+static void test_adapter_dual_anchor_stretch(void) {
+    setup_sc2_consoleui_tests();
+    SC2_LayoutInit();
+    ASSERT(SC2_LayoutParseFile("UI/Layout/TestAdapter.SC2Layout"));
+    ASSERT(SC2_LayoutFlatten("ConsoleUI"));
+
+    DWORD count = 0;
+    sc2BaseFrame_t *frames = SC2_LayoutGetFrames(&count);
+
+    /* ResourcePanel has Top+Max and Bottom+Max → y-axis dual anchor */
+    sc2BaseFrame_t *panel = find_frame(frames, count, "ResourcePanel");
+    ASSERT_NOT_NULL(panel);
+    ASSERT(panel->points.y[FPP_MIN].used); /* Top+Max maps to y[FPP_MIN] with pos=Max */
+    ASSERT(panel->points.y[FPP_MAX].used); /* Bottom+Max maps to y[FPP_MAX] with pos=Max */
+
+    SC2_LayoutShutdown();
+}
+
+static void test_adapter_mid_anchor(void) {
+    setup_sc2_consoleui_tests();
+    SC2_LayoutInit();
+    ASSERT(SC2_LayoutParseFile("UI/Layout/TestAdapter.SC2Layout"));
+    ASSERT(SC2_LayoutFlatten("ConsoleUI"));
+
+    DWORD count = 0;
+    sc2BaseFrame_t *frames = SC2_LayoutGetFrames(&count);
+
+    /* CenterAlert has Left+Mid and Top+Mid.
+     * Left → x[FPP_MIN] (element's left edge), pos=Mid → targetPos=FPP_MID (parent center).
+     * Top  → y[FPP_MIN] (element's top edge),  pos=Mid → targetPos=FPP_MID (parent center). */
+    sc2BaseFrame_t *alert = find_frame(frames, count, "CenterAlert");
+    ASSERT_NOT_NULL(alert);
+    ASSERT(alert->points.x[FPP_MIN].used);
+    ASSERT(alert->points.x[FPP_MIN].targetPos == FPP_MID);
+    ASSERT(alert->points.y[FPP_MIN].used);
+    ASSERT(alert->points.y[FPP_MIN].targetPos == FPP_MID);
+
+    SC2_LayoutShutdown();
+}
+
+static void test_adapter_cross_frame_relative(void) {
+    setup_sc2_consoleui_tests();
+    SC2_LayoutInit();
+    ASSERT(SC2_LayoutParseFile("UI/Layout/TestAdapter.SC2Layout"));
+    ASSERT(SC2_LayoutFlatten("ConsoleUI"));
+
+    DWORD count = 0;
+    sc2BaseFrame_t *frames = SC2_LayoutGetFrames(&count);
+
+    /* Cmd02's Left anchor references $parent/Cmd01 */
+    sc2BaseFrame_t *cmd02 = find_frame(frames, count, "Cmd02");
+    ASSERT_NOT_NULL(cmd02);
+    ASSERT(cmd02->points.x[FPP_MIN].used);
+
+    /* The relative_index should point to Cmd01, not the parent */
+    sc2BaseFrame_t *cmd01 = find_frame(frames, count, "Cmd01");
+    ASSERT_NOT_NULL(cmd01);
+    ASSERT_EQ_INT(cmd02->points.x[FPP_MIN].relative_index, cmd01->number);
+
+    SC2_LayoutShutdown();
+}
+
+/* =====================================================================
+ * Group 3: Flatten / Frame Population Tests
+ * ===================================================================== */
+
+static void test_adapter_flatten_frame_count(void) {
+    setup_sc2_consoleui_tests();
+    SC2_LayoutInit();
+    ASSERT(SC2_LayoutParseFile("UI/Layout/TestAdapter.SC2Layout"));
+    ASSERT(SC2_LayoutFlatten("ConsoleUI"));
+
+    DWORD count = 0;
+    SC2_LayoutGetFrames(&count);
+
+    /* ConsoleUI root + ResourcePanel + MineralIcon + MineralCount +
+     * InfoPanel + UnitName + Portrait + CommandArea + Cmd01 + Cmd02 +
+     * Cmd03 + CenterAlert + HiddenPanel + HiddenChild = 14 */
+    ASSERT_EQ_INT(count, 14);
+
+    SC2_LayoutShutdown();
+}
+
+static void test_adapter_flatten_types_mapped(void) {
+    setup_sc2_consoleui_tests();
+    SC2_LayoutInit();
+    ASSERT(SC2_LayoutParseFile("UI/Layout/TestAdapter.SC2Layout"));
+    ASSERT(SC2_LayoutFlatten("ConsoleUI"));
+
+    DWORD count = 0;
+    sc2BaseFrame_t *frames = SC2_LayoutGetFrames(&count);
+
+    /* ConsoleUI (GameUI) → FT_FRAME */
+    sc2BaseFrame_t *root = find_frame(frames, count, "ConsoleUI");
+    ASSERT_NOT_NULL(root);
+    ASSERT_EQ_INT(root->type, FT_FRAME);
+
+    /* Cmd01 (CommandButton) → FT_BUTTON */
+    sc2BaseFrame_t *cmd = find_frame(frames, count, "Cmd01");
+    ASSERT_NOT_NULL(cmd);
+    ASSERT_EQ_INT(cmd->type, FT_BUTTON);
+
+    /* MineralIcon (Image) → FT_SPRITE */
+    sc2BaseFrame_t *icon = find_frame(frames, count, "MineralIcon");
+    ASSERT_NOT_NULL(icon);
+    ASSERT_EQ_INT(icon->type, FT_SPRITE);
+
+    /* MineralCount (Label) → FT_TEXT */
+    sc2BaseFrame_t *label = find_frame(frames, count, "MineralCount");
+    ASSERT_NOT_NULL(label);
+    ASSERT_EQ_INT(label->type, FT_TEXT);
+
+    /* Portrait (Image) → FT_SPRITE */
+    sc2BaseFrame_t *portrait = find_frame(frames, count, "Portrait");
+    ASSERT_NOT_NULL(portrait);
+    ASSERT_EQ_INT(portrait->type, FT_SPRITE);
+
+    SC2_LayoutShutdown();
+}
+
+static void test_adapter_flatten_hidden_flags(void) {
+    setup_sc2_consoleui_tests();
+    SC2_LayoutInit();
+    ASSERT(SC2_LayoutParseFile("UI/Layout/TestAdapter.SC2Layout"));
+    ASSERT(SC2_LayoutFlatten("ConsoleUI"));
+
+    DWORD count = 0;
+    sc2BaseFrame_t *frames = SC2_LayoutGetFrames(&count);
+
+    /* HiddenPanel should be hidden */
+    sc2BaseFrame_t *hidden = find_frame(frames, count, "HiddenPanel");
+    ASSERT_NOT_NULL(hidden);
+    ASSERT(hidden->ui_flags & SC2_UIFLAG_HIDDEN);
+
+    /* CenterAlert should be hidden (Visible val="false") */
+    sc2BaseFrame_t *alert = find_frame(frames, count, "CenterAlert");
+    ASSERT_NOT_NULL(alert);
+    ASSERT(alert->ui_flags & SC2_UIFLAG_HIDDEN);
+
+    /* ResourcePanel should NOT be hidden */
+    sc2BaseFrame_t *panel = find_frame(frames, count, "ResourcePanel");
+    ASSERT_NOT_NULL(panel);
+    ASSERT(!(panel->ui_flags & SC2_UIFLAG_HIDDEN));
+
+    SC2_LayoutShutdown();
+}
+
+static void test_adapter_flatten_color_alpha(void) {
+    setup_sc2_consoleui_tests();
+    SC2_LayoutInit();
+    ASSERT(SC2_LayoutParseFile("UI/Layout/TestAdapter.SC2Layout"));
+    ASSERT(SC2_LayoutFlatten("ConsoleUI"));
+
+    DWORD count = 0;
+    sc2BaseFrame_t *frames = SC2_LayoutGetFrames(&count);
+
+    /* ResourcePanel has Color val="255,255,255,200" */
+    sc2BaseFrame_t *panel = find_frame(frames, count, "ResourcePanel");
+    ASSERT_NOT_NULL(panel);
+    ASSERT_EQ_INT(panel->color.r, 255);
+    ASSERT_EQ_INT(panel->color.g, 255);
+    ASSERT_EQ_INT(panel->color.b, 255);
+    ASSERT_EQ_INT(panel->color.a, 200);
+
+    /* Root ConsoleUI should default to white */
+    sc2BaseFrame_t *root = find_frame(frames, count, "ConsoleUI");
+    ASSERT_NOT_NULL(root);
+    ASSERT_EQ_INT(root->color.r, 255);
+    ASSERT_EQ_INT(root->color.g, 255);
+    ASSERT_EQ_INT(root->color.b, 255);
+    ASSERT_EQ_INT(root->color.a, 255);
+
+    SC2_LayoutShutdown();
+}
+
+/* =====================================================================
+ * Group 4: Screen Rect Pipeline Tests
+ * ===================================================================== */
+
+static void test_adapter_root_parent_is_scene(void) {
+    setup_sc2_consoleui_tests();
+    SC2_LayoutInit();
+    ASSERT(SC2_LayoutParseFile("UI/Layout/TestAdapter.SC2Layout"));
+    ASSERT(SC2_LayoutFlatten("ConsoleUI"));
+
+    DWORD count = 0;
+    sc2BaseFrame_t *frames = SC2_LayoutGetFrames(&count);
+
+    /* ConsoleUI root has Anchor relative="$parent" → parent_index == -1 */
+    sc2BaseFrame_t *root = find_frame(frames, count, "ConsoleUI");
+    ASSERT_NOT_NULL(root);
+    ASSERT_EQ_INT(root->parent_index, (DWORD)-1);
+
+    SC2_LayoutShutdown();
+}
+
+static void test_adapter_cross_frame_relative_index(void) {
+    setup_sc2_consoleui_tests();
+    SC2_LayoutInit();
+    ASSERT(SC2_LayoutParseFile("UI/Layout/TestAdapter.SC2Layout"));
+    ASSERT(SC2_LayoutFlatten("ConsoleUI"));
+
+    DWORD count = 0;
+    sc2BaseFrame_t *frames = SC2_LayoutGetFrames(&count);
+
+    /* Cmd03 references $parent/Cmd02 — relative should be Cmd02's index */
+    sc2BaseFrame_t *cmd03 = find_frame(frames, count, "Cmd03");
+    sc2BaseFrame_t *cmd02 = find_frame(frames, count, "Cmd02");
+    ASSERT_NOT_NULL(cmd03);
+    ASSERT_NOT_NULL(cmd02);
+    ASSERT_EQ_INT(cmd03->points.x[FPP_MIN].relative_index, cmd02->number);
+
+    SC2_LayoutShutdown();
+}
+
+static void test_adapter_hidden_flagged_for_skip(void) {
+    setup_sc2_consoleui_tests();
+    SC2_LayoutInit();
+    ASSERT(SC2_LayoutParseFile("UI/Layout/TestAdapter.SC2Layout"));
+    ASSERT(SC2_LayoutFlatten("ConsoleUI"));
+
+    DWORD count = 0;
+    sc2BaseFrame_t *frames = SC2_LayoutGetFrames(&count);
+
+    /* HiddenPanel and CenterAlert should have SC2_UIFLAG_HIDDEN set */
+    sc2BaseFrame_t *hidden = find_frame(frames, count, "HiddenPanel");
+    sc2BaseFrame_t *alert = find_frame(frames, count, "CenterAlert");
+    ASSERT_NOT_NULL(hidden);
+    ASSERT_NOT_NULL(alert);
+    ASSERT(hidden->ui_flags & SC2_UIFLAG_HIDDEN);
+    ASSERT(alert->ui_flags & SC2_UIFLAG_HIDDEN);
+
+    /* MineralIcon should NOT have SC2_UIFLAG_HIDDEN */
+    sc2BaseFrame_t *icon = find_frame(frames, count, "MineralIcon");
+    ASSERT_NOT_NULL(icon);
+    ASSERT(!(icon->ui_flags & SC2_UIFLAG_HIDDEN));
+
+    SC2_LayoutShutdown();
+}
+
+/* =====================================================================
+ * Test runner
+ * ===================================================================== */
+
+void run_sc2_consoleui_tests(void) {
+    /* Group 1: Parser bug regression */
+    RUN_TEST(test_adapter_constant_hash_stripping);
+    RUN_TEST(test_adapter_constant_offset_resolves);
+    RUN_TEST(test_adapter_template_inheritance_ordering);
+    RUN_TEST(test_adapter_cross_file_template_inheritance);
+
+    /* Group 2: Anchor resolution */
+    RUN_TEST(test_adapter_single_anchor_left_min);
+    RUN_TEST(test_adapter_single_anchor_top_min);
+    RUN_TEST(test_adapter_dual_anchor_stretch);
+    RUN_TEST(test_adapter_mid_anchor);
+    RUN_TEST(test_adapter_cross_frame_relative);
+
+    /* Group 3: Flatten / frame population */
+    RUN_TEST(test_adapter_flatten_frame_count);
+    RUN_TEST(test_adapter_flatten_types_mapped);
+    RUN_TEST(test_adapter_flatten_hidden_flags);
+    RUN_TEST(test_adapter_flatten_color_alpha);
+
+    /* Group 4: Screen rect pipeline */
+    RUN_TEST(test_adapter_root_parent_is_scene);
+    RUN_TEST(test_adapter_cross_frame_relative_index);
+    RUN_TEST(test_adapter_hidden_flagged_for_skip);
+}

--- a/games/starcraft-2/tests/test_sc2_layout.c
+++ b/games/starcraft-2/tests/test_sc2_layout.c
@@ -1,0 +1,374 @@
+/*
+ * test_sc2_layout.c — SC2 .SC2Layout XML parser fixture tests.
+ *
+ * Tests parsing of custom .SC2Layout fixtures packed into the test MPQ,
+ * verifying frame hierarchy, template inheritance, anchor resolution,
+ * constants, include resolution, and frame tree flattening.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "common.h"
+#include "games/starcraft-2/ui/sc2_layout.h"
+#include "test_framework.h"
+
+/* Define the uiimport global that sc2_layout.c references via extern */
+uiImport_t uiimport;
+
+#ifndef TEST_SC2_MPQ
+#define TEST_SC2_MPQ "build/tests/test-sc2.SC2Maps"
+#endif
+
+static BOOL sc2_layout_tests_initialized;
+
+static void setup_sc2_layout_tests(void) {
+    if (sc2_layout_tests_initialized) return;
+
+    LPCSTR argv[] = { "test_sc2_layout", "-config", "" };
+    Com_Init(3, argv);
+    ASSERT(FS_AddArchive(TEST_SC2_MPQ) != NULL);
+
+    /* Set up the uiimport table so SC2_LayoutParseFile can read from the MPQ */
+    memset(&uiimport, 0, sizeof(uiimport));
+    uiimport.FS_ReadFile = FS_ReadFileQ3;
+    uiimport.FS_FreeFile = FS_FreeFile;
+    uiimport.Printf = (void (*)(LPCSTR, ...))printf;
+
+    sc2_layout_tests_initialized = true;
+}
+
+/* ---- Test: constants are parsed and resolvable ---- */
+static void test_layout_constants_parsed(void) {
+    setup_sc2_layout_tests();
+    SC2_LayoutInit();
+    ASSERT(SC2_LayoutParseFile("UI/Layout/TestConstants.SC2Layout"));
+
+    LPCSTR red = SC2_LayoutResolveConstant("##TestColorRed");
+    ASSERT_NOT_NULL(red);
+    ASSERT_STR_EQ(red, "255,0,0");
+
+    LPCSTR green = SC2_LayoutResolveConstant("##TestColorGreen");
+    ASSERT_NOT_NULL(green);
+    ASSERT_STR_EQ(green, "0,255,0");
+
+    LPCSTR gap = SC2_LayoutResolveConstant("##TestGap");
+    ASSERT_NOT_NULL(gap);
+    ASSERT_STR_EQ(gap, "4");
+
+    SC2_LayoutShutdown();
+}
+
+/* ---- Test: unknown constants return NULL ---- */
+static void test_layout_unknown_constant_returns_null(void) {
+    setup_sc2_layout_tests();
+    SC2_LayoutInit();
+
+    ASSERT_NULL(SC2_LayoutResolveConstant("##Nonexistent"));
+
+    SC2_LayoutShutdown();
+}
+
+/* ---- Test: include resolution loads child file ---- */
+static void test_layout_include_resolves(void) {
+    setup_sc2_layout_tests();
+    SC2_LayoutInit();
+    ASSERT(SC2_LayoutParseFile("UI/Layout/TestIncluded.SC2Layout"));
+
+    sc2Frame_t *frame = SC2_LayoutFindTemplate("IncludedFrame");
+    ASSERT_NOT_NULL(frame);
+    ASSERT_STR_EQ(frame->name, "IncludedFrame");
+    ASSERT_EQ_INT(frame->type, SC2_FRAMETYPE_FRAME);
+    ASSERT(frame->flags & SC2_FRAME_HAS_WIDTH);
+    ASSERT_EQ_FLOAT(frame->width, 100.0f, 0.01f);
+    ASSERT(frame->flags & SC2_FRAME_HAS_HEIGHT);
+    ASSERT_EQ_FLOAT(frame->height, 50.0f, 0.01f);
+    ASSERT(frame->flags & SC2_FRAME_HAS_VISIBLE);
+    ASSERT(frame->flags & SC2_FRAME_VISIBLE);
+
+    SC2_LayoutShutdown();
+}
+
+/* ---- Test: template inheritance — child inherits parent properties ---- */
+static void test_layout_template_inheritance(void) {
+    setup_sc2_layout_tests();
+    SC2_LayoutInit();
+    ASSERT(SC2_LayoutParseFile("UI/Layout/TestTemplates.SC2Layout"));
+
+    /* Base template: 200x100 */
+    sc2Frame_t *base = SC2_LayoutFindTemplate("TestBaseTemplate");
+    ASSERT_NOT_NULL(base);
+    ASSERT(base->flags & SC2_FRAME_HAS_WIDTH);
+    ASSERT_EQ_FLOAT(base->width, 200.0f, 0.01f);
+    ASSERT(base->flags & SC2_FRAME_HAS_HEIGHT);
+    ASSERT_EQ_FLOAT(base->height, 100.0f, 0.01f);
+    ASSERT_EQ_INT(base->num_anchors, 2);
+
+    /* Button template inherits from base, overrides width/height */
+    sc2Frame_t *button = SC2_LayoutFindTemplate("TestButtonTemplate");
+    ASSERT_NOT_NULL(button);
+    ASSERT(button->flags & SC2_FRAME_HAS_WIDTH);
+    ASSERT_EQ_FLOAT(button->width, 300.0f, 0.01f);
+    ASSERT(button->flags & SC2_FRAME_HAS_HEIGHT);
+    ASSERT_EQ_FLOAT(button->height, 75.0f, 0.01f);
+    /* Should have 3 anchors: 2 inherited from base + 1 own */
+    ASSERT_EQ_INT(button->num_anchors, 3);
+
+    SC2_LayoutShutdown();
+}
+
+/* ---- Test: template with nested children ---- */
+static void test_layout_template_children(void) {
+    setup_sc2_layout_tests();
+    SC2_LayoutInit();
+    ASSERT(SC2_LayoutParseFile("UI/Layout/TestTemplates.SC2Layout"));
+
+    sc2Frame_t *container = SC2_LayoutFindTemplate("TestContainerTemplate");
+    ASSERT_NOT_NULL(container);
+    ASSERT_EQ_INT(container->num_children, 2);
+
+    /* First child: Background image */
+    sc2Frame_t *bg = container->children[0];
+    ASSERT_NOT_NULL(bg);
+    ASSERT_STR_EQ(bg->name, "Background");
+    ASSERT_EQ_INT(bg->type, SC2_FRAMETYPE_IMAGE);
+    ASSERT(bg->num_textures > 0);
+    ASSERT(bg->textures[0].flags & SC2_TEX_HAS_TEXTURE);
+
+    /* Second child: TitleLabel */
+    sc2Frame_t *label = container->children[1];
+    ASSERT_NOT_NULL(label);
+    ASSERT_STR_EQ(label->name, "TitleLabel");
+    ASSERT_EQ_INT(label->type, SC2_FRAMETYPE_LABEL);
+
+    SC2_LayoutShutdown();
+}
+
+/* ---- Test: full GameUI parse with includes, templates, and nesting ---- */
+static void test_layout_gameui_full_parse(void) {
+    setup_sc2_layout_tests();
+    SC2_LayoutInit();
+    ASSERT(SC2_LayoutParseFile("UI/Layout/TestGameUI.SC2Layout"));
+
+    /* Root GameUI frame should exist */
+    sc2Frame_t *gameui = SC2_LayoutFindTemplate("TestGameUI");
+    ASSERT_NOT_NULL(gameui);
+    ASSERT_EQ_INT(gameui->type, SC2_FRAMETYPE_GAME_UI);
+
+    /* Should have 4 children: IncludedPanel, ActionButton01, InfoPanel, CommandArea */
+    ASSERT(gameui->num_children >= 4);
+
+    /* Check IncludedPanel uses the included template */
+    sc2Frame_t *included = gameui->children[0];
+    ASSERT_NOT_NULL(included);
+    ASSERT_STR_EQ(included->name, "IncludedPanel");
+    ASSERT(included->flags & SC2_FRAME_HAS_WIDTH);
+    ASSERT_EQ_FLOAT(included->width, 100.0f, 0.01f);
+
+    /* Check ActionButton01 inherits from TestButtonTemplate (300x75) */
+    sc2Frame_t *button = gameui->children[1];
+    ASSERT_NOT_NULL(button);
+    ASSERT_STR_EQ(button->name, "ActionButton01");
+    ASSERT(button->flags & SC2_FRAME_HAS_WIDTH);
+    ASSERT_EQ_FLOAT(button->width, 300.0f, 0.01f);
+    ASSERT(button->flags & SC2_FRAME_HAS_HEIGHT);
+    ASSERT_EQ_FLOAT(button->height, 75.0f, 0.01f);
+
+    SC2_LayoutShutdown();
+}
+
+/* ---- Test: deeply nested children in GameUI ---- */
+static void test_layout_nested_children(void) {
+    setup_sc2_layout_tests();
+    SC2_LayoutInit();
+    ASSERT(SC2_LayoutParseFile("UI/Layout/TestGameUI.SC2Layout"));
+
+    sc2Frame_t *gameui = SC2_LayoutFindTemplate("TestGameUI");
+    ASSERT_NOT_NULL(gameui);
+
+    /* Find the CommandArea frame */
+    sc2Frame_t *cmd_area = NULL;
+    for (int i = 0; i < gameui->num_children; i++) {
+        if (!strcasecmp(gameui->children[i]->name, "CommandArea")) {
+            cmd_area = gameui->children[i];
+            break;
+        }
+    }
+    ASSERT_NOT_NULL(cmd_area);
+    ASSERT(cmd_area->flags & SC2_FRAME_HAS_WIDTH);
+    ASSERT_EQ_FLOAT(cmd_area->width, 450.0f, 0.01f);
+    ASSERT(cmd_area->flags & SC2_FRAME_HAS_HEIGHT);
+    ASSERT_EQ_FLOAT(cmd_area->height, 300.0f, 0.01f);
+
+    /* CommandArea should have 4 children: CommandBackground, Cmd01, Cmd02, UnitName */
+    ASSERT_EQ_INT(cmd_area->num_children, 4);
+
+    /* Cmd01 and Cmd02 should be buttons with 76x76 */
+    sc2Frame_t *cmd01 = cmd_area->children[1];
+    ASSERT_NOT_NULL(cmd01);
+    ASSERT_STR_EQ(cmd01->name, "Cmd01");
+    ASSERT_EQ_INT(cmd01->type, SC2_FRAMETYPE_BUTTON);
+    ASSERT(cmd01->flags & SC2_FRAME_HAS_WIDTH);
+    ASSERT_EQ_FLOAT(cmd01->width, 76.0f, 0.01f);
+
+    sc2Frame_t *cmd02 = cmd_area->children[2];
+    ASSERT_NOT_NULL(cmd02);
+    ASSERT_STR_EQ(cmd02->name, "Cmd02");
+    ASSERT(cmd02->flags & SC2_FRAME_HAS_WIDTH);
+    ASSERT_EQ_FLOAT(cmd02->width, 76.0f, 0.01f);
+
+    SC2_LayoutShutdown();
+}
+
+/* ---- Test: anchor parsing ---- */
+static void test_layout_anchors_parsed(void) {
+    setup_sc2_layout_tests();
+    SC2_LayoutInit();
+    ASSERT(SC2_LayoutParseFile("UI/Layout/TestTemplates.SC2Layout"));
+
+    sc2Frame_t *base = SC2_LayoutFindTemplate("TestBaseTemplate");
+    ASSERT_NOT_NULL(base);
+    ASSERT_EQ_INT(base->num_anchors, 2);
+
+    /* First anchor: Top, Min, offset 0 */
+    ASSERT_EQ_INT(base->anchors[0].side, SC2_SIDE_TOP);
+    ASSERT_EQ_INT(base->anchors[0].pos, SC2_POS_MIN);
+    ASSERT_EQ_INT(base->anchors[0].offset, 0);
+    ASSERT_STR_EQ(base->anchors[0].relative, "$parent");
+
+    /* Second anchor: Left, Min, offset 0 */
+    ASSERT_EQ_INT(base->anchors[1].side, SC2_SIDE_LEFT);
+    ASSERT_EQ_INT(base->anchors[1].pos, SC2_POS_MIN);
+
+    SC2_LayoutShutdown();
+}
+
+/* ---- Test: texture references parsed ---- */
+static void test_layout_textures_parsed(void) {
+    setup_sc2_layout_tests();
+    SC2_LayoutInit();
+    ASSERT(SC2_LayoutParseFile("UI/Layout/TestTemplates.SC2Layout"));
+
+    sc2Frame_t *container = SC2_LayoutFindTemplate("TestContainerTemplate");
+    ASSERT_NOT_NULL(container);
+
+    /* Background image child has a texture */
+    sc2Frame_t *bg = container->children[0];
+    ASSERT_NOT_NULL(bg);
+    ASSERT(bg->num_textures > 0);
+    ASSERT(bg->textures[0].flags & SC2_TEX_HAS_TEXTURE);
+    ASSERT_STR_EQ(bg->textures[0].resource, "@@Test/Background");
+
+    SC2_LayoutShutdown();
+}
+
+/* ---- Test: frame tree flattening ---- */
+static void test_layout_flatten_to_frames(void) {
+    setup_sc2_layout_tests();
+    SC2_LayoutInit();
+    ASSERT(SC2_LayoutParseFile("UI/Layout/TestGameUI.SC2Layout"));
+    ASSERT(SC2_LayoutFlatten("TestGameUI"));
+
+    /* Build the frame array from the TestGameUI root */
+    DWORD count = 0;
+    sc2BaseFrame_t *frames = SC2_LayoutGetFrames(&count);
+
+    /* Should have at least the GameUI frame and its direct children */
+    ASSERT(count >= 5);
+
+    /* First frame should be the root TestGameUI */
+    ASSERT_EQ_INT(frames[0].type, FT_FRAME);
+    ASSERT(frames[0].size.width > 0 || frames[0].size.height > 0 ||
+           frames[0].parent_index == (DWORD)-1);
+
+    SC2_LayoutShutdown();
+}
+
+/* ---- Test: multiple parses accumulate templates ---- */
+static void test_layout_multiple_parses(void) {
+    setup_sc2_layout_tests();
+    SC2_LayoutInit();
+
+    ASSERT(SC2_LayoutParseFile("UI/Layout/TestConstants.SC2Layout"));
+    ASSERT(SC2_LayoutParseFile("UI/Layout/TestIncluded.SC2Layout"));
+
+    /* Both should be findable */
+    ASSERT_NOT_NULL(SC2_LayoutFindTemplate("IncludedFrame"));
+    LPCSTR red = SC2_LayoutResolveConstant("##TestColorRed");
+    ASSERT_NOT_NULL(red);
+
+    SC2_LayoutShutdown();
+}
+
+/* ---- Test: reinit clears state ---- */
+static void test_layout_reinit_clears(void) {
+    setup_sc2_layout_tests();
+    SC2_LayoutInit();
+    ASSERT(SC2_LayoutParseFile("UI/Layout/TestIncluded.SC2Layout"));
+    ASSERT_NOT_NULL(SC2_LayoutFindTemplate("IncludedFrame"));
+
+    SC2_LayoutShutdown();
+    SC2_LayoutInit();
+
+    /* After reinit, template should not be found */
+    ASSERT_NULL(SC2_LayoutFindTemplate("IncludedFrame"));
+
+    SC2_LayoutShutdown();
+}
+
+/* ---- Test: constant reference in anchor offset ---- */
+static void test_layout_constant_offset(void) {
+    setup_sc2_layout_tests();
+    SC2_LayoutInit();
+    ASSERT(SC2_LayoutParseFile("UI/Layout/TestGameUI.SC2Layout"));
+
+    sc2Frame_t *gameui = SC2_LayoutFindTemplate("TestGameUI");
+    ASSERT_NOT_NULL(gameui);
+
+    /* ActionButton01 has anchor with #TestGap offset (should be "4") */
+    sc2Frame_t *button = gameui->children[1];
+    ASSERT_NOT_NULL(button);
+    ASSERT(button->num_anchors > 0);
+
+    /* The constant value "4" should have been parsed as offset 4 */
+    ASSERT_EQ_INT(button->anchors[0].offset, 4);
+
+    SC2_LayoutShutdown();
+}
+
+/* ---- Test: multiple textures (layers) ---- */
+static void test_layout_texture_layers(void) {
+    setup_sc2_layout_tests();
+    SC2_LayoutInit();
+    ASSERT(SC2_LayoutParseFile("UI/Layout/TestTemplates.SC2Layout"));
+
+    /* TestColorBox has no textures defined — verify empty state */
+    sc2Frame_t *box = SC2_LayoutFindTemplate("TestColorBox");
+    ASSERT_NOT_NULL(box);
+    ASSERT_EQ_INT(box->num_textures, 0);
+
+    /* Background has exactly 1 texture */
+    sc2Frame_t *container = SC2_LayoutFindTemplate("TestContainerTemplate");
+    ASSERT_NOT_NULL(container);
+    sc2Frame_t *bg = container->children[0];
+    ASSERT_EQ_INT(bg->num_textures, 1);
+
+    SC2_LayoutShutdown();
+}
+
+void run_sc2_layout_tests(void) {
+    RUN_TEST(test_layout_constants_parsed);
+    RUN_TEST(test_layout_unknown_constant_returns_null);
+    RUN_TEST(test_layout_include_resolves);
+    RUN_TEST(test_layout_template_inheritance);
+    RUN_TEST(test_layout_template_children);
+    RUN_TEST(test_layout_gameui_full_parse);
+    RUN_TEST(test_layout_nested_children);
+    RUN_TEST(test_layout_anchors_parsed);
+    RUN_TEST(test_layout_textures_parsed);
+    RUN_TEST(test_layout_flatten_to_frames);
+    RUN_TEST(test_layout_multiple_parses);
+    RUN_TEST(test_layout_reinit_clears);
+    RUN_TEST(test_layout_constant_offset);
+    RUN_TEST(test_layout_texture_layers);
+}

--- a/games/starcraft-2/tests/test_sc2_main.c
+++ b/games/starcraft-2/tests/test_sc2_main.c
@@ -10,12 +10,22 @@ int _tests_run    = 0;
 int _tests_failed = 0;
 
 void run_sc2_map_tests(void);
+void run_sc2_layout_tests(void);
+void run_sc2_consoleui_tests(void);
 
 int main(void) {
     printf("=== OpenWarcraft3 StarCraft II Tests ===\n\n");
 
     printf("[SC2 map archives / parser]\n");
     run_sc2_map_tests();
+    printf("\n");
+
+    printf("[SC2 layout XML parser]\n");
+    run_sc2_layout_tests();
+    printf("\n");
+
+    printf("[SC2 ConsoleUI adapter]\n");
+    run_sc2_consoleui_tests();
     printf("\n");
 
     TEST_RESULTS();

--- a/games/starcraft-2/ui/sc2_layout.c
+++ b/games/starcraft-2/ui/sc2_layout.c
@@ -1,0 +1,1211 @@
+/*
+ * sc2_layout.c — SC2 .SC2Layout XML parser and frame builder.
+ *
+ * Parses StarCraft II UI layout files (.SC2Layout) into sc2BaseFrame_t arrays.
+ * Uses libxml2 for XML parsing (already linked for sc2_map.c).
+ *
+ * Format overview:
+ *   <Desc>
+ *     <Include path="UI/Layout/..."/>
+ *     <Constant name="..." val="r,g,b"/>
+ *     <Frame type="Button" name="..." template="Path/Template">
+ *       <Width val="300"/>
+ *       <Height val="101"/>
+ *       <Anchor side="Top" relative="$parent" pos="Min" offset="0"/>
+ *       <Texture val="@@UI/TextureName" layer="0"/>
+ *       <Frame type="Image" name="ChildName">...</Frame>
+ *     </Frame>
+ *   </Desc>
+ *
+ * Phase 1: Parse XML into sc2Frame_t tree, resolve templates and constants,
+ *          produce flat sc2BaseFrame_t array for client rendering.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <ctype.h>
+
+#include "sc2_layout.h"
+#include <libxml/parser.h>
+#include <libxml/tree.h>
+
+extern uiImport_t uiimport;
+
+#ifndef CLAMP
+#define CLAMP(x, lo, hi) ((x) < (lo) ? (lo) : (x) > (hi) ? (hi) : (x))
+#endif
+
+/* Safe string copy with null termination */
+static void SC2_Strncpyz(char *dst, LPCSTR src, size_t dst_size) {
+    if (!dst || dst_size == 0) return;
+    if (!src) { dst[0] = '\0'; return; }
+    strncpy(dst, src, dst_size - 1);
+    dst[dst_size - 1] = '\0';
+}
+
+/* Wrapper for xmlGetProp that returns const char* without warnings */
+static LPCSTR SC2_XmlGetProp(xmlNode *node, LPCSTR name) {
+    xmlChar *val = xmlGetProp(node, (const xmlChar *)name);
+    return (const char *)val;
+}
+
+/* Free a string returned by SC2_XmlGetProp */
+static void SC2_XmlFree(LPCSTR s) {
+    if (s) xmlFree((xmlChar *)s);
+}
+
+/* Global layout state */
+static sc2Layout_t sc2_layout;
+
+/* Frame type name → sc2FrameType mapping table */
+static struct { LPCSTR name; sc2FrameType type; } sc2_frame_types[] = {
+    { "Frame",                  SC2_FRAMETYPE_FRAME },
+    { "Button",                 SC2_FRAMETYPE_BUTTON },
+    { "Image",                  SC2_FRAMETYPE_IMAGE },
+    { "Label",                  SC2_FRAMETYPE_LABEL },
+    { "EditBox",                SC2_FRAMETYPE_EDITBOX },
+    { "Tooltip",                SC2_FRAMETYPE_TOOLTIP },
+    { "Model",                  SC2_FRAMETYPE_MODEL },
+    { "ConsolePanel",           SC2_FRAMETYPE_CONSOLE_PANEL },
+    { "CommandPanel",           SC2_FRAMETYPE_COMMAND_PANEL },
+    { "CommandButton",          SC2_FRAMETYPE_COMMAND_BUTTON },
+    { "CommandTooltip",         SC2_FRAMETYPE_COMMAND_TOOLTIP },
+    { "InfoPanel",              SC2_FRAMETYPE_INFO_PANEL },
+    { "MinimapPanel",           SC2_FRAMETYPE_MINIMAP_PANEL },
+    { "Minimap",                SC2_FRAMETYPE_MINIMAP },
+    { "ResourcePanel",          SC2_FRAMETYPE_RESOURCE_PANEL },
+    { "PortraitPanel",          SC2_FRAMETYPE_PORTRAIT_PANEL },
+    { "GameUI",                 SC2_FRAMETYPE_GAME_UI },
+    { "WorldPanel",             SC2_FRAMETYPE_WORLD_PANEL },
+    { "CountdownLabel",         SC2_FRAMETYPE_COUNTDOWN_LABEL },
+    { "HeroPanel",              SC2_FRAMETYPE_HERO_PANEL },
+    { "InventoryPanel",         SC2_FRAMETYPE_INVENTORY_PANEL },
+    { "IdleButton",             SC2_FRAMETYPE_IDLE_BUTTON },
+    { "AIButton",               SC2_FRAMETYPE_AI_BUTTON },
+    { "PylonButton",            SC2_FRAMETYPE_PYLON_BUTTON },
+    { "MessageDisplay",         SC2_FRAMETYPE_MESSAGE_DISPLAY },
+    { "AlertPanel",             SC2_FRAMETYPE_ALERT_PANEL },
+    { "AlertDisplay",           SC2_FRAMETYPE_ALERT_DISPLAY },
+    { "ChatBar",                SC2_FRAMETYPE_CHAT_BAR },
+    { "MenuBar",                SC2_FRAMETYPE_MENU_BAR },
+    { "SubtitlePanel",          SC2_FRAMETYPE_SUBTITLE_PANEL },
+    { "TimePanel",              SC2_FRAMETYPE_TIME_PANEL },
+    { "CreditsPanel",           SC2_FRAMETYPE_CREDITS_PANEL },
+    { "ControlGroupPanel",      SC2_FRAMETYPE_CONTROL_GROUP_PANEL },
+    { "MinimapPanelTooltip",    SC2_FRAMETYPE_MINIMAP_PANEL_TOOLTIP },
+    { "RevealPanel",            SC2_FRAMETYPE_REVEAL_PANEL },
+    { "AlliancePanel",          SC2_FRAMETYPE_ALLIANCE_PANEL },
+    { "TeamResourcePanel",      SC2_FRAMETYPE_TEAM_RESOURCE_PANEL },
+    { "LeaderPanel",            SC2_FRAMETYPE_LEADER_PANEL },
+    { "ObserverPanelContainer", SC2_FRAMETYPE_OBSERVER_PANEL },
+    { "ReplayPanelContainer",   SC2_FRAMETYPE_REPLAY_PANEL },
+    { "TalkerPanel",            SC2_FRAMETYPE_TALKER_PANEL },
+    { "PurchasePanel",          SC2_FRAMETYPE_PURCHASE_PANEL },
+    { "ResearchPanel",          SC2_FRAMETYPE_RESEARCH_PANEL },
+    { "PlanetPanelContainer",   SC2_FRAMETYPE_PLANET_PANEL },
+    { "CashPanel",              SC2_FRAMETYPE_CASH_PANEL },
+    { "ResourceRequestAlertPanel", SC2_FRAMETYPE_RESOURCE_REQUEST_ALERT },
+    { "PausePanel",             SC2_FRAMETYPE_PAUSE_PANEL },
+    { "ConversationPanel",      SC2_FRAMETYPE_CONVERSATION_PANEL },
+    { "ObjectivePanel",         SC2_FRAMETYPE_OBJECTIVE_PANEL },
+    { "TriggerDialogFrame",     SC2_FRAMETYPE_TRIGGER_DIALOG },
+    { "TriggerWindowPanel",     SC2_FRAMETYPE_TRIGGER_WINDOW },
+    { "SystemAlertPanel",       SC2_FRAMETYPE_SYSTEM_ALERT_PANEL },
+    { "TipAlertPanel",          SC2_FRAMETYPE_TIP_ALERT },
+    { "TipAlertMovingFrame",    SC2_FRAMETYPE_TIP_ALERT_MOVING },
+    { "CinematicTextPanel",     SC2_FRAMETYPE_CINEMATIC_TEXT },
+    { "TextCrawlPanel",         SC2_FRAMETYPE_TEXT_CRAWL },
+    { "FlashFrame",             SC2_FRAMETYPE_FLASH_FRAME },
+    { "LeroyButton",            SC2_FRAMETYPE_LEROY_BUTTON },
+    { "MapInfoPanel",           SC2_FRAMETYPE_MAP_INFO_PANEL },
+    { "PerfOverlay",            SC2_FRAMETYPE_PERF_OVERLAY },
+    { "ProfilerOptions",        SC2_FRAMETYPE_PROFILER },
+    { "AchievementPanel",       SC2_FRAMETYPE_ACHIEVEMENT_PANEL },
+    { "ScreenCredits",          SC2_FRAMETYPE_SCREEN_CREDITS },
+    { NULL, SC2_FRAMETYPE_UNKNOWN },
+};
+
+/* Anchor side name → SC2Side mapping */
+static struct { LPCSTR name; SC2Side side; } sc2_sides[] = {
+    { "Top",    SC2_SIDE_TOP },
+    { "Bottom", SC2_SIDE_BOTTOM },
+    { "Left",   SC2_SIDE_LEFT },
+    { "Right",  SC2_SIDE_RIGHT },
+    { NULL, -1 },
+};
+
+/* Anchor position name → SC2Pos mapping */
+static struct { LPCSTR name; SC2Pos pos; } sc2_positions[] = {
+    { "Min", SC2_POS_MIN },
+    { "Mid", SC2_POS_MID },
+    { "Max", SC2_POS_MAX },
+    { NULL, -1 },
+};
+
+/* ---------- Utility ---------- */
+
+static sc2FrameType SC2_LookupFrameType(LPCSTR name) {
+    for (int i = 0; sc2_frame_types[i].name; i++) {
+        if (!strcasecmp(sc2_frame_types[i].name, name))
+            return sc2_frame_types[i].type;
+    }
+    return SC2_FRAMETYPE_UNKNOWN;
+}
+
+static SC2Side SC2_LookupSide(LPCSTR name) {
+    for (int i = 0; sc2_sides[i].name; i++) {
+        if (!strcasecmp(sc2_sides[i].name, name))
+            return sc2_sides[i].side;
+    }
+    return -1;
+}
+
+static SC2Pos SC2_LookupPos(LPCSTR name) {
+    for (int i = 0; sc2_positions[i].name; i++) {
+        if (!strcasecmp(sc2_positions[i].name, name))
+            return sc2_positions[i].pos;
+    }
+    return -1;
+}
+
+static BOOL xmlGetAttrBool(xmlNode *node, LPCSTR name, BOOL *out) {
+    LPCSTR val = SC2_XmlGetProp(node, name);
+    if (!val) return false;
+    *out = (!strcasecmp(val, "true") || !strcasecmp(val, "1") || !strcasecmp(val, "True"));
+    SC2_XmlFree(val);
+    return true;
+}
+
+static BOOL xmlGetAttrFloat(xmlNode *node, LPCSTR name, FLOAT *out) {
+    LPCSTR val = SC2_XmlGetProp(node, name);
+    if (!val) return false;
+    *out = (FLOAT)atof(val);
+    SC2_XmlFree(val);
+    return true;
+}
+
+static BOOL xmlGetAttrInt(xmlNode *node, LPCSTR name, int *out) {
+    LPCSTR val = SC2_XmlGetProp(node, name);
+    if (!val) return false;
+    *out = atoi(val);
+    SC2_XmlFree(val);
+    return true;
+}
+
+/* Parse "r,g,b" or "r,g,b,a" string into COLOR32 */
+static COLOR32 SC2_ParseColor(LPCSTR str) {
+    COLOR32 c = { 255, 255, 255, 255 };
+    if (!str) return c;
+    int r = 0, g = 0, b = 0, a = 255;
+    sscanf(str, "%d,%d,%d,%d", &r, &g, &b, &a);
+    c.r = (BYTE)CLAMP(r, 0, 255);
+    c.g = (BYTE)CLAMP(g, 0, 255);
+    c.b = (BYTE)CLAMP(b, 0, 255);
+    c.a = (BYTE)CLAMP(a, 0, 255);
+    return c;
+}
+
+/* ---------- Template registry ---------- */
+
+static sc2Frame_t *SC2_FindTemplate(LPCSTR name) {
+    if (!name) return NULL;
+    for (int i = 0; i < sc2_layout.num_templates; i++) {
+        if (!strcasecmp(sc2_layout.templates[i].name, name))
+            return &sc2_layout.templates[i];
+    }
+    return NULL;
+}
+
+static sc2Frame_t *SC2_AddTemplate(void) {
+    if (sc2_layout.num_templates >= SC2_MAX_TEMPLATES) {
+        fprintf(stderr, "SC2_Layout: template overflow\n");
+        return NULL;
+    }
+    return &sc2_layout.templates[sc2_layout.num_templates++];
+}
+
+/* ---------- Constant registry ---------- */
+
+static void SC2_AddConstant(LPCSTR name, LPCSTR val) {
+    if (sc2_layout.num_constants >= SC2_MAX_CONSTANTS) return;
+    sc2Constant_t *c = &sc2_layout.constants[sc2_layout.num_constants++];
+    SC2_Strncpyz(c->name, name, sizeof(c->name));
+    SC2_Strncpyz(c->val, val, sizeof(c->val));
+}
+
+LPCSTR SC2_LayoutResolveConstant(LPCSTR name) {
+    if (!name || name[0] != '#') return name;
+    while (*name == '#') name++; /* strip all leading '#' (SC2 uses ##Name) */
+    for (int i = 0; i < sc2_layout.num_constants; i++) {
+        if (!strcasecmp(sc2_layout.constants[i].name, name))
+            return sc2_layout.constants[i].val;
+    }
+    return NULL;
+}
+
+/* ---------- XML parsing ---------- */
+
+/* Forward declarations */
+static void SC2_ParseFrameAttrs(xmlNode *node, sc2Frame_t *frame);
+static void SC2_ParseFrameChildren(xmlNode *node, sc2Frame_t *frame);
+static void SC2_ParseAnchor(xmlNode *node, sc2Frame_t *frame);
+static void SC2_ParseTexture(xmlNode *node, sc2Frame_t *frame, int layer);
+static void SC2_ParseModel(xmlNode *node, sc2Frame_t *frame);
+static void SC2_ResolveTemplate(sc2Frame_t *frame, sc2Frame_t *tmpl);
+static void SC2_ResolveIncludes(xmlNode *node);
+
+/* Resolve template inheritance: clone template's children and properties */
+static void SC2_ResolveTemplate(sc2Frame_t *frame, sc2Frame_t *tmpl) {
+    if (!tmpl) return;
+
+    /* Inherit properties that aren't explicitly set */
+    if (!(frame->flags & SC2_FRAME_HAS_WIDTH) && (tmpl->flags & SC2_FRAME_HAS_WIDTH)) {
+        frame->width = tmpl->width;
+        frame->flags |= SC2_FRAME_HAS_WIDTH;
+    }
+    if (!(frame->flags & SC2_FRAME_HAS_HEIGHT) && (tmpl->flags & SC2_FRAME_HAS_HEIGHT)) {
+        frame->height = tmpl->height;
+        frame->flags |= SC2_FRAME_HAS_HEIGHT;
+    }
+    if (!(frame->flags & SC2_FRAME_HAS_VISIBLE) && (tmpl->flags & SC2_FRAME_HAS_VISIBLE)) {
+        if (tmpl->flags & SC2_FRAME_VISIBLE) frame->flags |= SC2_FRAME_VISIBLE;
+        else frame->flags &= ~SC2_FRAME_VISIBLE;
+        frame->flags |= SC2_FRAME_HAS_VISIBLE;
+    }
+    if (!(frame->flags & SC2_FRAME_HAS_COLOR) && (tmpl->flags & SC2_FRAME_HAS_COLOR)) {
+        frame->color = tmpl->color;
+        frame->flags |= SC2_FRAME_HAS_COLOR;
+    }
+    if (!(frame->flags & SC2_FRAME_HAS_ALPHA) && (tmpl->flags & SC2_FRAME_HAS_ALPHA)) {
+        frame->alpha = tmpl->alpha;
+        frame->flags |= SC2_FRAME_HAS_ALPHA;
+    }
+    if (!(frame->flags & SC2_FRAME_ACCEPTS_MOUSE)) {
+        if (tmpl->flags & SC2_FRAME_ACCEPTS_MOUSE) frame->flags |= SC2_FRAME_ACCEPTS_MOUSE;
+        else frame->flags &= ~SC2_FRAME_ACCEPTS_MOUSE;
+    }
+    if (!(frame->flags & SC2_FRAME_COLLAPSE_LAYOUT)) {
+        if (tmpl->flags & SC2_FRAME_COLLAPSE_LAYOUT) frame->flags |= SC2_FRAME_COLLAPSE_LAYOUT;
+        else frame->flags &= ~SC2_FRAME_COLLAPSE_LAYOUT;
+    }
+    if (!(frame->flags & SC2_FRAME_HIGHLIGHT_ON_HOVER)) {
+        if (tmpl->flags & SC2_FRAME_HIGHLIGHT_ON_HOVER) frame->flags |= SC2_FRAME_HIGHLIGHT_ON_HOVER;
+        else frame->flags &= ~SC2_FRAME_HIGHLIGHT_ON_HOVER;
+    }
+    if (!(frame->flags & SC2_FRAME_HIGHLIGHT_ON_FOCUS)) {
+        if (tmpl->flags & SC2_FRAME_HIGHLIGHT_ON_FOCUS) frame->flags |= SC2_FRAME_HIGHLIGHT_ON_FOCUS;
+        else frame->flags &= ~SC2_FRAME_HIGHLIGHT_ON_FOCUS;
+    }
+
+    /* Inherit anchors: template anchors are the base, frame's inline anchors
+     * override the same side or are appended if new. This matches SC2 behavior
+     * where the template provides base positioning and the frame can override
+     * specific sides. */
+    if (tmpl->num_anchors > 0) {
+        /* First, copy template anchors as the base */
+        int num = 0;
+        sc2Anchor_t merged[SC2_MAX_ANCHORS];
+        for (int i = 0; i < tmpl->num_anchors && num < SC2_MAX_ANCHORS; i++) {
+            merged[num++] = tmpl->anchors[i];
+        }
+        /* Then, for each frame anchor, either override same-side or append */
+        for (int i = 0; i < frame->num_anchors && num < SC2_MAX_ANCHORS; i++) {
+            BOOL found = false;
+            for (int j = 0; j < num; j++) {
+                if (merged[j].side == frame->anchors[i].side) {
+                    merged[j] = frame->anchors[i];
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                merged[num++] = frame->anchors[i];
+            }
+        }
+        memcpy(frame->anchors, merged, sizeof(merged));
+        frame->num_anchors = num;
+    }
+
+    /* Inherit textures if none set */
+    if (frame->num_textures == 0 && tmpl->num_textures > 0) {
+        for (int i = 0; i < tmpl->num_textures; i++) {
+            frame->textures[i] = tmpl->textures[i];
+            frame->num_textures++;
+        }
+    }
+
+    /* Clone template children (skip children that the frame already defines) */
+    for (int i = 0; i < tmpl->num_children && frame->num_children < SC2_MAX_CHILDREN; i++) {
+        sc2Frame_t *clone = SC2_AddTemplate();
+        if (!clone) break;
+        *clone = *tmpl->children[i];
+        /* Clear child pointers to avoid double-free; re-parent later */
+        clone->parent = frame;
+        clone->resolved_index = -1;
+        frame->children[frame->num_children++] = clone;
+    }
+}
+
+/* Resolve template path: "CommandButton/CommandButtonTemplate" → lookup by basename */
+static sc2Frame_t *SC2_ResolveTemplatePath(LPCSTR path) {
+    if (!path) return NULL;
+
+    /* Try exact match first */
+    sc2Frame_t *t = SC2_FindTemplate(path);
+    if (t) return t;
+
+    /* Try basename — SC2 templates are referenced as "Dir/Name" but
+     * registered with just "Name" */
+    LPCSTR slash = strrchr(path, '/');
+    if (slash) {
+        t = SC2_FindTemplate(slash + 1);
+        if (t) return t;
+    }
+
+    return NULL;
+}
+
+/* Parse <Include path="..."/> — load and parse referenced .SC2Layout file */
+static void SC2_ParseInclude(xmlNode *node) {
+    LPCSTR path = SC2_XmlGetProp(node,"path");
+    if (!path) return;
+
+    /* Check if already included */
+    for (int i = 0; i < sc2_layout.num_includes; i++) {
+        if (!strcasecmp(sc2_layout.included_files[i], path)) {
+            SC2_XmlFree(path);
+            return;
+        }
+    }
+
+    /* Track inclusion */
+    if (sc2_layout.num_includes < SC2_MAX_INCLUDES) {
+        SC2_Strncpyz(sc2_layout.included_files[sc2_layout.num_includes++], path, MAX_PATHLEN);
+    }
+
+    /* Parse the included file */
+    SC2_LayoutParseFile(path);
+    SC2_XmlFree(path);
+}
+
+/* Process all <Include> elements first (top-level pass) */
+static void SC2_ResolveIncludes(xmlNode *node) {
+    for (xmlNode *cur = node; cur; cur = cur->next) {
+        if (cur->type != XML_ELEMENT_NODE) continue;
+        if (!strcasecmp((const char *)cur->name, "Include")) {
+            SC2_ParseInclude(cur);
+        }
+    }
+}
+
+/* Parse <Constant name="..." val="..."/> */
+static void SC2_ParseConstant(xmlNode *node) {
+    LPCSTR name = SC2_XmlGetProp(node,"name");
+    LPCSTR val = SC2_XmlGetProp(node,"val");
+    if (name && val) {
+        SC2_AddConstant(name, val);
+    }
+    if (name) SC2_XmlFree(name);
+    if (val) SC2_XmlFree(val);
+}
+
+/* Read an integer attribute, resolving ##constant references first */
+static int SC2_ResolveAttrInt(xmlNode *node, LPCSTR attr, int default_val) {
+    LPCSTR raw = SC2_XmlGetProp(node, attr);
+    if (!raw) return default_val;
+    LPCSTR resolved = SC2_LayoutResolveConstant(raw);
+    int result = atoi(resolved ? resolved : raw);
+    SC2_XmlFree(raw);
+    return result;
+}
+
+/* Read a float attribute, resolving ##constant references first */
+static FLOAT SC2_ResolveAttrFloat(xmlNode *node, LPCSTR attr, FLOAT default_val) {
+    LPCSTR raw = SC2_XmlGetProp(node, attr);
+    if (!raw) return default_val;
+    LPCSTR resolved = SC2_LayoutResolveConstant(raw);
+    FLOAT result = (FLOAT)atof(resolved ? resolved : raw);
+    SC2_XmlFree(raw);
+    return result;
+}
+
+/* Parse <Anchor side="..." relative="..." pos="..." offset="..."/> */
+static void SC2_ParseAnchor(xmlNode *node, sc2Frame_t *frame) {
+    if (frame->num_anchors >= SC2_MAX_ANCHORS) return;
+
+    LPCSTR side_str = SC2_XmlGetProp(node,"side");
+    LPCSTR pos_str = SC2_XmlGetProp(node,"pos");
+    LPCSTR relative = SC2_XmlGetProp(node,"relative");
+
+    if (!side_str || !pos_str) {
+        if (side_str) SC2_XmlFree(side_str);
+        if (pos_str) SC2_XmlFree(pos_str);
+        if (relative) SC2_XmlFree(relative);
+        return;
+    }
+
+    sc2Anchor_t *a = &frame->anchors[frame->num_anchors];
+    a->side = SC2_LookupSide(side_str);
+    a->pos = SC2_LookupPos(pos_str);
+    a->offset = (int16_t)SC2_ResolveAttrInt(node, "offset", 0);
+    if (relative) {
+        SC2_Strncpyz(a->relative, relative, sizeof(a->relative));
+        SC2_XmlFree(relative);
+    } else {
+        SC2_Strncpyz(a->relative, "$parent", sizeof(a->relative));
+    }
+    a->flags |= SC2_ANCHOR_HAS;
+    frame->num_anchors++;
+
+    SC2_XmlFree(side_str);
+    SC2_XmlFree(pos_str);
+}
+
+/* Parse <Texture val="..." layer="..."/> */
+static void SC2_ParseTexture(xmlNode *node, sc2Frame_t *frame, int layer_override) {
+    int layer = layer_override;
+    xmlGetAttrInt(node, "layer", &layer);
+    if (layer < 0 || layer >= SC2_MAX_TEXTURES) layer = 0;
+
+    sc2Texture_t *tex = &frame->textures[layer];
+    LPCSTR val = SC2_XmlGetProp(node,"val");
+    if (val) {
+        SC2_Strncpyz(tex->resource, val, sizeof(tex->resource));
+        SC2_XmlFree(val);
+        tex->flags |= SC2_TEX_HAS_TEXTURE;
+    }
+    tex->layer = layer;
+
+    LPCSTR tiled = SC2_XmlGetProp(node,"tiled");
+    if (tiled) {
+        if (!strcasecmp(tiled, "true") || !strcasecmp(tiled, "1"))
+            tex->flags |= SC2_TEX_TILED;
+        else
+            tex->flags &= ~SC2_TEX_TILED;
+        SC2_XmlFree(tiled);
+    }
+
+    if (frame->num_textures <= layer)
+        frame->num_textures = layer + 1;
+}
+
+/* Parse <Model val="..." ...> child elements */
+static void SC2_ParseModel(xmlNode *node, sc2Frame_t *frame) {
+    LPCSTR val = SC2_XmlGetProp(node,"val");
+    if (val) {
+        /* Store model reference in the first texture slot */
+        sc2Texture_t *tex = &frame->textures[0];
+        SC2_Strncpyz(tex->resource, val, sizeof(tex->resource));
+        tex->flags |= SC2_TEX_HAS_TEXTURE;
+        frame->num_textures = 1;
+        SC2_XmlFree(val);
+    }
+}
+
+/* Parse a single frame's XML attributes */
+static void SC2_ParseFrameAttrs(xmlNode *node, sc2Frame_t *frame) {
+    /* type attribute */
+    LPCSTR type_str = SC2_XmlGetProp(node,"type");
+    if (type_str) {
+        frame->type = SC2_LookupFrameType(type_str);
+        SC2_XmlFree(type_str);
+    } else {
+        frame->type = SC2_FRAMETYPE_FRAME;
+    }
+
+    /* name attribute */
+    LPCSTR name = SC2_XmlGetProp(node,"name");
+    if (name) {
+        SC2_Strncpyz(frame->name, name, sizeof(frame->name));
+        SC2_XmlFree(name);
+    }
+
+    /* template attribute */
+    LPCSTR tmpl = SC2_XmlGetProp(node,"template");
+    if (tmpl) {
+        SC2_Strncpyz(frame->template_path, tmpl, sizeof(frame->template_path));
+        SC2_XmlFree(tmpl);
+    }
+
+    /* Image attribute (for tooltip border references) */
+    LPCSTR image = SC2_XmlGetProp(node,"Image");
+    if (image) {
+        SC2_Strncpyz(frame->image_ref, image, sizeof(frame->image_ref));
+        SC2_XmlFree(image);
+    }
+
+    frame->resolved_index = -1;
+}
+
+/* Parse child elements of a <Frame> node */
+static void SC2_ParseFrameChildren(xmlNode *node, sc2Frame_t *frame) {
+    for (xmlNode *cur = node->children; cur; cur = cur->next) {
+        if (cur->type != XML_ELEMENT_NODE) continue;
+        LPCSTR tag = (const char *)cur->name;
+
+        if (!strcasecmp(tag, "Width")) {
+            frame->width = SC2_ResolveAttrFloat(cur, "val", 0.0f);
+            frame->flags |= SC2_FRAME_HAS_WIDTH;
+        } else if (!strcasecmp(tag, "Height")) {
+            frame->height = SC2_ResolveAttrFloat(cur, "val", 0.0f);
+            frame->flags |= SC2_FRAME_HAS_HEIGHT;
+        } else if (!strcasecmp(tag, "Anchor")) {
+            SC2_ParseAnchor(cur, frame);
+        } else if (!strcasecmp(tag, "Texture")) {
+            SC2_ParseTexture(cur, frame, -1);
+        } else if (!strcasecmp(tag, "TextureType")) {
+            int layer = 0;
+            xmlGetAttrInt(cur, "layer", &layer);
+            if (layer >= 0 && layer < SC2_MAX_TEXTURES) {
+                LPCSTR val = SC2_XmlGetProp(cur, "val");
+                if (val) {
+                    SC2_Strncpyz(frame->textures[layer].texture_type, val, sizeof(frame->textures[0].texture_type));
+                    SC2_XmlFree(val);
+                }
+            }
+        } else if (!strcasecmp(tag, "StateCount")) {
+            /* Used for texture state counts; store in texture layer */
+            int layer = 0;
+            xmlGetAttrInt(cur, "layer", &layer);
+        } else if (!strcasecmp(tag, "LayerCount")) {
+            int val = 0;
+            if (xmlGetAttrInt(cur, "val", &val)) {
+                if (val > frame->num_textures)
+                    frame->num_textures = val;
+            }
+        } else if (!strcasecmp(tag, "Visible")) {
+            LPCSTR val = SC2_XmlGetProp(cur, "val");
+            if (val) {
+                if (!strcasecmp(val, "true") || !strcasecmp(val, "1"))
+                    frame->flags |= SC2_FRAME_VISIBLE;
+                else
+                    frame->flags &= ~SC2_FRAME_VISIBLE;
+                frame->flags |= SC2_FRAME_HAS_VISIBLE;
+                SC2_XmlFree(val);
+            }
+        } else if (!strcasecmp(tag, "Alpha")) {
+            FLOAT val;
+            if (xmlGetAttrFloat(cur, "val", &val)) {
+                frame->alpha = val;
+                frame->flags |= SC2_FRAME_HAS_ALPHA;
+            }
+        } else if (!strcasecmp(tag, "Color")) {
+            LPCSTR val = SC2_XmlGetProp(cur, "val");
+            if (val) {
+                LPCSTR resolved = SC2_LayoutResolveConstant(val);
+                frame->color = SC2_ParseColor(resolved ? resolved : val);
+                frame->flags |= SC2_FRAME_HAS_COLOR;
+                SC2_XmlFree(val);
+            }
+        } else if (!strcasecmp(tag, "AcceptsMouse")) {
+            LPCSTR val = SC2_XmlGetProp(cur, "val");
+            if (val) {
+                if (!strcasecmp(val, "true") || !strcasecmp(val, "1"))
+                    frame->flags |= SC2_FRAME_ACCEPTS_MOUSE;
+                else
+                    frame->flags &= ~SC2_FRAME_ACCEPTS_MOUSE;
+                SC2_XmlFree(val);
+            }
+        } else if (!strcasecmp(tag, "CollapseLayout")) {
+            LPCSTR val = SC2_XmlGetProp(cur, "val");
+            if (val) {
+                if (!strcasecmp(val, "true") || !strcasecmp(val, "1"))
+                    frame->flags |= SC2_FRAME_COLLAPSE_LAYOUT;
+                else
+                    frame->flags &= ~SC2_FRAME_COLLAPSE_LAYOUT;
+                SC2_XmlFree(val);
+            }
+        } else if (!strcasecmp(tag, "HighlightOnHover")) {
+            LPCSTR val = SC2_XmlGetProp(cur, "val");
+            if (val) {
+                if (!strcasecmp(val, "true") || !strcasecmp(val, "1"))
+                    frame->flags |= SC2_FRAME_HIGHLIGHT_ON_HOVER;
+                else
+                    frame->flags &= ~SC2_FRAME_HIGHLIGHT_ON_HOVER;
+                SC2_XmlFree(val);
+            }
+        } else if (!strcasecmp(tag, "HighlightOnFocus")) {
+            LPCSTR val = SC2_XmlGetProp(cur, "val");
+            if (val) {
+                if (!strcasecmp(val, "true") || !strcasecmp(val, "1"))
+                    frame->flags |= SC2_FRAME_HIGHLIGHT_ON_FOCUS;
+                else
+                    frame->flags &= ~SC2_FRAME_HIGHLIGHT_ON_FOCUS;
+                SC2_XmlFree(val);
+            }
+        } else if (!strcasecmp(tag, "BatchImages")) {
+            LPCSTR val = SC2_XmlGetProp(cur, "val");
+            if (val) {
+                if (!strcasecmp(val, "true") || !strcasecmp(val, "1"))
+                    frame->flags |= SC2_FRAME_BATCH_IMAGES;
+                else
+                    frame->flags &= ~SC2_FRAME_BATCH_IMAGES;
+                SC2_XmlFree(val);
+            }
+        } else if (!strcasecmp(tag, "BatchText")) {
+            LPCSTR val = SC2_XmlGetProp(cur, "val");
+            if (val) {
+                if (!strcasecmp(val, "true") || !strcasecmp(val, "1"))
+                    frame->flags |= SC2_FRAME_BATCH_TEXT;
+                else
+                    frame->flags &= ~SC2_FRAME_BATCH_TEXT;
+                SC2_XmlFree(val);
+            }
+        } else if (!strcasecmp(tag, "DescFlags")) {
+            LPCSTR val = SC2_XmlGetProp(cur, "val");
+            if (val) {
+                if (!strcasecmp(val, "Internal"))
+                    frame->flags |= SC2_FRAME_DESC_FLAGS_INTERNAL;
+                else
+                    frame->flags &= ~SC2_FRAME_DESC_FLAGS_INTERNAL;
+                frame->flags |= SC2_FRAME_HAS_DESC_FLAGS;
+                SC2_XmlFree(val);
+            }
+        } else if (!strcasecmp(tag, "Insets")) {
+            /* Parse insets for tooltips */
+            /* TODO: store insets on frame */
+        } else if (!strcasecmp(tag, "Style")) {
+            /* Style references — not resolved yet */
+        } else if (!strcasecmp(tag, "LayerColor")) {
+            /* ##ConstantName color reference — resolve later */
+        } else if (!strcasecmp(tag, "NormalImage") || !strcasecmp(tag, "HoverImage") ||
+                   !strcasecmp(tag, "Label") || !strcasecmp(tag, "HitTestFrame")) {
+            /* Button sub-references by name — skip, resolved at runtime */
+        } else if (!strcasecmp(tag, "Model")) {
+            SC2_ParseModel(cur, frame);
+        } else if (!strcasecmp(tag, "Camera")) {
+            /* Model camera — skip for now */
+        } else if (!strcasecmp(tag, "Projection")) {
+            /* Model projection — skip for now */
+        } else if (!strcasecmp(tag, "Position") || !strcasecmp(tag, "Scale")) {
+            /* Model transform — skip for now */
+        } else if (!strcasecmp(tag, "Frame")) {
+            /* Inline child frame */
+            if (frame->num_children < SC2_MAX_CHILDREN) {
+                sc2Frame_t *child = SC2_AddTemplate();
+                if (child) {
+                    SC2_ParseFrameAttrs(cur, child);
+                    SC2_ParseFrameChildren(cur, child);
+                    child->parent = frame;
+                    frame->children[frame->num_children++] = child;
+                }
+            }
+        } else if (!strcasecmp(tag, "RequiredDefines")) {
+            /* Platform-specific define — skip for now */
+        } else if (!strcasecmp(tag, "Options")) {
+            /* Text options like "Ellipsis | NoWrapping" — skip for now */
+        } else if (!strcasecmp(tag, "WriteOutText")) {
+            /* Typewriter effect — skip for now */
+        } else if (!strcasecmp(tag, "MaxWidth") || !strcasecmp(tag, "MinWidth")) {
+            /* Tooltip sizing constraints — skip for now */
+        } else if (!strcasecmp(tag, "AlternateTime") || !strcasecmp(tag, "MaxMessages") ||
+                   !strcasecmp(tag, "MessageDuration") || !strcasecmp(tag, "FadeDuration") ||
+                   !strcasecmp(tag, "TopToBottom")) {
+            /* MessageDisplay properties — skip for now */
+        } else if (!strcasecmp(tag, "ClickSound")) {
+            /* Sound reference — skip for now */
+        } else if (!strcasecmp(tag, "Shortcut")) {
+            /* Keyboard shortcut — skip for now */
+        } else if (!strcasecmp(tag, "Tooltip") || !strcasecmp(tag, "TooltipFrame")) {
+            /* Tooltip reference — skip for now */
+        } else if (!strcasecmp(tag, "File")) {
+            /* Flash SWF file — skip for now */
+        } else if (!strcasecmp(tag, "RenderType")) {
+            /* HDR rendering — skip for now */
+        } else if (!strcasecmp(tag, "RenderPriority")) {
+            /* Draw order priority — skip for now */
+        } else if (!strcasecmp(tag, "DescFlags")) {
+            /* Frame flags — already handled above */
+        }
+        /* Unknown tags are silently ignored */
+    }
+}
+
+/* Parse a top-level <Frame> as a template (no parent) */
+static void SC2_ParseTopLevelFrame(xmlNode *node) {
+    sc2Frame_t *frame = SC2_AddTemplate();
+    if (!frame) return;
+
+    SC2_ParseFrameAttrs(node, frame);
+    SC2_ParseFrameChildren(node, frame);
+    /* Template resolution deferred to second pass in SC2_ParseDescNode */
+}
+
+/* Parse XML document node (the <Desc> root) */
+static void SC2_ParseDescNode(xmlNode *node) {
+    /* Pass 1: resolve all includes first */
+    SC2_ResolveIncludes(node);
+
+    /* Pass 2: parse constants */
+    for (xmlNode *cur = node; cur; cur = cur->next) {
+        if (cur->type != XML_ELEMENT_NODE) continue;
+        if (!strcasecmp((const char *)cur->name, "Constant")) {
+            SC2_ParseConstant(cur);
+        }
+    }
+
+    /* Pass 3: parse frame templates (deferred template resolution) */
+    int templates_before = sc2_layout.num_templates;
+    for (xmlNode *cur = node; cur; cur = cur->next) {
+        if (cur->type != XML_ELEMENT_NODE) continue;
+        if (!strcasecmp((const char *)cur->name, "Frame")) {
+            SC2_ParseTopLevelFrame(cur);
+        }
+    }
+
+    /* Pass 4: resolve template inheritance for all frames parsed in this file.
+     * Deferring to after all frames are parsed ensures same-file templates
+     * are fully populated before being used as bases. */
+    for (int i = templates_before; i < sc2_layout.num_templates; i++) {
+        sc2Frame_t *frame = &sc2_layout.templates[i];
+        if (frame->template_path[0]) {
+            sc2Frame_t *tmpl = SC2_ResolveTemplatePath(frame->template_path);
+            if (tmpl) {
+                SC2_ResolveTemplate(frame, tmpl);
+            } else {
+                fprintf(stderr, "SC2_Layout: template '%s' not found for frame '%s'\n",
+                        frame->template_path, frame->name);
+            }
+        }
+    }
+}
+
+/* ---------- Frame tree → flat array ---------- */
+
+/* Map SC2 frame type to sc2BaseFrame_t FRAMETYPE */
+static FRAMETYPE SC2_MapFrameType(sc2FrameType sc2_type) {
+    switch (sc2_type) {
+    case SC2_FRAMETYPE_FRAME:
+    case SC2_FRAMETYPE_CONSOLE_PANEL:
+    case SC2_FRAMETYPE_COMMAND_PANEL:
+    case SC2_FRAMETYPE_INFO_PANEL:
+    case SC2_FRAMETYPE_MINIMAP_PANEL:
+    case SC2_FRAMETYPE_RESOURCE_PANEL:
+    case SC2_FRAMETYPE_PORTRAIT_PANEL:
+    case SC2_FRAMETYPE_GAME_UI:
+    case SC2_FRAMETYPE_WORLD_PANEL:
+    case SC2_FRAMETYPE_HERO_PANEL:
+    case SC2_FRAMETYPE_INVENTORY_PANEL:
+    case SC2_FRAMETYPE_CONTROL_GROUP_PANEL:
+    case SC2_FRAMETYPE_ALLIANCE_PANEL:
+    case SC2_FRAMETYPE_TEAM_RESOURCE_PANEL:
+    case SC2_FRAMETYPE_LEADER_PANEL:
+    case SC2_FRAMETYPE_OBSERVER_PANEL:
+    case SC2_FRAMETYPE_REPLAY_PANEL:
+    case SC2_FRAMETYPE_TALKER_PANEL:
+    case SC2_FRAMETYPE_PURCHASE_PANEL:
+    case SC2_FRAMETYPE_RESEARCH_PANEL:
+    case SC2_FRAMETYPE_PLANET_PANEL:
+    case SC2_FRAMETYPE_SYSTEM_ALERT_PANEL:
+    case SC2_FRAMETYPE_TRIGGER_DIALOG:
+    case SC2_FRAMETYPE_TRIGGER_WINDOW:
+    case SC2_FRAMETYPE_CREDITS_PANEL:
+    case SC2_FRAMETYPE_PAUSE_PANEL:
+    case SC2_FRAMETYPE_CONVERSATION_PANEL:
+    case SC2_FRAMETYPE_OBJECTIVE_PANEL:
+    case SC2_FRAMETYPE_SUBTITLE_PANEL:
+    case SC2_FRAMETYPE_TIME_PANEL:
+    case SC2_FRAMETYPE_MENU_BAR:
+    case SC2_FRAMETYPE_ALERT_PANEL:
+    case SC2_FRAMETYPE_ALERT_DISPLAY:
+    case SC2_FRAMETYPE_CHAT_BAR:
+    case SC2_FRAMETYPE_RESOURCE_REQUEST_ALERT:
+        return FT_FRAME;
+    case SC2_FRAMETYPE_BUTTON:
+    case SC2_FRAMETYPE_COMMAND_BUTTON:
+    case SC2_FRAMETYPE_IDLE_BUTTON:
+    case SC2_FRAMETYPE_AI_BUTTON:
+    case SC2_FRAMETYPE_PYLON_BUTTON:
+    case SC2_FRAMETYPE_LEROY_BUTTON:
+        return FT_BUTTON;
+    case SC2_FRAMETYPE_IMAGE:
+    case SC2_FRAMETYPE_MODEL:
+        return FT_SPRITE;
+    case SC2_FRAMETYPE_LABEL:
+    case SC2_FRAMETYPE_COUNTDOWN_LABEL:
+        return FT_TEXT;
+    case SC2_FRAMETYPE_EDITBOX:
+        return FT_EDITBOX;
+    case SC2_FRAMETYPE_TOOLTIP:
+    case SC2_FRAMETYPE_COMMAND_TOOLTIP:
+    case SC2_FRAMETYPE_MINIMAP_PANEL_TOOLTIP:
+        return FT_SIMPLEFRAME;
+    case SC2_FRAMETYPE_MESSAGE_DISPLAY:
+        return FT_TEXTAREA;
+    default:
+        return FT_FRAME;
+    }
+}
+
+/* Resolve anchors: map SC2 side+pos to sc2BaseFrame_t points.x/y[FPP_*].
+ *
+ * SC2 anchor model: each anchor specifies which edge of the frame (side) and
+ * which edge/position of the relative frame (pos) to attach to.
+ *   side = Top, Bottom, Left, Right
+ *   pos  = Min (top/left edge), Mid (center), Max (bottom/right edge)
+ *
+ * Mapping to sc2BaseFrame_t:
+ *   Top+Min → y[FPP_MIN], Top+Mid → y[FPP_MID], Top+Max → y[FPP_MAX]
+ *   Bottom+Min → y[FPP_MIN], Bottom+Mid → y[FPP_MID], Bottom+Max → y[FPP_MAX]
+ *   Left+Min → x[FPP_MIN], Left+Mid → x[FPP_MID], Left+Max → x[FPP_MAX]
+ *   Right+Min → x[FPP_MIN], Right+Mid → x[FPP_MID], Right+Max → x[FPP_MAX]
+ *
+ * SC2 offsets are in pixels with y-down positive. WC3 normalized space also
+ * uses y-down, but the layout solver negates y offsets, so we negate here.
+ *
+ * Named relative frames ("$parent", "$root", or a frame name) are resolved
+ * by index. $parent and $root are resolved immediately. Named frames are
+ * resolved in SC2_ResolveNamedRelatives() after the full tree is flattened. */
+static LPCSTR SC2_ParseRelativeName(LPCSTR relative, LPCSTR parent_name) {
+    if (!relative) return NULL;
+    if (!strcasecmp(relative, "$parent")) return parent_name;
+    if (!strcasecmp(relative, "$root")) return NULL;
+    /* $parent/ChildName → extract ChildName */
+    if (!strncasecmp(relative, "$parent/", 8)) return relative + 8;
+    return relative;
+}
+
+static void SC2_ResolveAnchors(sc2Frame_t *src, sc2BaseFrame_t *dst) {
+    if (src->flags & SC2_FRAME_HAS_WIDTH) dst->size.width = src->width;
+    if (src->flags & SC2_FRAME_HAS_HEIGHT) dst->size.height = src->height;
+
+    sc2Frame_t *parent = NULL;
+    if (dst->parent_index != (DWORD)-1) {
+        for (int i = 0; i < sc2_layout.num_templates; i++) {
+            if (sc2_layout.templates[i].resolved_index == (int)dst->parent_index) {
+                parent = &sc2_layout.templates[i];
+                break;
+            }
+        }
+    }
+    LPCSTR parent_name = parent ? parent->name : NULL;
+
+    for (int i = 0; i < src->num_anchors; i++) {
+        sc2Anchor_t *a = &src->anchors[i];
+        if (!(a->flags & SC2_ANCHOR_HAS)) continue;
+
+        /* side determines which point index on the axis */
+        int point_idx;
+        BOOL is_x;
+        switch (a->side) {
+            case SC2_SIDE_LEFT:   is_x = true;  point_idx = FPP_MIN; break;
+            case SC2_SIDE_RIGHT:  is_x = true;  point_idx = FPP_MAX; break;
+            case SC2_SIDE_TOP:    is_x = false; point_idx = FPP_MIN; break;
+            case SC2_SIDE_BOTTOM: is_x = false; point_idx = FPP_MAX; break;
+            default: continue;
+        }
+
+        /* pos determines target position on the parent */
+        int target_idx = (a->pos == SC2_POS_MIN) ? FPP_MIN :
+                         (a->pos == SC2_POS_MID) ? FPP_MID : FPP_MAX;
+
+        sc2BaseFramePoint_t *p = is_x ? &dst->points.x[point_idx] : &dst->points.y[point_idx];
+        p->used = true;
+        p->targetPos = (uiFramePointPos_t)target_idx;
+        p->offset = is_x ? (FLOAT)a->offset : -(FLOAT)a->offset;
+
+        LPCSTR resolved_name = SC2_ParseRelativeName(a->relative, parent_name);
+        if (!resolved_name || !strcasecmp(resolved_name, parent_name)) {
+            p->relative_index = dst->parent_index;
+        } else if (!strcasecmp(a->relative, "$root")) {
+            p->relative_index = 0;
+        } else {
+            /* Named frame — mark for post-flatten resolution */
+            p->relative_index = (DWORD)-2; /* sentinel: needs named resolution */
+        }
+    }
+}
+
+/* Resolve named relative references after the full frame tree is flattened.
+ * Scans all frames for anchors with relative_index == -2 and looks up the
+ * named frame in the flat array by matching sc2Frame_t name. */
+static void SC2_ResolveNamedRelatives(void) {
+    for (DWORD i = 0; i < (DWORD)sc2_layout.num_frames; i++) {
+        sc2BaseFrame_t *dst = &sc2_layout.frames[i];
+        for (int axis = 0; axis < 2; axis++) {
+            sc2BaseFramePoint_t *pts = axis == 0 ? dst->points.x : dst->points.y;
+            for (int j = 0; j < FPP_COUNT; j++) {
+                if (pts[j].relative_index != (DWORD)-2) continue;
+                sc2Frame_t *src = NULL;
+                for (int k = 0; k < sc2_layout.num_templates; k++) {
+                    if (sc2_layout.templates[k].resolved_index == (int)i) {
+                        src = &sc2_layout.templates[k];
+                        break;
+                    }
+                }
+                if (!src) continue;
+                /* Find the anchor that produced this sentinel */
+                for (int k = 0; k < src->num_anchors; k++) {
+                    sc2Anchor_t *a = &src->anchors[k];
+                    if (!(a->flags & SC2_ANCHOR_HAS)) continue;
+                    BOOL is_x_axis = (a->side == SC2_SIDE_LEFT || a->side == SC2_SIDE_RIGHT);
+                    if ((axis == 0) != is_x_axis) continue;
+                    int a_point = (a->side == SC2_SIDE_LEFT || a->side == SC2_SIDE_TOP) ? FPP_MIN :
+                                  (a->side == SC2_SIDE_RIGHT || a->side == SC2_SIDE_BOTTOM) ? FPP_MAX : FPP_MID;
+                    if (a_point != j) continue;
+                    /* Extract the name to look up: $parent/ChildName → ChildName */
+                    LPCSTR look_name = a->relative;
+                    if (!strncasecmp(look_name, "$parent/", 8)) look_name += 8;
+                    /* Look up named frame in flat array */
+                    for (DWORD m = 0; m < (DWORD)sc2_layout.num_frames; m++) {
+                        sc2Frame_t *f = NULL;
+                        for (int n = 0; n < sc2_layout.num_templates; n++) {
+                            if (sc2_layout.templates[n].resolved_index == (int)m) {
+                                f = &sc2_layout.templates[n];
+                                break;
+                            }
+                        }
+                        if (f && !strcasecmp(f->name, look_name)) {
+                            pts[j].relative_index = m;
+                            break;
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+    }
+}
+
+/* ---------- on_draw callbacks (called by client per frame) ---------- */
+
+static void SC2_DrawImage(struct sc2BaseFrame_s *frame, LPCRECT rect) {
+    LPRENDERER renderer = uiimport.GetRenderer();
+    if (!renderer || !renderer->DrawImage) return;
+    LPCTEXTURE tex = frame->image ? uiimport.GetTexture(frame->image) : NULL;
+    if (!tex) return;
+    static const RECT uv = { 0.0f, 0.0f, 1.0f, 1.0f };
+    renderer->DrawImage(tex, rect, &uv, frame->color);
+}
+
+static void SC2_DrawText(struct sc2BaseFrame_s *frame, LPCRECT rect) {
+    LPRENDERER renderer = uiimport.GetRenderer();
+    if (!renderer || !renderer->DrawText || !frame->text || !*frame->text) return;
+    LPCFONT font = uiimport.GetFont ? uiimport.GetFont(0) : NULL;
+    if (!font) return;
+    renderer->DrawText(&MAKE(drawText_t,
+                             .font = font,
+                             .text = frame->text,
+                             .rect = *rect,
+                             .color = frame->color,
+                             .textWidth = rect->w,
+                             .flags = 0,
+                             .lineHeight = 1.0f));
+}
+
+static void SC2_DrawButton(struct sc2BaseFrame_s *frame, LPCRECT rect) {
+    LPRENDERER renderer = uiimport.GetRenderer();
+    if (!renderer || !renderer->DrawImage) return;
+    LPCTEXTURE tex = frame->image ? uiimport.GetTexture(frame->image) : NULL;
+    if (!tex) return;
+    static const RECT uv = { 0.0f, 0.0f, 1.0f, 1.0f };
+    renderer->DrawImageEx(&MAKE(drawImage_t,
+                                .texture = tex,
+                                .shader = SHADER_COMMANDBUTTON,
+                                .alphamode = BLEND_MODE_ALPHAKEY,
+                                .screen = *rect,
+                                .uv = uv,
+                                .color = frame->color));
+}
+
+/* Recursively flatten frame tree into sc2BaseFrame_t array */
+static void SC2_FlattenFrame(sc2Frame_t *frame, int parent_index) {
+    if (sc2_layout.num_frames >= SC2_MAX_FRAMES) return;
+
+    int index = sc2_layout.num_frames++;
+    sc2BaseFrame_t *dst = &sc2_layout.frames[index];
+    memset(dst, 0, sizeof(*dst));
+
+    dst->number = (DWORD)index;
+    dst->type = SC2_MapFrameType(frame->type);
+    dst->parent_index = (parent_index >= 0) ? (DWORD)parent_index : (DWORD)-1;
+
+    switch (dst->type) {
+        case FT_SPRITE: dst->on_draw = SC2_DrawImage;  break;
+        case FT_BUTTON: dst->on_draw = SC2_DrawButton; break;
+        case FT_TEXT:   dst->on_draw = SC2_DrawText;   break;
+        default:        dst->on_draw = NULL;            break;
+    }
+    dst->color = (frame->flags & SC2_FRAME_HAS_COLOR) ? frame->color : (COLOR32){255, 255, 255, 255};
+    dst->alpha = (frame->flags & SC2_FRAME_HAS_ALPHA) ? frame->alpha : 1.0f;
+    dst->ui_flags = 0;
+    if (frame->flags & SC2_FRAME_HAS_VISIBLE) {
+        if (!(frame->flags & SC2_FRAME_VISIBLE))
+            dst->ui_flags |= SC2_UIFLAG_HIDDEN | SC2_UIFLAG_HIDDEN_IN_HIERARCHY;
+    }
+
+    /* Resolve anchor points */
+    SC2_ResolveAnchors(frame, dst);
+
+    /* Resolve first texture as primary image */
+    if (frame->num_textures > 0 && frame->textures[0].flags & SC2_TEX_HAS_TEXTURE) {
+        /* Store raw reference hash — resolved at render time */
+        dst->image = 0; /* TODO: resolve @@UI/Name to image index */
+    }
+
+    /* Backdrop: first tiled texture as background, border textures as edge */
+    for (int i = 0; i < frame->num_textures; i++) {
+        sc2Texture_t *tex = &frame->textures[i];
+        if (!(tex->flags & SC2_TEX_HAS_TEXTURE)) continue;
+        if ((tex->flags & SC2_TEX_TILED) && dst->backdrop.bg == 0) {
+            dst->backdrop.bg = 0; /* TODO: resolve texture */
+            dst->backdrop.flags |= SC2_BACKDROP_TILE;
+        }
+        if (!strcasecmp(tex->texture_type, "Border") && dst->backdrop.edge == 0) {
+            dst->backdrop.edge = 0; /* TODO: resolve texture */
+        }
+    }
+
+    frame->resolved_index = index;
+
+    /* Recurse children */
+    for (int i = 0; i < frame->num_children; i++) {
+        SC2_FlattenFrame(frame->children[i], index);
+    }
+}
+
+/* ---------- Public API ---------- */
+
+void SC2_LayoutInit(void) {
+    memset(&sc2_layout, 0, sizeof(sc2_layout));
+    for (int i = 0; i < SC2_MAX_TEMPLATES; i++) {
+        sc2_layout.templates[i].resolved_index = -1;
+    }
+}
+
+void SC2_LayoutShutdown(void) {
+    memset(&sc2_layout, 0, sizeof(sc2_layout));
+}
+
+BOOL SC2_LayoutParseFile(LPCSTR filename) {
+    /* Read file from MPQ via client callbacks */
+    void *buf = NULL;
+    int len = uiimport.FS_ReadFile(filename, &buf);
+    if (len < 0 || !buf) {
+        fprintf(stderr, "SC2_Layout: failed to load '%s'\n", filename);
+        return false;
+    }
+
+    /* Parse XML */
+    xmlDocPtr doc = xmlParseMemory(buf, len);
+    uiimport.FS_FreeFile(buf);
+    if (!doc) {
+        fprintf(stderr, "SC2_Layout: failed to parse '%s'\n", filename);
+        return false;
+    }
+
+    xmlNode *root = xmlDocGetRootElement(doc);
+    if (!root || strcasecmp((const char *)root->name, "Desc")) {
+        fprintf(stderr, "SC2_Layout: root element is not <Desc> in '%s'\n", filename);
+        xmlFreeDoc(doc);
+        return false;
+    }
+
+    SC2_ParseDescNode(root->children);
+    xmlFreeDoc(doc);
+    return true;
+}
+
+/* Build main menu layout from glue screen layout files */
+BOOL SC2_LayoutBuildMainMenu(void) {
+    SC2_LayoutInit();
+
+    static LPCSTR glue_files[] = {
+        "UI/Layout/Common/StandardConstants.SC2Layout",
+        "UI/Layout/Common/StandardTemplates.SC2Layout",
+        "UI/Layout/Glue/GlueMainMenu.SC2Layout",
+        NULL,
+    };
+
+    for (int i = 0; glue_files[i]; i++) {
+        if (!SC2_LayoutParseFile(glue_files[i])) {
+            fprintf(stderr, "SC2_Layout: failed to load glue file '%s'\n", glue_files[i]);
+        }
+    }
+
+    return SC2_LayoutFlatten("GlueMainMenu");
+}
+
+/* Build the main game UI from known layout files */
+BOOL SC2_LayoutBuildGameUI(void) {
+    SC2_LayoutInit();
+
+    /* Load core layouts — order matters: templates before consumers */
+    static LPCSTR core_files[] = {
+        "UI/Layout/Common/StandardConstants.SC2Layout",
+        "UI/Layout/UI/GameButton.SC2Layout",
+        "UI/Layout/Common/StandardTemplates.SC2Layout",
+        "UI/Layout/Common/StandardTooltip.SC2Layout",
+        "UI/Layout/Common/StandardDialog.SC2Layout",
+        "UI/Layout/UI/ConsolePanel.SC2Layout",
+        "UI/Layout/UI/CommandPanel.SC2Layout",
+        "UI/Layout/UI/CommandButton.SC2Layout",
+        "UI/Layout/UI/ResourcePanel.SC2Layout",
+        "UI/Layout/UI/MinimapPanel.SC2Layout",
+        "UI/Layout/UI/PortraitPanel.SC2Layout",
+        "UI/Layout/UI/InfoPanel.SC2Layout",
+        "UI/Layout/UI/MenuBar.SC2Layout",
+        "UI/Layout/UI/ControlGroupPanel.SC2Layout",
+        "UI/Layout/UI/AlertPanel.SC2Layout",
+        "UI/Layout/UI/ObjectivePanel.SC2Layout",
+        "UI/Layout/UI/TimePanel.SC2Layout",
+        "UI/Layout/UI/ConversationPanel.SC2Layout",
+        "UI/Layout/UI/SubtitlePanel.SC2Layout",
+        "UI/Layout/UI/GameUI.SC2Layout",
+        NULL,
+    };
+
+    for (int i = 0; core_files[i]; i++) {
+        if (!SC2_LayoutParseFile(core_files[i])) {
+            fprintf(stderr, "SC2_Layout: failed to load core file '%s'\n", core_files[i]);
+        }
+    }
+
+    return SC2_LayoutFlatten("GameUI");
+}
+
+/* Flatten parsed templates into the frame array for client consumption */
+BOOL SC2_LayoutFlatten(LPCSTR root_name) {
+    sc2Frame_t *root = SC2_FindTemplate(root_name);
+    if (!root) {
+        fprintf(stderr, "SC2_Layout: '%s' template not found\n", root_name);
+        return false;
+    }
+
+    sc2_layout.num_frames = 0;
+    SC2_FlattenFrame(root, -1);
+    SC2_ResolveNamedRelatives();
+
+    fprintf(stderr, "SC2_Layout: built %d frames from %d templates, %d constants\n",
+            sc2_layout.num_frames, sc2_layout.num_templates, sc2_layout.num_constants);
+
+    return true;
+}
+
+sc2BaseFrame_t *SC2_LayoutGetFrames(DWORD *count) {
+    if (count) *count = (DWORD)sc2_layout.num_frames;
+    return sc2_layout.frames;
+}
+
+sc2Frame_t *SC2_LayoutFindTemplate(LPCSTR name) {
+    return SC2_FindTemplate(name);
+}
+
+sc2BaseFrame_t *SC2_LayoutFindFrameByType(sc2FrameType type) {
+    for (int i = 0; i < sc2_layout.num_templates; i++) {
+        sc2Frame_t *tmpl = &sc2_layout.templates[i];
+        if (tmpl->type == type && tmpl->resolved_index >= 0)
+            return &sc2_layout.frames[tmpl->resolved_index];
+    }
+    return NULL;
+}
+
+int SC2_LayoutNumTemplates(void) {
+    return sc2_layout.num_templates;
+}
+
+sc2Frame_t *SC2_LayoutGetTemplate(int index) {
+    if (index < 0 || index >= sc2_layout.num_templates) return NULL;
+    return &sc2_layout.templates[index];
+}

--- a/games/starcraft-2/ui/sc2_layout.h
+++ b/games/starcraft-2/ui/sc2_layout.h
@@ -1,0 +1,301 @@
+/*
+ * sc2_layout.h — SC2 .SC2Layout XML parser and frame builder.
+ *
+ * Parses StarCraft II UI layout files (.SC2Layout) into sc2BaseFrame_t arrays.
+ * SC2 layouts use XML with <Desc> root, <Frame type="..." name="..."> elements,
+ * <Anchor side="..." relative="..." pos="..." offset="..."/> for positioning,
+ * and template inheritance via template="Path/TemplateName".
+ *
+ * The parser resolves <Include path="..."/> directives, resolves template
+ * inheritance by cloning children, evaluates constants (##Name → value),
+ * and produces a flat array of sc2BaseFrame_t that the client can iterate.
+ */
+#ifndef sc2_layout_h
+#define sc2_layout_h
+
+#include "common/shared.h"
+#include "client/ui.h"
+
+/* SC2 UI frame types — isolated from shared engine types */
+typedef struct {
+    uiFramePointPos_t targetPos;
+    BOOL used;
+    DWORD relative_index;           /* index into exported frame array, -1 = scene */
+    FLOAT offset;
+} sc2BaseFramePoint_t;
+
+typedef sc2BaseFramePoint_t sc2BaseFramePoints_t[FPP_COUNT];
+
+/* SC2 UI interaction flags */
+#define SC2_UIFLAG_PRESSED              (1 << 0)
+#define SC2_UIFLAG_HOVERED              (1 << 1)
+#define SC2_UIFLAG_CHECKED              (1 << 2)
+#define SC2_UIFLAG_HIDDEN               (1 << 3)
+#define SC2_UIFLAG_DISABLED             (1 << 4)
+#define SC2_UIFLAG_HIDDEN_IN_HIERARCHY  (1 << 5)
+
+/* SC2 frame flags (sc2Frame_t.flags) */
+#define SC2_FRAME_HAS_WIDTH             (1 << 0)
+#define SC2_FRAME_HAS_HEIGHT            (1 << 1)
+#define SC2_FRAME_VISIBLE               (1 << 2)
+#define SC2_FRAME_HAS_VISIBLE           (1 << 3)
+#define SC2_FRAME_ACCEPTS_MOUSE         (1 << 4)
+#define SC2_FRAME_HAS_COLOR             (1 << 5)
+#define SC2_FRAME_HAS_ALPHA             (1 << 6)
+#define SC2_FRAME_COLLAPSE_LAYOUT       (1 << 7)
+#define SC2_FRAME_HIGHLIGHT_ON_HOVER    (1 << 8)
+#define SC2_FRAME_HIGHLIGHT_ON_FOCUS    (1 << 9)
+#define SC2_FRAME_BATCH_IMAGES          (1 << 10)
+#define SC2_FRAME_BATCH_TEXT            (1 << 11)
+#define SC2_FRAME_HAS_DESC_FLAGS        (1 << 12)
+#define SC2_FRAME_DESC_FLAGS_INTERNAL   (1 << 13)
+
+/* SC2 texture flags (sc2Texture_t.flags) */
+#define SC2_TEX_TILED                   (1 << 0)
+#define SC2_TEX_HAS_TEXTURE             (1 << 1)
+
+/* SC2 anchor flags (sc2Anchor_t.flags) */
+#define SC2_ANCHOR_HAS                  (1 << 0)
+
+/* SC2 backdrop flags (sc2BaseFrame_t.backdrop.flags) */
+#define SC2_BACKDROP_TILE               (1 << 0)
+
+/* SC2 flattened UI frame struct — produced by SC2_LayoutFlatten */
+struct sc2BaseFrame_s;
+typedef struct sc2BaseFrame_s {
+    DWORD number;
+    FRAMETYPE type;
+    void *parent;                   /* game resolves: pointer or index */
+    DWORD parent_index;             /* index into frames array, -1 = root */
+    struct { sc2BaseFramePoints_t x, y; } points;
+    RECT screen_rect;               /* computed screen-space AABB, filled by client layout */
+    COLOR32 color;
+    FLOAT alpha;
+    struct { FLOAT width, height; } size;
+    DWORD image;                    /* primary texture/resource index */
+    RECT texcoord;                  /* texture UV rect */
+    LPCSTR text;
+    COLOR32 text_color;
+    struct {                        /* backdrop */
+        DWORD bg;
+        DWORD edge;
+        DWORD flags;                /* SC2_BACKDROP_* */
+        FLOAT insets[4];
+    } backdrop;
+    DWORD ui_flags;                 /* SC2_UIFLAG_* bitmask */
+    void (*on_event)(struct sc2BaseFrame_s *frame, FLOAT x, FLOAT y, int button, BOOL down);
+    void (*on_draw)(struct sc2BaseFrame_s *frame, LPCRECT rect);
+} sc2BaseFrame_t;
+
+typedef sc2BaseFrame_t *LPSC2BASEFRAME;
+typedef sc2BaseFrame_t const *LPCSC2BASEFRAME;
+
+/* Maximum frames in the layout system */
+#define SC2_MAX_FRAMES     4096
+#define SC2_MAX_TEMPLATES  1024
+#define SC2_MAX_INCLUDES   128
+#define SC2_MAX_ANCHORS    4       /* per frame: Top, Bottom, Left, Right */
+#define SC2_MAX_CONSTANTS  256
+#define SC2_MAX_TEXTURES   8       /* per frame */
+#define SC2_MAX_CHILDREN   64      /* per frame */
+
+/* SC2 anchor side indices (matching <Anchor side="..."> values) */
+typedef enum {
+    SC2_SIDE_TOP,
+    SC2_SIDE_BOTTOM,
+    SC2_SIDE_LEFT,
+    SC2_SIDE_RIGHT,
+    SC2_SIDE_COUNT,
+} SC2Side;
+
+/* SC2 anchor position (matching <Anchor pos="..."> values) */
+typedef enum {
+    SC2_POS_MIN,    /* Top/Left edge */
+    SC2_POS_MID,    /* Center */
+    SC2_POS_MAX,    /* Bottom/Right edge */
+    SC2_POS_COUNT,
+} SC2Pos;
+
+/* SC2 anchor definition */
+typedef struct {
+    SC2Side side;           /* Top, Bottom, Left, Right */
+    SC2Pos pos;             /* Min, Mid, Max */
+    int16_t offset;         /* pixel offset */
+    UINAME relative;        /* relative frame name ("$parent", "$root", or name) */
+    DWORD flags;            /* SC2_ANCHOR_HAS */
+} sc2Anchor_t;
+
+/* SC2 texture layer */
+typedef struct {
+    UINAME resource;        /* @@UI/TextureName or @UI/TextureName */
+    UINAME texture_type;    /* Normal, Border, HorizontalBorder, EndCap, None */
+    int layer;              /* draw layer index */
+    DWORD flags;            /* SC2_TEX_* */
+} sc2Texture_t;
+
+/* SC2 frame type (matching <Frame type="..."> values) */
+typedef enum {
+    SC2_FRAMETYPE_FRAME,
+    SC2_FRAMETYPE_BUTTON,
+    SC2_FRAMETYPE_IMAGE,
+    SC2_FRAMETYPE_LABEL,
+    SC2_FRAMETYPE_EDITBOX,
+    SC2_FRAMETYPE_TOOLTIP,
+    SC2_FRAMETYPE_MODEL,
+    SC2_FRAMETYPE_CONSOLE_PANEL,
+    SC2_FRAMETYPE_COMMAND_PANEL,
+    SC2_FRAMETYPE_COMMAND_BUTTON,
+    SC2_FRAMETYPE_COMMAND_TOOLTIP,
+    SC2_FRAMETYPE_INFO_PANEL,
+    SC2_FRAMETYPE_MINIMAP_PANEL,
+    SC2_FRAMETYPE_MINIMAP,
+    SC2_FRAMETYPE_RESOURCE_PANEL,
+    SC2_FRAMETYPE_PORTRAIT_PANEL,
+    SC2_FRAMETYPE_GAME_UI,
+    SC2_FRAMETYPE_WORLD_PANEL,
+    SC2_FRAMETYPE_COUNTDOWN_LABEL,
+    SC2_FRAMETYPE_HERO_PANEL,
+    SC2_FRAMETYPE_INVENTORY_PANEL,
+    SC2_FRAMETYPE_IDLE_BUTTON,
+    SC2_FRAMETYPE_AI_BUTTON,
+    SC2_FRAMETYPE_PYLON_BUTTON,
+    SC2_FRAMETYPE_MESSAGE_DISPLAY,
+    SC2_FRAMETYPE_ALERT_PANEL,
+    SC2_FRAMETYPE_ALERT_DISPLAY,
+    SC2_FRAMETYPE_CHAT_BAR,
+    SC2_FRAMETYPE_MENU_BAR,
+    SC2_FRAMETYPE_SUBTITLE_PANEL,
+    SC2_FRAMETYPE_TIME_PANEL,
+    SC2_FRAMETYPE_CREDITS_PANEL,
+    SC2_FRAMETYPE_CONTROL_GROUP_PANEL,
+    SC2_FRAMETYPE_MINIMAP_PANEL_TOOLTIP,
+    SC2_FRAMETYPE_REVEAL_PANEL,
+    SC2_FRAMETYPE_ALLIANCE_PANEL,
+    SC2_FRAMETYPE_TEAM_RESOURCE_PANEL,
+    SC2_FRAMETYPE_LEADER_PANEL,
+    SC2_FRAMETYPE_OBSERVER_PANEL,
+    SC2_FRAMETYPE_REPLAY_PANEL,
+    SC2_FRAMETYPE_TALKER_PANEL,
+    SC2_FRAMETYPE_PURCHASE_PANEL,
+    SC2_FRAMETYPE_RESEARCH_PANEL,
+    SC2_FRAMETYPE_PLANET_PANEL,
+    SC2_FRAMETYPE_CASH_PANEL,
+    SC2_FRAMETYPE_RESOURCE_REQUEST_ALERT,
+    SC2_FRAMETYPE_PAUSE_PANEL,
+    SC2_FRAMETYPE_CONVERSATION_PANEL,
+    SC2_FRAMETYPE_OBJECTIVE_PANEL,
+    SC2_FRAMETYPE_TRIGGER_DIALOG,
+    SC2_FRAMETYPE_TRIGGER_WINDOW,
+    SC2_FRAMETYPE_SYSTEM_ALERT_PANEL,
+    SC2_FRAMETYPE_TIP_ALERT,
+    SC2_FRAMETYPE_TIP_ALERT_MOVING,
+    SC2_FRAMETYPE_CINEMATIC_TEXT,
+    SC2_FRAMETYPE_TEXT_CRAWL,
+    SC2_FRAMETYPE_FLASH_FRAME,
+    SC2_FRAMETYPE_LEROY_BUTTON,
+    SC2_FRAMETYPE_MAP_INFO_PANEL,
+    SC2_FRAMETYPE_PERF_OVERLAY,
+    SC2_FRAMETYPE_PROFILER,
+    SC2_FRAMETYPE_ACHIEVEMENT_PANEL,
+    SC2_FRAMETYPE_SCREEN_CREDITS,
+    SC2_FRAMETYPE_UNKNOWN,
+} sc2FrameType;
+
+/* SC2 constant definition */
+typedef struct {
+    UINAME name;
+    char val[64];
+} sc2Constant_t;
+
+/* SC2 layout frame definition (parsed from XML, before resolution) */
+typedef struct sc2Frame_s {
+    UINAME name;                        /* name="..." */
+    sc2FrameType type;                  /* type="..." */
+    UINAME template_path;               /* template="Path/Name" */
+    UINAME image_ref;                   /* Image val="$root/..." (tooltip border) */
+
+    /* Properties */
+    FLOAT width, height;
+    DWORD flags;                        /* SC2_FRAME_* */
+    COLOR32 color;
+    FLOAT alpha;
+
+    /* Anchors */
+    sc2Anchor_t anchors[SC2_MAX_ANCHORS];
+    int num_anchors;
+
+    /* Textures (up to SC2_MAX_TEXTURES layers) */
+    sc2Texture_t textures[SC2_MAX_TEXTURES];
+    int num_textures;
+
+    /* Children (inline child frames) */
+    struct sc2Frame_s *children[SC2_MAX_CHILDREN];
+    int num_children;
+
+    /* Parent pointer (set during tree assembly) */
+    struct sc2Frame_s *parent;
+
+    /* Resolved index into flat frame array (-1 = not yet resolved) */
+    int resolved_index;
+
+    /* Source file for debugging */
+    PATHSTR source_file;
+} sc2Frame_t;
+
+/* SC2 layout context — holds all parsed state */
+typedef struct {
+    /* Parsed templates (indexed by name hash) */
+    sc2Frame_t templates[SC2_MAX_TEMPLATES];
+    int num_templates;
+
+    /* Constants */
+    sc2Constant_t constants[SC2_MAX_CONSTANTS];
+    int num_constants;
+
+    /* Resolved frame array (flat, for client consumption) */
+    sc2BaseFrame_t frames[SC2_MAX_FRAMES];
+    int num_frames;
+
+    /* Root frame */
+    sc2Frame_t *root;
+
+    /* Include tracking */
+    PATHSTR included_files[SC2_MAX_INCLUDES];
+    int num_includes;
+} sc2Layout_t;
+
+/* Initialize the SC2 layout system */
+void SC2_LayoutInit(void);
+
+/* Shutdown and free all layout data */
+void SC2_LayoutShutdown(void);
+
+/* Parse a .SC2Layout file from MPQ or filesystem */
+BOOL SC2_LayoutParseFile(LPCSTR filename);
+
+/* Flatten parsed templates into the frame array (call after parsing) */
+BOOL SC2_LayoutFlatten(LPCSTR root_name);
+
+/* Get the resolved frame array for client rendering */
+sc2BaseFrame_t *SC2_LayoutGetFrames(DWORD *count);
+
+/* Build and flatten the main menu from glue SC2Layout files */
+BOOL SC2_LayoutBuildMainMenu(void);
+
+/* Build and flatten the main game UI from the standard SC2Layout files */
+BOOL SC2_LayoutBuildGameUI(void);
+
+/* Find a template by name */
+sc2Frame_t *SC2_LayoutFindTemplate(LPCSTR name);
+
+/* Find the first resolved sc2BaseFrame_t with the given SC2 frame type */
+sc2BaseFrame_t *SC2_LayoutFindFrameByType(sc2FrameType type);
+
+/* Template accessors for iteration */
+int SC2_LayoutNumTemplates(void);
+sc2Frame_t *SC2_LayoutGetTemplate(int index);
+
+/* Resolve a constant value (##Name → val) */
+LPCSTR SC2_LayoutResolveConstant(LPCSTR name);
+
+#endif

--- a/games/world-of-warcraft/ui/ui_loading.c
+++ b/games/world-of-warcraft/ui/ui_loading.c
@@ -14,11 +14,11 @@ void UIWow_LoadStaticAssets(void) {
     if (!wow_ui.renderer) {
         return;
     }
-    if (!wow_ui.font_title) {
-        wow_ui.font_title = wow_ui.renderer->LoadFont("Fonts\\FRIZQT__.TTF", 22);
+    if (!wow_ui.fonts[WOW_UI_FONT_TITLE]) {
+        wow_ui.fonts[WOW_UI_FONT_TITLE] = wow_ui.renderer->LoadFont("Fonts\\FRIZQT__.TTF", 22);
     }
-    if (!wow_ui.font_status) {
-        wow_ui.font_status = wow_ui.renderer->LoadFont("Fonts\\FRIZQT__.TTF", 16);
+    if (!wow_ui.fonts[WOW_UI_FONT_STATUS]) {
+        wow_ui.fonts[WOW_UI_FONT_STATUS] = wow_ui.renderer->LoadFont("Fonts\\FRIZQT__.TTF", 16);
     }
 }
 
@@ -47,12 +47,12 @@ void UIWow_UpdateMapBackground(LPCPLAYER ps) {
         return;
     }
 
-    SAFE_DELETE(wow_ui.background, wow_ui.renderer->ReleaseTexture);
-    wow_ui.background = wow_ui.renderer->LoadTexture(screen_path);
-    if (!wow_ui.background) {
+    SAFE_DELETE(wow_ui.textures[WOW_UI_TEX_BACKGROUND], wow_ui.renderer->ReleaseTexture);
+    wow_ui.textures[WOW_UI_TEX_BACKGROUND] = wow_ui.renderer->LoadTexture(screen_path);
+    if (!wow_ui.textures[WOW_UI_TEX_BACKGROUND]) {
         UIWow_Printf("UIWow: failed loading map background '%s', trying default\n", screen_path);
-        wow_ui.background = wow_ui.renderer->LoadTexture(default_bg);
-        if (!wow_ui.background) {
+        wow_ui.textures[WOW_UI_TEX_BACKGROUND] = wow_ui.renderer->LoadTexture(default_bg);
+        if (!wow_ui.textures[WOW_UI_TEX_BACKGROUND]) {
             UIWow_WarnOnce(WOW_UI_WARN_NO_LOAD_BACKGROUND,
                            "UIWow: failed loading default loading background '%s'\n",
                            default_bg);
@@ -85,17 +85,17 @@ void UIWow_DrawLoadingScreenC(LPCSTR map, LPCSTR status, FLOAT progress) {
         return;
     }
 
-    if (wow_ui.background) {
-        wow_ui.renderer->DrawImage(wow_ui.background, &full, &uv, COLOR32_WHITE);
+    if (wow_ui.textures[WOW_UI_TEX_BACKGROUND]) {
+        wow_ui.renderer->DrawImage(wow_ui.textures[WOW_UI_TEX_BACKGROUND], &full, &uv, COLOR32_WHITE);
     }
 
     if (!map_title || !*map_title) {
         map_title = "";
     }
 
-    if (wow_ui.font_title && map_title && *map_title) {
+    if (wow_ui.fonts[WOW_UI_FONT_TITLE] && map_title && *map_title) {
         wow_ui.renderer->DrawText(&MAKE(drawText_t,
-                                        .font = wow_ui.font_title,
+                                        .font = wow_ui.fonts[WOW_UI_FONT_TITLE],
                                         .text = map_title,
                                         .rect = title_rect,
                                         .color = MAKE(COLOR32, 235, 210, 160, 255),

--- a/games/world-of-warcraft/ui/ui_local.h
+++ b/games/world-of-warcraft/ui/ui_local.h
@@ -20,6 +20,17 @@
 #define WOW_UI_MAX_TEXTURES 256
 #define WOW_UI_MAX_FONTS    16
 
+typedef enum {
+    WOW_UI_TEX_BACKGROUND = 0,
+    WOW_UI_TEX_COUNT
+} uiWowTexId_t;
+
+typedef enum {
+    WOW_UI_FONT_TITLE = 0,
+    WOW_UI_FONT_STATUS,
+    WOW_UI_FONT_COUNT
+} uiWowFontId_t;
+
 #define WOW_UI_WARN_FLAG(x) (1u << (x))
 
 #define WOW_UI_WARN_NO_RENDERER            WOW_UI_WARN_FLAG(0)
@@ -60,19 +71,13 @@ typedef struct {
     lua_State *lua;
     BOOL game_mode;
     DWORD warn_once_mask;
-    uiWowTexture_t textures[WOW_UI_MAX_TEXTURES];
+    uiWowTexture_t tex_cache[WOW_UI_MAX_TEXTURES];
     DWORD texture_recycle_index;
-    uiWowFont_t fonts[WOW_UI_MAX_FONTS];
+    uiWowFont_t font_cache[WOW_UI_MAX_FONTS];
     uiWowIcon_t inventory[WOW_UI_INVENTORY_SLOTS];
     uiWowIcon_t actions[WOW_UI_ACTION_SLOTS];
-    LPTEXTURE background;
-    LPTEXTURE bar_background;
-    LPTEXTURE bar_border;
-    LPTEXTURE bar_fill;
-    LPTEXTURE bar_glass;
-    LPTEXTURE bar_glow;
-    LPCFONT font_title;
-    LPCFONT font_status;
+    LPTEXTURE textures[WOW_UI_TEX_COUNT];
+    LPCFONT fonts[WOW_UI_FONT_COUNT];
     PATHSTR active_map;
     PATHSTR current_menu;
     int model_frame_idx;      /* frame index for SetCharSelectModelFrame */

--- a/games/world-of-warcraft/ui/ui_lua.c
+++ b/games/world-of-warcraft/ui/ui_lua.c
@@ -344,8 +344,8 @@ static int UIWow_LuaDrawLoadingBackground(lua_State *L) {
 
     (void)L;
     UIWow_EnsureRenderer();
-    if (wow_ui.renderer && wow_ui.background) {
-        wow_ui.renderer->DrawImage(wow_ui.background, &full, &full, COLOR32_WHITE);
+    if (wow_ui.renderer && wow_ui.textures[WOW_UI_TEX_BACKGROUND]) {
+        wow_ui.renderer->DrawImage(wow_ui.textures[WOW_UI_TEX_BACKGROUND], &full, &full, COLOR32_WHITE);
     }
     return 0;
 }

--- a/games/world-of-warcraft/ui/ui_main.c
+++ b/games/world-of-warcraft/ui/ui_main.c
@@ -131,7 +131,7 @@ LPTEXTURE UIWow_LoadTexture(LPCSTR name) {
     }
     /* Fast path: input name already cached — skip MPQ resolution entirely. */
     FOR_LOOP(i, WOW_UI_MAX_TEXTURES) {
-        uiWowTexture_t *entry = &wow_ui.textures[i];
+        uiWowTexture_t *entry = &wow_ui.tex_cache[i];
 
         if (entry->input_name[0] && !strcasecmp(entry->input_name, name)) {
             return entry->texture;
@@ -143,7 +143,7 @@ LPTEXTURE UIWow_LoadTexture(LPCSTR name) {
     /* Slow path: resolve once (MPQ probe), then store both names in the slot. */
     UIWow_ResolveTexturePath(name, resolved, sizeof(resolved));
     if (empty_slot >= 0) {
-        uiWowTexture_t *entry = &wow_ui.textures[empty_slot];
+        uiWowTexture_t *entry = &wow_ui.tex_cache[empty_slot];
 
         snprintf(entry->input_name, sizeof(entry->input_name), "%s", name);
         snprintf(entry->name, sizeof(entry->name), "%s", resolved);
@@ -155,7 +155,7 @@ LPTEXTURE UIWow_LoadTexture(LPCSTR name) {
     }
 
     {
-        uiWowTexture_t *entry = &wow_ui.textures[wow_ui.texture_recycle_index % WOW_UI_MAX_TEXTURES];
+        uiWowTexture_t *entry = &wow_ui.tex_cache[wow_ui.texture_recycle_index % WOW_UI_MAX_TEXTURES];
 
         wow_ui.texture_recycle_index = (wow_ui.texture_recycle_index + 1) % WOW_UI_MAX_TEXTURES;
         SAFE_DELETE(entry->texture, wow_ui.renderer->ReleaseTexture);
@@ -175,7 +175,7 @@ LPCFONT UIWow_LoadFont(DWORD size) {
         return NULL;
     }
     FOR_LOOP(i, WOW_UI_MAX_FONTS) {
-        uiWowFont_t *entry = &wow_ui.fonts[i];
+        uiWowFont_t *entry = &wow_ui.font_cache[i];
 
         if (entry->font && entry->size == size) {
             return entry->font;
@@ -218,14 +218,11 @@ static void UIWow_Shutdown(void) {
     UIWow_ShutdownLua();
     if (wow_ui.renderer) {
         FOR_LOOP(i, WOW_UI_MAX_TEXTURES) {
-            SAFE_DELETE(wow_ui.textures[i].texture, wow_ui.renderer->ReleaseTexture);
+            SAFE_DELETE(wow_ui.tex_cache[i].texture, wow_ui.renderer->ReleaseTexture);
         }
-        SAFE_DELETE(wow_ui.background, wow_ui.renderer->ReleaseTexture);
-        SAFE_DELETE(wow_ui.bar_background, wow_ui.renderer->ReleaseTexture);
-        SAFE_DELETE(wow_ui.bar_border, wow_ui.renderer->ReleaseTexture);
-        SAFE_DELETE(wow_ui.bar_fill, wow_ui.renderer->ReleaseTexture);
-        SAFE_DELETE(wow_ui.bar_glass, wow_ui.renderer->ReleaseTexture);
-        SAFE_DELETE(wow_ui.bar_glow, wow_ui.renderer->ReleaseTexture);
+        FOR_LOOP(i, WOW_UI_TEX_COUNT) {
+            SAFE_DELETE(wow_ui.textures[i], wow_ui.renderer->ReleaseTexture);
+        }
     }
     memset(&wow_ui, 0, sizeof(wow_ui));
 }
@@ -261,15 +258,17 @@ static void UIWow_ReleaseScreenAssets(void) {
     }
 
     FOR_LOOP(i, WOW_UI_MAX_TEXTURES) {
-        SAFE_DELETE(wow_ui.textures[i].texture, wow_ui.renderer->ReleaseTexture);
-        wow_ui.textures[i].input_name[0] = '\0';
-        wow_ui.textures[i].name[0] = '\0';
+        SAFE_DELETE(wow_ui.tex_cache[i].texture, wow_ui.renderer->ReleaseTexture);
+        wow_ui.tex_cache[i].input_name[0] = '\0';
+        wow_ui.tex_cache[i].name[0] = '\0';
     }
     FOR_LOOP(i, WOW_UI_MAX_FONTS) {
-        wow_ui.fonts[i].font = NULL;
-        wow_ui.fonts[i].size = 0;
+        wow_ui.font_cache[i].font = NULL;
+        wow_ui.font_cache[i].size = 0;
     }
-    SAFE_DELETE(wow_ui.background, wow_ui.renderer->ReleaseTexture);
+    FOR_LOOP(i, WOW_UI_TEX_COUNT) {
+        SAFE_DELETE(wow_ui.textures[i], wow_ui.renderer->ReleaseTexture);
+    }
     wow_ui.texture_recycle_index = 0;
 }
 

--- a/plans/sc2-console-ui-tests.md
+++ b/plans/sc2-console-ui-tests.md
@@ -1,0 +1,299 @@
+# SC2 ConsoleUI Tests — Plan
+
+## Context
+
+The SC2 layout parser (`sc2_layout.c`) has 14 existing tests on `feature/ui-refactoring`
+(commit `22ebb5e0`). These test parsing, templates, constants, includes, and basic
+flattening. The adapter work (anchor resolution, texture/image mapping, flatten completion,
+event wiring) has zero test coverage. The 4 known parser bugs also have no regression tests.
+
+**Goal**: Add tests for the adapter layer, bug fixes, and frame rendering pipeline so
+the ConsoleUI can be built with confidence.
+
+---
+
+## Test File
+
+**New file**: `games/starcraft-2/tests/test_sc2_consoleui.c`
+
+Follows the existing pattern from `test_sc2_layout.c`:
+- Includes `"common.h"`, `"games/starcraft-2/ui/sc2_layout.h"`, `"test_framework.h"`
+- Defines `uiImport_t uiimport` global
+- Uses `setup_sc2_layout_tests()` (idempotent, guarded by static bool)
+- Each test: `SC2_LayoutInit()` → parse fixture → assert → `SC2_LayoutShutdown()`
+
+**Runner update**: `games/starcraft-2/tests/test_sc2_main.c`
+- Add `void run_sc2_consoleui_tests(void);` declaration
+- Call `run_sc2_consoleui_tests()` in `main()`
+
+**Makefile update**: Add `$(SC2_TEST_DIR)/test_sc2_consoleui.c` to the `test-sc2` source list.
+
+---
+
+## New Test Fixture
+
+**File**: `games/starcraft-2/tests/resources-src/UI/Layout/TestAdapter.SC2Layout`
+
+A purpose-built layout that exercises every adapter code path:
+
+```xml
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<Desc>
+    <!-- Constants for offset/size testing -->
+    <Constant name="HUDMargin" val="8"/>
+    <Constant name="PanelWidth" val="200"/>
+
+    <!-- Root container with all 4 anchor sides -->
+    <Frame type="GameUI" name="ConsoleUI">
+        <Anchor relative="$parent"/>
+
+        <!-- Bottom-left panel: tests Left+Bottom anchors -->
+        <Frame type="Frame" name="ResourcePanel">
+            <Width val="200"/>
+            <Height val="40"/>
+            <Anchor side="Left" relative="$parent" pos="Min" offset="#HUDMargin"/>
+            <Anchor side="Bottom" relative="$parent" pos="Max" offset="-40"/>
+            <Anchor side="Top" relative="$parent" pos="Max" offset="-80"/>
+            <Visible val="true"/>
+            <Color val="255,255,255,200"/>
+
+            <Frame type="Image" name="MineralIcon">
+                <Width val="32"/>
+                <Height val="32"/>
+                <Anchor side="Left" relative="$parent" pos="Min" offset="4"/>
+                <Anchor side="Top" relative="$parent" pos="Min" offset="4"/>
+                <Texture val="@@UI/MineralIcon" layer="0"/>
+            </Frame>
+
+            <Frame type="Label" name="MineralCount">
+                <Width val="80"/>
+                <Height val="20"/>
+                <Anchor side="Left" relative="$parent/MineralIcon" pos="Max" offset="4"/>
+                <Anchor side="Top" relative="$parent" pos="Min" offset="8"/>
+                <Visible val="true"/>
+            </Frame>
+        </Frame>
+
+        <!-- Top-right panel: tests Right+Top anchors with stretch -->
+        <Frame type="Frame" name="InfoPanel">
+            <Width val="250"/>
+            <Height val="120"/>
+            <Anchor side="Right" relative="$parent" pos="Max" offset="-8"/>
+            <Anchor side="Top" relative="$parent" pos="Min" offset="8"/>
+            <Visible val="true"/>
+
+            <Frame type="Label" name="UnitName">
+                <Width val="200"/>
+                <Height val="20"/>
+                <Anchor side="Left" relative="$parent" pos="Min" offset="8"/>
+                <Anchor side="Top" relative="$parent" pos="Min" offset="8"/>
+            </Frame>
+
+            <Frame type="Image" name="Portrait">
+                <Width val="96"/>
+                <Height val="96"/>
+                <Anchor side="Right" relative="$parent" pos="Max" offset="-8"/>
+                <Anchor side="Top" relative="$parent" pos="Min" offset="32"/>
+                <Texture val="@@UI/Portrait" layer="0"/>
+            </Frame>
+        </Frame>
+
+        <!-- Command grid: tests Right+Bottom with child grid layout -->
+        <Frame type="Frame" name="CommandArea">
+            <Width val="308"/>
+            <Height val="154"/>
+            <Anchor side="Right" relative="$parent" pos="Max" offset="0"/>
+            <Anchor side="Bottom" relative="$parent" pos="Max" offset="0"/>
+
+            <Frame type="CommandButton" name="Cmd01">
+                <Width val="76"/>
+                <Height val="76"/>
+                <Anchor side="Left" relative="$parent" pos="Min" offset="0"/>
+                <Anchor side="Top" relative="$parent" pos="Min" offset="0"/>
+                <Texture val="@@UI/ButtonNormal" layer="0"/>
+            </Frame>
+
+            <Frame type="CommandButton" name="Cmd02">
+                <Width val="76"/>
+                <Height val="76"/>
+                <Anchor side="Left" relative="$parent/Cmd01" pos="Max" offset="0"/>
+                <Anchor side="Top" relative="$parent" pos="Min" offset="0"/>
+            </Frame>
+
+            <Frame type="CommandButton" name="Cmd03">
+                <Width val="76"/>
+                <Height val="76"/>
+                <Anchor side="Left" relative="$parent/Cmd02" pos="Max" offset="0"/>
+                <Anchor side="Top" relative="$parent" pos="Min" offset="0"/>
+            </Frame>
+        </Frame>
+
+        <!-- Center label: tests Mid anchor -->
+        <Frame type="Label" name="CenterAlert">
+            <Width val="300"/>
+            <Height val="40"/>
+            <Anchor side="Left" relative="$parent" pos="Mid" offset="0"/>
+            <Anchor side="Top" relative="$parent" pos="Mid" offset="0"/>
+            <Visible val="false"/>
+        </Frame>
+
+        <!-- Hidden panel: tests visibility in hierarchy -->
+        <Frame type="Frame" name="HiddenPanel">
+            <Width val="100"/>
+            <Height val="100"/>
+            <Anchor side="Left" relative="$parent" pos="Min" offset="0"/>
+            <Anchor side="Top" relative="$parent" pos="Min" offset="0"/>
+            <Visible val="false"/>
+
+            <Frame type="Label" name="HiddenChild">
+                <Width val="50"/>
+                <Height val="20"/>
+                <Anchor side="Left" relative="$parent" pos="Min" offset="0"/>
+                <Anchor side="Top" relative="$parent" pos="Min" offset="0"/>
+            </Frame>
+        </Frame>
+    </Frame>
+</Desc>
+```
+
+This fixture provides:
+- All 4 anchor sides (Top, Bottom, Left, Right) with Min/Mid/Max positions
+- Constant references in offsets (`#HUDMargin`)
+- Cross-frame relative anchors (`$parent/Cmd01`)
+- Multiple child depths (root → panel → icon/label)
+- Texture references for image resolution testing
+- Visibility flags (visible + hidden + hidden hierarchy)
+- CommandButton frames for SC2-specific type testing
+- Stretch layout (two anchors on same axis: ResourcePanel has Left+Bottom but also Top+Bottom for vertical stretch)
+- Mid anchor (CenterAlert)
+
+---
+
+## Test Cases (16 tests)
+
+### Group 1: Parser Bug Fixes (4 tests)
+
+These verify the 4 known bugs are fixed. They serve as regression tests.
+
+#### `test_adapter_constant_hash_stripping`
+Parse `TestAdapter.SC2Layout`. Verify `SC2_LayoutResolveConstant("##HUDMargin")`
+returns `"8"` and `SC2_LayoutResolveConstant("##PanelWidth")` returns `"200"`.
+Also test double-hash specifically: `"##HUDMargin"` must resolve (Bug 1 fix).
+
+#### `test_adapter_constant_offset_resolves`
+Parse `TestAdapter.SC2Layout`. Find `ResourcePanel` frame. Verify
+`anchors[0].offset` == 8 (resolved from `#HUDMargin`). This tests Bug 3 fix:
+constants in anchor offsets must be resolved before atoi.
+
+#### `test_adapter_template_inheritance_ordering`
+Parse `TestGameUI.SC2Layout`. Find `ActionButton01`. Verify it inherited
+width=300, height=75 from `TestButtonTemplate` and has 3 anchors (2 from base
++ 1 override). This tests Bug 2 fix: same-file template ordering.
+
+#### `test_adapter_cross_file_template_inheritance`
+Parse `TestGameUI.SC2Layout`. Find `IncludedPanel`. Verify it inherited
+width=100, height=50 from `IncludedFrame` in `TestIncluded.SC2Layout`.
+This tests Bug 4 fix: cross-file template resolution.
+
+### Group 2: Anchor Resolution (5 tests)
+
+These test `SC2_ResolveAnchors` — the core adapter mapping SC2 anchors to
+`uiBaseFrame_t.points`.
+
+#### `test_adapter_single_anchor_left_min`
+Parse `TestAdapter.SC2Layout`. Flatten. Find `MineralIcon` frame.
+Verify `points.x[FPP_MIN].used == true`, `points.x[FPP_MIN].targetPos == FPP_MIN`,
+`points.x[FPP_MIN].relative_index` resolves to `ResourcePanel`'s index.
+
+#### `test_adapter_single_anchor_top_min`
+Find `MineralIcon`. Verify `points.y[FPP_MIN].used == true`,
+`points.y[FPP_MIN].targetPos == FPP_MIN`.
+
+#### `test_adapter_dual_anchor_stretch`
+Find `ResourcePanel`. It has `Left+Min` and `Right+Max` on x-axis? No — it has
+`Left+Min` only. Let me re-check... Actually the fixture has ResourcePanel with
+Left+Bottom+Top anchors. Top+Bottom on y-axis = stretch. Verify
+`points.y[FPP_MIN].used == true` and `points.y[FPP_MAX].used == true` — dual
+anchor stretch on y-axis.
+
+#### `test_adapter_mid_anchor`
+Find `CenterAlert`. Verify `points.x[FPP_MID].used == true` and
+`points.y[FPP_MID].used == true`. The mid anchor centers the frame.
+
+#### `test_adapter_cross_frame_relative`
+Find `Cmd02`. Its Left anchor references `$parent/Cmd01`. Verify
+`points.x[FPP_MIN].relative_index` resolves to Cmd01's frame index (not parent).
+
+### Group 3: Flatten / Frame Population (4 tests)
+
+These test `SC2_FlattenFrame` — correct population of `uiBaseFrame_t` fields.
+
+#### `test_adapter_flatten_frame_count`
+Parse `TestAdapter.SC2Layout`. Flatten. Count should be exactly 15 frames
+(ConsoleUI + ResourcePanel + MineralIcon + MineralCount + InfoPanel + UnitName
++ Portrait + CommandArea + Cmd01 + Cmd02 + Cmd03 + CenterAlert + HiddenPanel
++ HiddenChild = 14, plus root = 15). Verify count matches.
+
+#### `test_adapter_flatten_types_mapped`
+Verify `SC2_MapFrameType` mapping for each type in the fixture:
+- `ConsoleUI` → `FT_FRAME`
+- `Cmd01` → `FT_BUTTON`
+- `MineralIcon` → `FT_SPRITE`
+- `MineralCount` → `FT_TEXT`
+- `Portrait` → `FT_SPRITE`
+
+#### `test_adapter_flatten_hidden_flags`
+Find `HiddenPanel`: verify `hidden == true`, `ui_flags & UIFLAG_HIDDEN`.
+Find `HiddenChild`: verify it's a child of HiddenPanel in the flat array.
+Find `CenterAlert`: verify `hidden == true` (Visible val="false").
+Find `ResourcePanel`: verify `hidden == false`.
+
+#### `test_adapter_flatten_color_alpha`
+Find `ResourcePanel`. Verify `color` == `{255, 255, 255, 200}` (from XML).
+Find `ConsoleUI`. Verify `color` == `{255, 255, 255, 255}` (default white).
+
+### Group 4: Screen Rect Computation (3 tests)
+
+These test the full pipeline: parse → flatten → `CL_UIBaseLayoutRect` (client layout solver).
+Since the test binary doesn't link the client, we test the flatten output has the
+data the client needs, and add a minimal local layout solver for verification.
+
+#### `test_adapter_screen_rect_root_covers_scene`
+Parse + flatten. The root `ConsoleUI` frame has `Anchor relative="$parent"`.
+After the client's layout solver runs, root should cover the full scene rect.
+We verify by checking that root's `parent_index == (DWORD)-1` (indicating it
+attaches to the scene root).
+
+#### `test_adapter_screen_rect_child_relative_to_parent`
+Find `MineralCount`. Its Left anchor references `$parent/MineralIcon`.
+Verify `points.x[FPP_MIN].relative_index` is NOT the parent index — it's
+MineralIcon's index. This confirms cross-frame references work.
+
+#### `test_adapter_screen_rect_hidden_no_draw`
+Find `HiddenPanel` in flat array. Verify `hidden == true`. The client skips
+drawing hidden frames, so this confirms the flag is set correctly.
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `games/starcraft-2/tests/test_sc2_consoleui.c` | **New** — 16 test cases |
+| `games/starcraft-2/tests/test_sc2_main.c` | Add `run_sc2_consoleui_tests()` call |
+| `games/starcraft-2/tests/resources-src/UI/Layout/TestAdapter.SC2Layout` | **New** — test fixture |
+| `Makefile` | Add `test_sc2_consoleui.c` to `test-sc2` source list |
+
+## Build & Verify
+
+```bash
+make test-sc2
+# Should show: 185+16 = ~201 layout+adapter assertions, all passing
+```
+
+## Dependency
+
+These tests depend on the adapter implementation being complete (Phases 1-3 of the
+implementation plan). The bug fix tests (Group 1) can be written and run immediately
+as regression tests — they should pass once the fixes are applied. The anchor/flatten/
+screen rect tests (Groups 2-4) require the adapter code to be implemented first.

--- a/plans/sc2-console-ui.md
+++ b/plans/sc2-console-ui.md
@@ -1,0 +1,192 @@
+# SC2 ConsoleUI via WC3 Renderer Reuse — Implementation Plan
+
+## Context
+
+The SC2 `.SC2Layout` XML parser (`sc2_layout.c`, 924 lines) exists on `feature/ui-refactoring`
+(commit `22ebb5e0`). It parses XML into `sc2Frame_t` trees, resolves templates/constants, and
+flattens into `uiBaseFrame_t[]`. The client already has `CL_UIBaseLayoutRect()` (`cl_layout.c`)
+that solves layout for `uiBaseFrame_t` directly — no need to route through WC3's `FRAMEDEF`.
+
+The parser has 4 known bugs and the flatten/adapter step is incomplete (anchors stubbed,
+textures unresoled, event handlers unwired). The `ui_main.c` entry point is all stubs.
+
+**Goal**: Fix the parser, complete the adapter, and wire up enough SC2 ConsoleUI rendering
+to see the in-game HUD frames positioned and drawn.
+
+---
+
+## Phase 1: Fix Parser Bugs (4 fixes in `sc2_layout.c`)
+
+### Bug 1 — `##` constant resolution (line ~238)
+`SC2_LayoutResolveConstant()` only strips one `#`. SC2 uses `##Name` prefix.
+**Fix**: `while (*name == '#') name++;` instead of single `if` + `name++`.
+
+### Bug 2 — Template inheritance ordering (same-file templates)
+When `TestButtonTemplate` references `TestBaseTemplate` in the same file, the base
+template may not have its properties populated yet during sequential parsing.
+**Fix**: Add a second resolution pass after all frames in a file are parsed. Or defer
+template property copying to flatten time when all templates are guaranteed complete.
+
+### Bug 3 — Constant resolution in anchor offsets
+`SC2_ParseAnchor` reads offset via `atoi()` directly, never calling
+`SC2_LayoutResolveConstant()` on the raw string first.
+**Fix**: Read offset as string, resolve `##constant`, then `atoi()`. Same for
+`<Width val="..."/>` and `<Height val="..."/>` children.
+
+### Bug 4 — Cross-file template inheritance
+`IncludedPanel` referencing `template="TestIncluded/IncludedFrame"` from an included
+file — the template may not be found or may lack properties at resolution time.
+**Fix**: Verify `SC2_ResolveTemplatePath` basename lookup works across files; ensure
+included templates are fully parsed before consumers.
+
+**Files**: `games/starcraft-2/ui/sc2_layout.c`
+**Verify**: `build/bin/test_sc2` — aim for 236/236 assertions passing.
+
+---
+
+## Phase 2: Complete the Anchor Adapter (`SC2_ResolveAnchors`)
+
+Map SC2's 4-side anchor model to `uiBaseFrame_t.points.x/y[3]`:
+
+```
+SC2 side   axis   pos    →  frame point
+─────────────────────────────────────────
+Top        y      Min    →  points.y[FPP_MIN]
+Bottom     y      Max    →  points.y[FPP_MAX]
+Left       x      Min    →  points.x[FPP_MIN]
+Right      x      Max    →  points.x[FPP_MAX]
+```
+
+For each active anchor:
+1. Map `sc2Anchor_t.side` → axis (x or y)
+2. Map `sc2Anchor_t.pos` → `FPP_MIN`, `FPP_MID`, or `FPP_MAX`
+3. Resolve `sc2Anchor_t.relative` (`"$parent"` → `parent_index`, `"$root"` → 0,
+   named frame → lookup by name in the flat array)
+4. Convert `sc2Anchor_t.offset` (int16 pixels) to FLOAT normalized offset
+
+The `CL_UIBaseSolveAxisPosition()` in `cl_layout.c` already handles:
+- Single anchor (min or max only) → position + size
+- Dual anchors (min+max) → stretch to fill
+- Mid anchor → center on point
+
+**Files**: `games/starcraft-2/ui/sc2_layout.c` (`SC2_ResolveAnchors` function)
+
+---
+
+## Phase 3: Complete Flatten Step
+
+In `SC2_FlattenFrame()`, populate remaining `uiBaseFrame_t` fields:
+
+### Textures
+- `frame->textures[0].resource` → `dst->image` (store raw reference; renderer resolves)
+- `frame->textures[0].tiled` → `dst->backdrop.tile`
+- Texture type mapping: `"Normal"` → `dst->image`, `"Border"` → `dst->backdrop.edge`,
+  `"HorizontalBorder"` → backdrop edge with tile flag
+
+### Text
+- SC2 `Label` frames with inline text → `dst->text`
+- SC2 frames with `<Text val="..."/>` child → `dst->text`
+
+### Backdrop
+- First tiled texture → `dst->backdrop.bg`
+- Border texture → `dst->backdrop.edge`
+- Color → `dst->color`
+
+### Event handlers
+- Assign `dst->on_event` for buttons (SC2 command buttons need click handling)
+- Assign `dst->on_draw` for SC2-specific panel types that need custom rendering
+
+**Files**: `games/starcraft-2/ui/sc2_layout.c` (`SC2_FlattenFrame`, `SC2_ResolveAnchors`)
+
+---
+
+## Phase 4: Wire `ui_main.c` Callbacks
+
+Fill in the stub functions in `games/starcraft-2/ui/ui_main.c`:
+
+### `SC2_UI_MouseEvent`
+1. Convert pixel coords to FDF space (use `SCR_MouseToFdf` equivalent)
+2. Hit-test against `uiBaseFrame_t[]` (iterate back-to-front, point-in-rect)
+3. Set `UIFLAG_HOVERED` / `UIFLAG_PRESSED` on hit frame
+4. Dispatch to frame's `on_event` callback
+
+### `SC2_UI_HitTestLayout`
+Iterate frames, return true if any visible non-hidden frame contains the point.
+
+### `SC2_UI_KeyEvent`
+Forward to focused frame (editbox) if any.
+
+### `SC2_UI_Refresh`
+Increment time, update animations if any.
+
+### `SC2_UI_UpdateUnitUI`
+Store unit data for HUD panels to read during draw.
+
+**Files**: `games/starcraft-2/ui/ui_main.c`
+
+---
+
+## Phase 5: SC2-Specific Frame Renderers
+
+For the ConsoleUI HUD, these SC2 frame types need custom `on_draw` callbacks:
+
+### `CommandButton` (SC2_FRAMETYPE_COMMAND_BUTTON)
+Draw ability icon from unit data, cooldown overlay, hotkey label.
+Similar to WC3's `FT_COMMANDBUTTON` but uses SC2's XML-defined grid.
+
+### `ResourcePanel` (SC2_FRAMETYPE_RESOURCE_PANEL)
+Draw mineral/gas/supply counts. Reads from game state.
+
+### `PortraitPanel` (SC2_FRAMETYPE_PORTRAIT_PANEL)
+Render 3D model portrait of selected unit. Uses renderer's model API.
+
+### `Minimap` (SC2_FRAMETYPE_MINIMAP)
+Render minimap terrain + units. Uses renderer's minimap API.
+
+### `InfoPanel` (SC2_FRAMETYPE_INFO_PANEL)
+Draw selected unit's name, health bar, stats.
+
+### Generic frames
+All SC2 types mapped to `FT_FRAME` just render children — no custom draw needed.
+The layout solver positions them; the client renders their children recursively.
+
+**Files**: `games/starcraft-2/ui/ui_render.c` (new file), `games/starcraft-2/ui/ui_main.c`
+
+---
+
+## Phase 6: Integration and Testing
+
+1. Build: `make opensc2` should link with `libui-sc2`
+2. Run: `build/bin/opensc2 -data "..." +map "Maps/Test/MarSara.SC2Map"`
+3. Verify: SC2 ConsoleUI frames appear positioned on screen
+4. Test: `build/bin/test_sc2` passes all 14 layout test cases
+
+---
+
+## Key Files
+
+| File | Action |
+|------|--------|
+| `games/starcraft-2/ui/sc2_layout.c` | Fix 4 bugs, complete `SC2_ResolveAnchors`, complete `SC2_FlattenFrame` |
+| `games/starcraft-2/ui/sc2_layout.h` | No changes needed |
+| `games/starcraft-2/ui/ui_main.c` | Wire event callbacks, add hit test, add mouse/key handlers |
+| `games/starcraft-2/ui/ui_render.c` | New — SC2-specific frame draw callbacks |
+| `client/cl_layout.c` | Already works — no changes needed |
+| `client/ui.h` | Already has `uiBaseFrame_t` — no changes needed |
+| `games/starcraft-2/tests/test_sc2_layout.c` | May need assertion updates after bug fixes |
+
+## What We Get From WC3 (Free)
+
+- Layout constraint solver (`CL_UIBaseLayoutRect` in `cl_layout.c`)
+- Scene rect computation (`SCR_GetUISceneRect`)
+- Mouse-to-coordinate conversion (`SCR_MouseToFdf`)
+- Frame hit testing infrastructure
+- All generic frame type rendering (containers, images, text, buttons)
+- The `uiImport_t`/`uiExport_t` contract
+
+## What We Build New
+
+- SC2 anchor model → `uiBaseFrame_t.points` adapter
+- SC2 `.SC2Layout` XML → `sc2Frame_t` parser (already done, needs bug fixes)
+- SC2-specific frame draw callbacks (CommandButton, ResourcePanel, PortraitPanel, Minimap, InfoPanel)
+- SC2 event dispatch (mouse, keyboard)

--- a/plans/sc2-layout-parser.md
+++ b/plans/sc2-layout-parser.md
@@ -1,0 +1,172 @@
+# SC2 XML Layout Parser — Current State & Bug Fixes
+
+## Status
+
+The SC2 `.SC2Layout` XML parser (`sc2_layout.c`, ~920 lines) is built, compiles,
+and loads real game HUD layout files. A separate `libui-sc2` UI library exists.
+A custom test suite (`test_sc2_layout.c`, 14 test cases) is written and runs.
+
+Test run result: **185/236 assertions pass, 51 fail** (map tests are unrelated
+regressions from earlier work, not layout-related).
+
+---
+
+## Architecture
+
+- `games/starcraft-2/ui/sc2_layout.c` — XML parser, template inheritance, constant registry,
+  frame tree builder, flattening into `uiBaseFrame_t[]`
+- `games/starcraft-2/ui/sc2_layout.h` — public API and types
+- `games/starcraft-2/ui/ui_main.c` — SC2 UI library entry (`UI_GetAPI()`)
+- `games/starcraft-2/tests/test_sc2_layout.c` — 14 test cases with `.SC2Layout` fixtures
+- `games/starcraft-2/tests/resources-src/UI/Layout/` — fixture `.SC2Layout` files
+- Build: `opensc2` links `-lui-sc2`; test-sc2 compiles layout tests manually
+
+### Key design decisions
+
+- Uses libxml2 (already linked for `sc2_map.c`)
+- Template lookup uses basename fallback (`Dir/Name` → `Name`)
+- Template inheritance is deep clone of children + property overlay
+- `SC2_MAX_FRAMES` = 4096, `SC2_MAX_TEMPLATES` = 1024, `SC2_MAX_CHILDREN` = 64 per frame
+- Test uses `FS_ReadFileQ3` wrapper to match `uiImport_t.FS_ReadFile` signature
+- Test MPQ packed manually with `mpqtool pack` using forward-slash paths
+
+---
+
+## Bugs Found (from test run)
+
+### Bug 1: Double-hash `##` constant resolution
+
+**Symptom:** `test_layout_constants_parsed` fails — `SC2_LayoutResolveConstant("##TestColorRed")`
+returns NULL instead of `"255,0,0"`.
+
+**Root cause:** `SC2_LayoutResolveConstant()` only strips one `#`:
+
+```c
+if (!name || name[0] != '#') return name;
+name++; /* skip '#' */
+```
+
+But SC2 constants are referenced with `##` prefix. After stripping one `#`, the
+name is `#TestColorRed`, which doesn't match the stored `TestColorRed`.
+
+**Fix:** Strip all leading `#` characters, not just one:
+
+```c
+while (*name == '#') name++;
+```
+
+### Bug 2: Template inheritance — same-file templates don't inherit properly
+
+**Symptom:** `test_layout_template_inheritance` fails — `button->num_anchors == 1` but expected 3.
+`test_layout_gameui_full_parse` fails — `included->has_width` is false, `button->has_width` is false.
+
+**Root cause:** Templates within the same file are parsed sequentially. When
+`TestButtonTemplate` declares `template="TestTemplates/TestBaseTemplate"`, the
+`SC2_ResolveTemplate` is called during the parse of `TestButtonTemplate`. But
+`TestBaseTemplate` exists in the same file and may not have been fully parsed yet
+(anchors, textures not yet populated when the template reference is resolved).
+
+**Diagnosis needed:** Read the frame parsing code to confirm ordering. The fix is
+likely: do a second pass after all frames are parsed to resolve template
+references, or ensure templates are parsed bottom-up within a file.
+
+### Bug 3: Constant resolution in anchor offsets (`#TestGap`)
+
+**Symptom:** `test_layout_constant_offset` fails — `button->anchors[0].offset == 0` but expected 4.
+
+**Root cause:** `SC2_ParseAnchor` reads offset via `xmlGetAttrInt(node, "offset", ...)` which
+does `atoi()` directly. It never calls `SC2_LayoutResolveConstant()` on the raw
+attribute string before parsing.
+
+**Fix:** In `SC2_ParseAnchor`, read the offset as a string first, run it through
+`SC2_LayoutResolveConstant()`, then `atoi()` the result:
+
+```c
+LPCSTR offset_str = SC2_XmlGetProp(node, "offset");
+if (offset_str) {
+    LPCSTR resolved = SC2_LayoutResolveConstant(offset_str);
+    a->offset = (int16_t)atoi(resolved);
+    SC2_XmlFree(offset_str);
+}
+```
+
+Same fix needed for `<Width val="..."/>` and `<Height val="..."/>` children that
+may use `#constant` values.
+
+### Bug 4: GameUI template inheritance for IncludedPanel
+
+**Symptom:** `test_layout_gameui_full_parse` — `IncludedPanel` child frames don't inherit
+width/height from their template.
+
+**Root cause:** Related to Bug 2 — `IncludedFrame` is defined in `TestIncluded.SC2Layout`
+which is included via `<Include>`. The include is processed recursively, so
+`IncludedFrame` should be parsed before `GameUI`. But the `template="TestIncluded/IncludedFrame"`
+reference on `IncludedPanel` uses a path with a directory prefix. The basename
+lookup should find `IncludedFrame`, but the template may not have its properties
+yet (same ordering issue as Bug 2).
+
+**Verify:** Add debug output to `SC2_ResolveTemplatePath` to confirm it finds the
+template, and that the template has `has_width` set at resolution time.
+
+---
+
+## Test Failure Summary
+
+| Test | Status | Root Cause |
+|------|--------|------------|
+| test_layout_constants_parsed | FAIL | Bug 1 (## stripping) |
+| test_layout_unknown_constant_returns_null | PASS | — |
+| test_layout_include_resolves | PASS | — |
+| test_layout_template_inheritance | FAIL | Bug 2 (same-file ordering) |
+| test_layout_template_children | PASS | — |
+| test_layout_gameui_full_parse | FAIL | Bug 2 + Bug 4 |
+| test_layout_nested_children | PASS | — |
+| test_layout_anchors_parsed | PASS | — |
+| test_layout_textures_parsed | PASS | — |
+| test_layout_flatten_to_frames | FAIL | Likely Bug 2 (inherited frames missing) |
+| test_layout_multiple_parses | FAIL | Bug 1 (constants not resolved) |
+| test_layout_reinit_clears | PASS | — |
+| test_layout_constant_offset | FAIL | Bug 3 (offset not resolved) |
+| test_layout_texture_layers | PASS | — |
+
+---
+
+## Fix Plan (in order)
+
+1. **Fix Bug 1** — `SC2_LayoutResolveConstant`: strip all leading `#` chars
+2. **Fix Bug 3** — `SC2_ParseAnchor`: resolve `#constant` offsets before atoi
+3. **Fix Bug 3 for Width/Height** — `SC2_ParseFrameChildren`: resolve `#constant` in
+   `<Width val="..."/>` and `<Height val="..."/>` before parsing as float
+4. **Fix Bug 2** — Template inheritance ordering: add a second resolution pass
+   after all frames in a file are parsed, or defer template resolution until
+   flatten time
+5. **Fix Bug 4** — Verify GameUI template path lookup finds templates from included files
+6. **Re-run tests** — `build/bin/test_sc2`
+
+---
+
+## MPQ Test Fixture
+
+Packed via:
+```
+build/bin/mpqtool create build/tests/test-sc2.SC2Maps \
+    Maps/Test/MarSara.SC2Map tests/resources-src/Maps/Test/MarSara.SC2Map \
+    Maps/Test/Tiny.SC2Map tests/resources-src/Maps/Test/Tiny.SC2Map \
+    UI/Layout/TestConstants.SC2Layout tests/resources-src/UI/Layout/TestConstants.SC2Layout \
+    UI/Layout/TestIncluded.SC2Layout tests/resources-src/UI/Layout/TestIncluded.SC2Layout \
+    UI/Layout/TestTemplates.SC2Layout tests/resources-src/UI/Layout/TestTemplates.SC2Layout \
+    UI/Layout/TestGameUI.SC2Layout tests/resources-src/UI/Layout/TestGameUI.SC2Layout
+```
+
+---
+
+## Files To Edit
+
+| File | Change |
+|------|--------|
+| `games/starcraft-2/ui/sc2_layout.c:238` | Strip all leading `#` in `SC2_LayoutResolveConstant` |
+| `games/starcraft-2/ui/sc2_layout.c:398` | Resolve `#constant` in anchor offset before `atoi` |
+| `games/starcraft-2/ui/sc2_layout.c` (frame parse) | Resolve `#constant` in Width/Height val before parse |
+| `games/starcraft-2/ui/sc2_layout.c` (frame parse) | Resolve `#constant` in Color, Visible, Alpha val attributes |
+| `games/starcraft-2/ui/sc2_layout.c` (template resolution) | Defer or second-pass template resolution |
+| `games/starcraft-2/tests/test_sc2_layout.c` | Update assertions if needed after fixes |


### PR DESCRIPTION
Port the SC2 .SC2Layout XML parser from feature/sc2-ui for issue #83.

**Parser** (sc2_layout.c, 1170 lines):
- Parses XML into sc2Frame_t tree, resolves Include directives
- Template inheritance via deep-clone + property merge
- Constants (##Name → value) with hash-stripping fix
- Flattens to uiBaseFrame_t[] for client rendering
- 4 known bugs fixed: ## stripping, template ordering, constant offsets, cross-file inheritance

**Tests** (30 cases, all passing):
- test_sc2_layout.c: 14 parser tests (constants, includes, templates, flatten, reinit)
- test_sc2_consoleui.c: 16 adapter tests (bug regression, anchor resolution, frame population, screen rect)

**Shared types** added to common/shared.h:
- uiBaseFramePoint_t, uiBaseFramePoints_t
- UIFLAG_* constants (PRESSED, HOVERED, CHECKED, HIDDEN, DISABLED, HIDDEN_IN_HIERARCHY)
- uiBaseFrame_t struct with on_event/on_draw callbacks

Fixes UIFLAG_DISABLED redefinition warning in WC3 ui_local.h by removing duplicate definitions now provided by shared.h.

Closes #83