### PR TITLE
Fix UI fdf symbol clash

### DIFF
--- a/games/warcraft-3/common/stb_fdf.h
+++ b/games/warcraft-3/common/stb_fdf.h
@@ -523,6 +523,8 @@ void UI_MenuAddItem(LPFRAMEDEF frame, LPCSTR text, LONG value);
 #include <strings.h>
 #endif
 
+#pragma GCC visibility push(hidden)
+
 /* ---- Tokenizer (merged from parser.c) ------------------------------------ */
 
 #define PARSER_MAX_SEGMENT 1024
@@ -1924,6 +1926,8 @@ void UI_SetTexture(LPFRAMEDEF frame, LPCSTR name, BOOL decorate) {
 void UI_SetTexture2(LPFRAMEDEF frame, LPCSTR name, BOOL decorate) {
     frame->Texture.Image2 = UI_LoadTexture(name, decorate);
 }
+
+#pragma GCC visibility pop
 
 #endif /* STB_FDF_IMPLEMENTATION */
 

--- a/games/warcraft-3/game/hud/hud.c
+++ b/games/warcraft-3/game/hud/hud.c
@@ -279,21 +279,23 @@ void UI_AddCreateGameSlot(DWORD slot, LPCSTR name, LPCSTR race, LPCSTR color, DW
     (void)slot; (void)name; (void)race; (void)color; (void)team;
 }
 
+#define BZ_HOST_HIDDEN __attribute__((visibility("hidden")))
+
 /* FDF host services — game module implementations using gi */
-HANDLE UI_FdfAlloc(long size) { return gi.MemAlloc(size); }
-void UI_FdfFree(HANDLE ptr) { gi.MemFree(ptr); }
-DWORD UI_FdfFontIndex(LPCSTR name, DWORD size) { return gi.FontIndex(name, size); }
-int UI_FdfReadFile(LPCSTR name, HANDLE *out) {
+BZ_HOST_HIDDEN HANDLE UI_FdfAlloc(long size) { return gi.MemAlloc(size); }
+BZ_HOST_HIDDEN void UI_FdfFree(HANDLE ptr) { gi.MemFree(ptr); }
+BZ_HOST_HIDDEN DWORD UI_FdfFontIndex(LPCSTR name, DWORD size) { return gi.FontIndex(name, size); }
+BZ_HOST_HIDDEN int UI_FdfReadFile(LPCSTR name, HANDLE *out) {
     DWORD size = 0;
     *out = gi.ReadFile(name, &size);
     return *out ? (int)size : -1;
 }
-void UI_FdfFreeFile(HANDLE buf) { gi.MemFree(buf); }
+BZ_HOST_HIDDEN void UI_FdfFreeFile(HANDLE buf) { gi.MemFree(buf); }
 
 /* Game module doesn't handle UI events or themes — stub these */
 void UI_WireFrameTypeFunctions(LPFRAMEDEF frame) { (void)frame; }
 void UI_ClearTheme(void) {}
-void UI_ClearTextures(void) {}
+BZ_HOST_HIDDEN void UI_ClearTextures(void) {}
 
 /* Game module doesn't load 3D models for UI — stub */
-DWORD UI_LoadModel(LPCSTR file, BOOL decorate) { (void)file; (void)decorate; return 0; }
+BZ_HOST_HIDDEN DWORD UI_LoadModel(LPCSTR file, BOOL decorate) { (void)file; (void)decorate; return 0; }

--- a/games/warcraft-3/game/hud/hud.c
+++ b/games/warcraft-3/game/hud/hud.c
@@ -293,8 +293,8 @@ BZ_HOST_HIDDEN int UI_FdfReadFile(LPCSTR name, HANDLE *out) {
 BZ_HOST_HIDDEN void UI_FdfFreeFile(HANDLE buf) { gi.MemFree(buf); }
 
 /* Game module doesn't handle UI events or themes — stub these */
-void UI_WireFrameTypeFunctions(LPFRAMEDEF frame) { (void)frame; }
-void UI_ClearTheme(void) {}
+BZ_HOST_HIDDEN void UI_WireFrameTypeFunctions(LPFRAMEDEF frame) { (void)frame; }
+BZ_HOST_HIDDEN void UI_ClearTheme(void) {}
 BZ_HOST_HIDDEN void UI_ClearTextures(void) {}
 
 /* Game module doesn't load 3D models for UI — stub */

--- a/games/warcraft-3/game/hud/hud_cinematic.c
+++ b/games/warcraft-3/game/hud/hud_cinematic.c
@@ -35,7 +35,7 @@ void UI_ShowInterface(LPEDICT ent, BOOL flag, FLOAT duration) {
         ent->client->ps.uiflags = ~(1u << LAYER_CINEMATIC);
 }
 
-void UI_ShowMainMenu(LPEDICT ent) { (void)ent; }
+__attribute__((visibility("hidden"))) void UI_ShowMainMenu(LPEDICT ent) { (void)ent; }
 
 void UI_ShowGameInterface(LPEDICT ent) {
     UI_WriteCinematicLayer(ent);

--- a/games/warcraft-3/game/hud/hud_write.c
+++ b/games/warcraft-3/game/hud/hud_write.c
@@ -243,13 +243,15 @@ LPCSTR UI_FormatMessageText(LPCSTR text) {
     return out;
 }
 
-DWORD UI_LoadTexture(LPCSTR path, BOOL forcewrap) {
+#define BZ_HOST_HIDDEN __attribute__((visibility("hidden")))
+
+BZ_HOST_HIDDEN DWORD UI_LoadTexture(LPCSTR path, BOOL forcewrap) {
     (void)forcewrap;
     /* The shipped Hero*Icon skin entries name absent files; register WC3's matching infocard assets instead. */
     return gi.ImageIndex(UI_ResolveTextureAlias(path));
 }
 
-LPCSTR Theme_String(LPCSTR key, LPCSTR def) {
+BZ_HOST_HIDDEN LPCSTR Theme_String(LPCSTR key, LPCSTR def) {
     LPCSTR value = NULL;
     if (key && !strstr(key, "\\") && game.config.theme) {
         value = FS_FindSheetCell(game.config.theme, "Default", key);
@@ -257,7 +259,7 @@ LPCSTR Theme_String(LPCSTR key, LPCSTR def) {
     return value ? value : def;
 }
 
-FLOAT Theme_Float(LPCSTR key, LPCSTR def) {
+BZ_HOST_HIDDEN FLOAT Theme_Float(LPCSTR key, LPCSTR def) {
     (void)key;
     return def ? atof(def) : 0.0f;
 }

--- a/games/warcraft-3/ui/ui_fdf.c
+++ b/games/warcraft-3/ui/ui_fdf.c
@@ -53,7 +53,7 @@ static LPCSTR EnsureExtension(LPCSTR file, LPCSTR ext) {
     return file;
 }
 
-DWORD UI_LoadTexture(LPCSTR file, BOOL decorate) {
+BZ_HOST_HIDDEN DWORD UI_LoadTexture(LPCSTR file, BOOL decorate) {
     LPRENDERER renderer;
     LPCSTR resolved;
     DWORD index;

--- a/games/warcraft-3/ui/ui_fdf.c
+++ b/games/warcraft-3/ui/ui_fdf.c
@@ -17,6 +17,8 @@
 #define MAX_IMAGES  1024
 #define MAX_MODELS  256
 
+#define BZ_HOST_HIDDEN __attribute__((visibility("hidden")))
+
 /* ---- Texture/model cache (UI-module specific) ----------------------------- */
 
 static LPCTEXTURE ui_textures[MAX_IMAGES] = { 0 };
@@ -26,7 +28,7 @@ static BOOL ui_texture_decorated[MAX_IMAGES] = { 0 };
 static LPCMODEL ui_models[MAX_MODELS] = { 0 };
 static PATHSTR ui_model_names[MAX_MODELS] = { 0 };
 
-void UI_ClearTextures(void) {
+BZ_HOST_HIDDEN void UI_ClearTextures(void) {
     memset(ui_textures, 0, sizeof(ui_textures));
     memset(ui_texture_names, 0, sizeof(ui_texture_names));
     memset(ui_texture_keys, 0, sizeof(ui_texture_keys));
@@ -116,7 +118,7 @@ LPCMODEL UI_GetModel(DWORD index) {
     return ui_models[index];
 }
 
-DWORD UI_LoadModel(LPCSTR file, BOOL decorate) {
+BZ_HOST_HIDDEN DWORD UI_LoadModel(LPCSTR file, BOOL decorate) {
     LPRENDERER renderer = NULL;
     DWORD modelIndex = 0;
     LPCSTR model = file;
@@ -145,14 +147,14 @@ DWORD UI_GetTime(void) { return 0; /* TODO: implement via client time */ }
 
 /* ---- FDF host services (UI module) ---------------------------------------- */
 
-HANDLE UI_FdfAlloc(long size) { return uiimport.MemAlloc(size); }
-void UI_FdfFree(HANDLE ptr) { uiimport.MemFree(ptr); }
-DWORD UI_FdfFontIndex(LPCSTR name, DWORD size) { return uiimport.FontIndex(name, size); }
-int UI_FdfReadFile(LPCSTR name, HANDLE *out) {
+BZ_HOST_HIDDEN HANDLE UI_FdfAlloc(long size) { return uiimport.MemAlloc(size); }
+BZ_HOST_HIDDEN void UI_FdfFree(HANDLE ptr) { uiimport.MemFree(ptr); }
+BZ_HOST_HIDDEN DWORD UI_FdfFontIndex(LPCSTR name, DWORD size) { return uiimport.FontIndex(name, size); }
+BZ_HOST_HIDDEN int UI_FdfReadFile(LPCSTR name, HANDLE *out) {
     int size = uiimport.FS_ReadFile(name, out);
     return size;
 }
-void UI_FdfFreeFile(HANDLE buf) { uiimport.FS_FreeFile(buf); }
+BZ_HOST_HIDDEN void UI_FdfFreeFile(HANDLE buf) { uiimport.FS_FreeFile(buf); }
 
 /* ---- UI_BindMapList (UI-module specific) ----------------------------------- */
 

--- a/games/warcraft-3/ui/ui_main.c
+++ b/games/warcraft-3/ui/ui_main.c
@@ -111,7 +111,7 @@ uiScreen_t *UI_GetCurrentScreen(void) {
     return ui_current_screen;
 }
 
-void UI_ShowMainMenu(void) {
+__attribute__((visibility("hidden"))) void UI_ShowMainMenu(void) {
     UI_SetScreen(&mainMenuScreen);
     MainMenu_ShowMainPanel();
 }

--- a/games/warcraft-3/ui/ui_render.c
+++ b/games/warcraft-3/ui/ui_render.c
@@ -580,7 +580,7 @@ static void UI_CheckBoxDraw(LPCFRAMEDEF frame, LPCRECT rect) {
 }
 
 /* Wire per-type event handler and draw function pointers */
-void UI_WireFrameTypeFunctions(LPFRAMEDEF frame) {
+__attribute__((visibility("hidden"))) void UI_WireFrameTypeFunctions(LPFRAMEDEF frame) {
     if (!frame) {
         return;
     }

--- a/games/warcraft-3/ui/ui_theme.c
+++ b/games/warcraft-3/ui/ui_theme.c
@@ -8,6 +8,8 @@
 
 #define MAX_THEME_ENTRIES 1024
 
+#define BZ_HOST_HIDDEN __attribute__((visibility("hidden")))
+
 typedef struct {
     UINAME category;
     UINAME key;
@@ -24,7 +26,7 @@ static char *UI_ThemeTrim(char *text) {
     return text;
 }
 
-void UI_ClearTheme(void) {
+BZ_HOST_HIDDEN void UI_ClearTheme(void) {
     memset(theme_entries, 0, sizeof(theme_entries));
     theme_count = 0;
 }
@@ -133,7 +135,7 @@ static LPCSTR UI_ThemeEffectiveCategory(LPCSTR category) {
     return player_category ? player_category : category;
 }
 
-LPCSTR Theme_String(LPCSTR entry, LPCSTR category) {
+BZ_HOST_HIDDEN LPCSTR Theme_String(LPCSTR entry, LPCSTR category) {
     LPCSTR filename = NULL;
     char versioned[128];
     LPCSTR fallback = "Default";
@@ -173,7 +175,7 @@ LPCSTR Theme_String(LPCSTR entry, LPCSTR category) {
     return entry;
 }
 
-FLOAT Theme_Float(LPCSTR entry, LPCSTR category) {
+BZ_HOST_HIDDEN FLOAT Theme_Float(LPCSTR entry, LPCSTR category) {
     return atof(Theme_String(entry, category));
 }
 


### PR DESCRIPTION
libgame.so and libui.so each define their own copies of several private
helper functions (FDF host services, UI_ShowMainMenu, UI_LoadTexture,
Theme_String, etc.) with the same non-static names. Since openwarcraft3
links both directly, ELF's default symbol resolution binds calls from
either module to whichever definition loads first - not the caller's own.

Tested on OpenBSD (amd64): fixes a crash reaching the main menu.