### PR TITLE
fix menu for wc3

### DIFF
--- a/client/cl_main.c
+++ b/client/cl_main.c
@@ -618,7 +618,11 @@ void CL_Init(void) {
     CL_SetMenuBindings();
     cls.state = ca_disconnected;
     scr_initialized = true;
+#ifdef WOW
     CL_MenuCommand("menu_login");
+#else
+    CL_MenuCommand("menu_main");
+#endif
 }
 
 void CL_ConnectionlessPacket(const netadr_t *from, LPSIZEBUF msg) {


### PR DESCRIPTION
CL_Init() hardcoded CL_MenuCommand("menu_login") at client startup, but
"menu_login" is only registered by the WoW UI module. WC3 registers
"menu_main" instead, so the command was silently unknown and the client
never showed a menu screen.
Now picks the right command per game(#ifdef WOW), matching the existing
pattern already used elsewhere in common/common.c.

Tested on OpenBSD (amd64): fixes a black screen on startup.