### PR TITLE
fix-vertex-bounds

### DIFF
--- a/games/warcraft-3/renderer/w3m/r_war3map_utils.c
+++ b/games/warcraft-3/renderer/w3m/r_war3map_utils.c
@@ -1,6 +1,8 @@
 #include "r_war3map.h"
 
 LPCWAR3MAPVERTEX GetWar3MapVertex(LPCWAR3MAP war3Map, DWORD x, DWORD y) {
+    x = MIN(x, war3Map->width - 1);
+    y = MIN(y, war3Map->height - 1);
     int const index = x + y * war3Map->width;
     char const *ptr = ((char const *)war3Map->vertices) + index * sizeof(WAR3MAPVERTEX);
     return (LPCWAR3MAPVERTEX)ptr;


### PR DESCRIPTION
GetWar3MapVertex(map, x, y) did no bounds checking on x/y before indexing
into the vertices array. Terrain code (cliff height sampling) calls it
with x+1/y+1 at map edges, which reads one past the array — and since x/y
are unsigned, any caller passing a negative float can wrap to a huge
index instead.

Clamped x/y to [0, width-1]/[0, height-1] inside the function.

Tested on OpenBSD (amd64): fixes a segfault loading a campaign map (Human02.w3m).