### PR TITLE
fix-mdx-camera

### DIFF
--- a/client/cl_view.c
+++ b/client/cl_view.c
@@ -31,7 +31,7 @@ static void CL_SendBegin(void) {
     MSG_WriteString(&cls.netchan.message, "begin");
 }
 
-void Matrix4_fromViewAngles(LPCVECTOR3 target, LPCVECTOR3 angles, FLOAT distance, LPMATRIX4 output) {
+static void Matrix4_fromViewAngles(LPCVECTOR3 target, LPCVECTOR3 angles, FLOAT distance, LPMATRIX4 output) {
     VECTOR3 const vieworg = Vector3_unm(target);
     Matrix4_identity(output);
     Matrix4_translate(output, &(VECTOR3){0, 0, -distance});
@@ -123,7 +123,7 @@ static void Matrix4_getSc2CameraMatrix(LPCVECTOR3 origin,
 }
 #endif
 
-void Matrix4_getLightMatrix(LPCVECTOR3 sunangles, FLOAT scale, LPMATRIX4 output) {
+static void Matrix4_getLightMatrix(LPCVECTOR3 sunangles, FLOAT scale, LPMATRIX4 output) {
     MATRIX4 proj, view, tmp1, tmp2;
     viewCamera_t const *a = cl.viewDef.camerastate+1;
     viewCamera_t const *b = cl.viewDef.camerastate+0;

--- a/games/warcraft-3/renderer/mdx/r_mdx_render.c
+++ b/games/warcraft-3/renderer/mdx/r_mdx_render.c
@@ -13,7 +13,7 @@
 //} mdxVertexAttribute_t;
 
 
-void Matrix4_fromViewAngles(LPCVECTOR3 target, LPCVECTOR3 angles, float distance, LPMATRIX4 output) {
+static void Matrix4_fromViewAngles(LPCVECTOR3 target, LPCVECTOR3 angles, float distance, LPMATRIX4 output) {
     VECTOR3 const vieworg = Vector3_unm(target);
     Matrix4_identity(output);
     Matrix4_translate(output, &(VECTOR3){0, 0, -distance});
@@ -21,7 +21,7 @@ void Matrix4_fromViewAngles(LPCVECTOR3 target, LPCVECTOR3 angles, float distance
     Matrix4_translate(output, &vieworg);
 }
 
-void Matrix4_getLightMatrix(LPCVECTOR3 sunangles, LPCVECTOR3 target, float scale, LPMATRIX4 output) {
+static void Matrix4_getLightMatrix(LPCVECTOR3 sunangles, LPCVECTOR3 target, float scale, LPMATRIX4 output) {
     MATRIX4 proj, view;
     Matrix4_ortho(&proj, -scale, scale, -scale, scale, 100.0, 3500.0);
     Matrix4_fromViewAngles(target, sunangles, 1000, &view);


### PR DESCRIPTION
Two different functions in this codebase were both named
Matrix4_getLightMatrix, but with a different number of arguments (one in
client/cl_view.c, one in games/warcraft-3/renderer/mdx/r_mdx_render.c).
Since neither was static, the wrong one could get called, misaligning
arguments and corrupting the stack.

Made both static so each file uses its own version.
