### PR TITLE
Stretch UI canvas to fill the window instead of anchor-growing to aspect ratio

### DIFF
--- a/client/cl_layout.c
+++ b/client/cl_layout.c
@@ -11,29 +11,12 @@ struct {
     bool calculated;
 } runtimes[MAX_LAYOUT_OBJECTS];
 
+/* Fixed 0.8x0.6 canvas regardless of window aspect: the final FDF->pixel
+ * conversion already stretches this to fill the window, so HUD panels
+ * anchored to different edges stay flush against each other instead of
+ * drifting apart on non-4:3 resolutions. */
 static RECT SCR_GetUISceneRect(void) {
-    size2_t window = re.GetWindowSize();
-    FLOAT window_aspect = UI_MIN_ASPECT;
-    FLOAT x_scale = 1.0f;
-    FLOAT y_scale = 1.0f;
-
-    if (window.width > 0 && window.height > 0) {
-        window_aspect = (FLOAT)window.width / (FLOAT)window.height;
-    }
-
-    if (window_aspect > UI_MIN_ASPECT) {
-        x_scale = window_aspect / UI_MIN_ASPECT;
-    } else if (window_aspect < UI_MIN_ASPECT) {
-        y_scale = UI_MIN_ASPECT / window_aspect;
-    }
-
-    FLOAT scene_w = UI_BASE_WIDTH * x_scale;
-    FLOAT scene_h = UI_BASE_HEIGHT * y_scale;
-    return MAKE(RECT,
-                (UI_BASE_WIDTH - scene_w) * 0.5f,
-                (UI_BASE_HEIGHT - scene_h) * 0.5f,
-                scene_w,
-                scene_h);
+    return MAKE(RECT, 0, 0, UI_BASE_WIDTH, UI_BASE_HEIGHT);
 }
 
 VECTOR2 get_x(LPCRECT rect) {

--- a/client/cl_scrn.c
+++ b/client/cl_scrn.c
@@ -142,25 +142,13 @@ static RECT Rect_inset(LPCRECT r, FLOAT inset) {
 static VECTOR2 SCR_LayoutScreenToFdf(int x, int y) {
     LPRENDERER renderer = &re;
     size2_t window = renderer->GetWindowSize();
-    FLOAT x_scale = 1.0f, y_scale = 1.0f;
     FLOAT nx = 0, ny = 0;
-    FLOAT window_aspect = UI_MIN_ASPECT;
 
     if (window.width > 0 && window.height > 0) {
-        window_aspect = (FLOAT)window.width / (FLOAT)window.height;
         nx = (FLOAT)x / (FLOAT)window.width;
         ny = (FLOAT)y / (FLOAT)window.height;
     }
-    if      (window_aspect > UI_MIN_ASPECT) x_scale = window_aspect / UI_MIN_ASPECT;
-    else if (window_aspect < UI_MIN_ASPECT) y_scale = UI_MIN_ASPECT / window_aspect;
-
-    RECT scene = {
-        .w = UI_BASE_WIDTH  * x_scale,
-        .h = UI_BASE_HEIGHT * y_scale,
-    };
-    scene.x = (UI_BASE_WIDTH  - scene.w) * 0.5f;
-    scene.y = (UI_BASE_HEIGHT - scene.h) * 0.5f;
-    return MAKE(VECTOR2, scene.x + nx * scene.w, scene.y + ny * scene.h);
+    return MAKE(VECTOR2, nx * UI_BASE_WIDTH, ny * UI_BASE_HEIGHT);
 }
 
 static RECT get_uvrect(uint8_t const *tc) {

--- a/games/warcraft-3/ui/ui_main.c
+++ b/games/warcraft-3/ui/ui_main.c
@@ -583,28 +583,14 @@ void UI_KeyEventLocal(int key, BOOL down, DWORD time) {
 static VECTOR2 UI_PixelToFdf(int px, int py) {
     LPRENDERER renderer = uiimport.GetRenderer();
     size2_t window = renderer && renderer->GetWindowSize ? renderer->GetWindowSize() : MAKE(size2_t, 0, 0);
-    FLOAT window_aspect = UI_MIN_ASPECT;
-    FLOAT x_scale = 1.0f;
-    FLOAT y_scale = 1.0f;
-    RECT scene;
     FLOAT nx = 0;
     FLOAT ny = 0;
 
     if (window.width > 0 && window.height > 0) {
-        window_aspect = (FLOAT)window.width / (FLOAT)window.height;
         nx = (FLOAT)px / (FLOAT)window.width;
         ny = (FLOAT)py / (FLOAT)window.height;
     }
-    if (window_aspect > UI_MIN_ASPECT) {
-        x_scale = window_aspect / UI_MIN_ASPECT;
-    } else if (window_aspect < UI_MIN_ASPECT) {
-        y_scale = UI_MIN_ASPECT / window_aspect;
-    }
-    scene.w = UI_BASE_WIDTH * x_scale;
-    scene.h = UI_BASE_HEIGHT * y_scale;
-    scene.x = (UI_BASE_WIDTH - scene.w) * 0.5f;
-    scene.y = (UI_BASE_HEIGHT - scene.h) * 0.5f;
-    return MAKE(VECTOR2, scene.x + nx * scene.w, scene.y + ny * scene.h);
+    return MAKE(VECTOR2, nx * UI_BASE_WIDTH, ny * UI_BASE_HEIGHT);
 }
 
 /* All UI mouse work starts here so draw code only consumes event-updated state. */

--- a/games/warcraft-3/ui/ui_render.c
+++ b/games/warcraft-3/ui/ui_render.c
@@ -148,39 +148,7 @@ static RECT UI_GetSceneRect(void) {
     if (scene_rect_valid) {
         return scene_rect;
     }
-    
-    LPRENDERER renderer = uiimport.GetRenderer();
-    size2_t window;
-    FLOAT window_aspect = UI_MIN_ASPECT;
-    FLOAT x_scale = 1.0f;
-    FLOAT y_scale = 1.0f;
-
-    if (!renderer || !renderer->GetWindowSize) {
-        return (RECT) { 0, 0, UI_BASE_WIDTH, UI_BASE_HEIGHT };
-    }
-
-    window = renderer->GetWindowSize();
-
-    if (window.width > 0 && window.height > 0) {
-        window_aspect = (FLOAT)window.width / (FLOAT)window.height;
-    }
-
-    if (window_aspect > UI_MIN_ASPECT) {
-        x_scale = window_aspect / UI_MIN_ASPECT;
-    } else if (window_aspect < UI_MIN_ASPECT) {
-        y_scale = UI_MIN_ASPECT / window_aspect;
-    }
-
-    FLOAT scene_w = UI_BASE_WIDTH * x_scale;
-    FLOAT scene_h = UI_BASE_HEIGHT * y_scale;
-    
-    scene_rect = (RECT) {
-        .x = (UI_BASE_WIDTH - scene_w) * 0.5f,
-        .y = (UI_BASE_HEIGHT - scene_h) * 0.5f,
-        .w = scene_w,
-        .h = scene_h
-    };
-    
+    scene_rect = (RECT) { 0, 0, UI_BASE_WIDTH, UI_BASE_HEIGHT };
     scene_rect_valid = TRUE;
     return scene_rect;
 }

--- a/renderer/r_draw.c
+++ b/renderer/r_draw.c
@@ -7,16 +7,7 @@
 #define R_UI_MIN_ASPECT  UI_MIN_ASPECT
 
 RECT R_UISceneRect(void) {
-    size2_t window = R_GetWindowSize();
-    float aspect = (float)window.width / (float)window.height;
-    float x_scale = aspect > R_UI_MIN_ASPECT ? aspect / R_UI_MIN_ASPECT : 1.0f;
-    float y_scale = aspect < R_UI_MIN_ASPECT ? R_UI_MIN_ASPECT / aspect : 1.0f;
-    float scene_w = R_UI_BASE_WIDTH  * x_scale;
-    float scene_h = R_UI_BASE_HEIGHT * y_scale;
-    return MAKE(RECT,
-                (R_UI_BASE_WIDTH  - scene_w) * 0.5f,
-                (R_UI_BASE_HEIGHT - scene_h) * 0.5f,
-                scene_w, scene_h);
+    return MAKE(RECT, 0, 0, R_UI_BASE_WIDTH, R_UI_BASE_HEIGHT);
 }
 
 void R_DrawChar(int x, int y, int c) {


### PR DESCRIPTION
Switched from letterbox-style anchor growth to a simple uniform stretch
of the UI canvas. I think this looks better than gaps/black bars between
HUD panels, even with the minor distortion on wide screens.