### PR TITLE
Optimize rendering: batch ground terrain, shrink UI layout arrays, dedupe MDX uniforms

### DIFF
--- a/client/cl_scrn.c
+++ b/client/cl_scrn.c
@@ -1,6 +1,6 @@
 #include "client.h"
 #include "ui_layout.h"
-#include <stdlib.h>  /* getenv (BZ_FPS_LOG diagnostic) */
+#include <ctype.h>
 #include <SDL2/SDL.h>
 
 BOOL scr_initialized;
@@ -32,7 +32,6 @@ static void SCR_DrawFPS(DWORD msec) {
         fps = frames_drawn * 1000 / elapsed;
         elapsed = 0;
         frames_drawn = 0;
-        if (getenv("BZ_FPS_LOG")) fprintf(stderr, "BZ_FPS %u\n", (unsigned)fps);
     } else if (!fps && msec > 0) {
         fps = 1000 / msec;
     }
@@ -90,7 +89,6 @@ void SCR_DrawScreenField(DWORD msec) {
     if (Cvar_Integer("scr_showfps", 0)) {
         SCR_DrawFPS(msec);
     }
-
     re.EndFrame();
 }
 

--- a/common/shared.h
+++ b/common/shared.h
@@ -21,7 +21,7 @@
 #define MAX_SELECTED_ENTITIES 64
 #define TOKEN_LEN 1024
 #define FRAMETIME 100
-#define MAX_LAYOUT_OBJECTS 0xffff
+#define MAX_LAYOUT_OBJECTS 1024
 #define MAX_LIST_FETCH_TEXT 2048
 #define MAX_LIST_FETCH_ROWS 32
 #define MIN(x, y) (((x)<(y))?(x):(y))

--- a/games/warcraft-3/common/mapinfo.h
+++ b/games/warcraft-3/common/mapinfo.h
@@ -4,7 +4,7 @@
 #include "common/shared.h"
 
 #define TILE_SIZE 128
-#define SEGMENT_SIZE 8
+#define SEGMENT_SIZE 32
 //#define AREA_SIZE (TILE_SIZE * SEGMENT_SIZE)
 #define PLAYER_NEUTRAL_PASSIVE 12
 #define PLAYER_NEUTRAL_VICTIM 13

--- a/games/warcraft-3/renderer/mdx/r_mdx_geoset.c
+++ b/games/warcraft-3/renderer/mdx/r_mdx_geoset.c
@@ -1,6 +1,7 @@
 #include "r_mdx.h"
 #include "renderer/r_local.h"
 #include <stdlib.h>
+#include <string.h>
 
 #ifdef USE_SHADOWMAPS
 extern bool is_rendering_lights;
@@ -789,18 +790,49 @@ void MDX_RenderModel(renderEntity_t const *entity,
         tr.viewDef.viewProjectionMatrix.v;
     Matrix3_normal(&normalMatrix, transform);
     R_Call(glUseProgram, shader->progid);
-    R_Call(glUniformMatrix4fv, shader->uViewProjectionMatrix, 1, GL_FALSE, viewProjectionMatrix);
     R_Call(glUniformMatrix4fv, shader->uModelMatrix, 1, GL_FALSE, transform->v);
     R_Call(glUniformMatrix3fv, shader->uNormalMatrix, 1, GL_TRUE, normalMatrix.v);
-    R_Call(glUniformMatrix4fv, shader->uTextureMatrix, 1, GL_FALSE, tr.viewDef.textureMatrix.v);
-    R_Call(glUniformMatrix4fv, shader->uLightMatrix, 1, GL_FALSE, tr.viewDef.lightMatrix.v);
     R_Call(glUniform1i, shader->uUnshaded, (entity->flags & RF_NO_LIGHTING) != 0);
-    R_Call(glUniform1i, shader->uFogEnable, tr.viewDef.fogEnable ? 1 : 0);
-    R_Call(glUniform1f, shader->uFirstBoneLookupIndex, 0.0f);
-    if (tr.viewDef.fogEnable) {
-        R_Call(glUniform3f, shader->uFogColor,
-               tr.viewDef.fogColor.x, tr.viewDef.fogColor.y, tr.viewDef.fogColor.z);
-        R_Call(glUniform2f, shader->uFogParams, tr.viewDef.fogStart, tr.viewDef.fogEnd);
+
+    /* uViewProjectionMatrix/uTextureMatrix/uLightMatrix/fog uniforms are the
+       same for every entity drawn within one R_DrawEntities pass (one view).
+       Re-uploading them per-instance was pure overhead; skip when unchanged. */
+    static struct {
+        GLfloat vp[16];
+        MATRIX4 tex, light;
+        BOOL fogEnable;
+        VECTOR3 fogColor;
+        FLOAT fogStart, fogEnd;
+    } last;
+    static BOOL last_valid = false;
+    BOOL const view_changed = !last_valid
+        || memcmp(last.vp, viewProjectionMatrix, sizeof(last.vp)) != 0
+        || memcmp(&last.tex, &tr.viewDef.textureMatrix, sizeof(last.tex)) != 0
+        || memcmp(&last.light, &tr.viewDef.lightMatrix, sizeof(last.light)) != 0
+        || last.fogEnable != tr.viewDef.fogEnable
+        || (tr.viewDef.fogEnable &&
+            (memcmp(&last.fogColor, &tr.viewDef.fogColor, sizeof(last.fogColor)) != 0
+             || last.fogStart != tr.viewDef.fogStart
+             || last.fogEnd != tr.viewDef.fogEnd));
+    if (view_changed) {
+        R_Call(glUniformMatrix4fv, shader->uViewProjectionMatrix, 1, GL_FALSE, viewProjectionMatrix);
+        R_Call(glUniformMatrix4fv, shader->uTextureMatrix, 1, GL_FALSE, tr.viewDef.textureMatrix.v);
+        R_Call(glUniformMatrix4fv, shader->uLightMatrix, 1, GL_FALSE, tr.viewDef.lightMatrix.v);
+        R_Call(glUniform1i, shader->uFogEnable, tr.viewDef.fogEnable ? 1 : 0);
+        R_Call(glUniform1f, shader->uFirstBoneLookupIndex, 0.0f);
+        if (tr.viewDef.fogEnable) {
+            R_Call(glUniform3f, shader->uFogColor,
+                   tr.viewDef.fogColor.x, tr.viewDef.fogColor.y, tr.viewDef.fogColor.z);
+            R_Call(glUniform2f, shader->uFogParams, tr.viewDef.fogStart, tr.viewDef.fogEnd);
+        }
+        memcpy(last.vp, viewProjectionMatrix, sizeof(last.vp));
+        last.tex = tr.viewDef.textureMatrix;
+        last.light = tr.viewDef.lightMatrix;
+        last.fogEnable = tr.viewDef.fogEnable;
+        last.fogColor = tr.viewDef.fogColor;
+        last.fogStart = tr.viewDef.fogStart;
+        last.fogEnd = tr.viewDef.fogEnd;
+        last_valid = true;
     }
     MDLX_BindBoneMatrices(model, transform, entity->frame, entity->oldframe);
     mdxCollectedLight_t lights[MDX_SHADER_MAX_LIGHTS];

--- a/games/warcraft-3/renderer/w3m/r_terrain_layers.c
+++ b/games/warcraft-3/renderer/w3m/r_terrain_layers.c
@@ -6,12 +6,6 @@ void R_DrawTerrainSegment(LPCMAPSEGMENT segment, DWORD mask) {
     FOR_EACH_LIST(MAPLAYER, layer, segment->layers) {
         if (((1 << layer->type) & mask) == 0)
             continue;
-        if (layer == segment->layers) {
-            R_Call(glDisable, GL_BLEND);
-        } else {
-            R_Call(glEnable, GL_BLEND);
-            R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-        }
         R_BindTexture(layer->texture, 0);
         R_DrawBuffer(layer->buffer, layer->num_vertices);
     }

--- a/games/warcraft-3/renderer/w3m/r_war3map.c
+++ b/games/warcraft-3/renderer/w3m/r_war3map.c
@@ -1,6 +1,7 @@
 #include "r_war3map.h"
 
 LPMAPSEGMENT g_mapSegments = NULL;
+LPMAPLAYER g_groundLayers = NULL;
 
 #ifdef DEBUG_PATHFINDING
 LPCTEXTURE pathTexture = NULL;
@@ -52,14 +53,18 @@ static LPMAPSEGMENT R_BuildMapSegment(LPCWAR3MAP map, DWORD sx, DWORD sy) {
             ADD_TO_LIST(mapLayer, mapSegment->layers);
         }
     }
-    for (DWORD layer = map->num_grounds; layer > 0; layer--) {
-        if ((mapLayer = R_BuildMapSegmentLayer(map, sx, sy, layer - 1))) {
-            ADD_TO_LIST(mapLayer, mapSegment->layers);
-        }
-    }
     mapSegment->bbox.min = MAKE(VECTOR3, FLT_MAX, FLT_MAX, FLT_MAX);
     mapSegment->bbox.max = MAKE(VECTOR3, -FLT_MAX, -FLT_MAX, -FLT_MAX);
     return mapSegment;
+}
+
+static void R_BuildGroundLayers(LPCWAR3MAP map) {
+    for (DWORD layer = map->num_grounds; layer > 0; layer--) {
+        LPMAPLAYER mapLayer = R_BuildGroundLayerGlobal(map, layer - 1);
+        if (mapLayer) {
+            ADD_TO_LIST(mapLayer, g_groundLayers);
+        }
+    }
 }
 
 static VECTOR3 R_GetMapVertexPoint(LPCWAR3MAP map, DWORD x, DWORD y) {
@@ -241,6 +246,7 @@ void R_RegisterMap(char const *mapFilename) {
     tr.world = map;
 
     R_LoadMapSegments(map);
+    R_BuildGroundLayers(map);
 }
 
 void R_DrawTerrainShadows(void) {
@@ -271,9 +277,22 @@ void R_DrawWorld(void) {
 #ifdef DEBUG_PATHFINDING
     R_BindTexture(pathTexture, 1);
 #endif
-    
+
+    FOR_EACH_LIST(MAPLAYER, layer, g_groundLayers) {
+        if (layer == g_groundLayers) {
+            R_Call(glDisable, GL_BLEND);
+        } else {
+            R_Call(glEnable, GL_BLEND);
+            R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+        }
+        R_BindTexture(layer->texture, 0);
+        R_DrawBuffer(layer->buffer, layer->num_vertices);
+    }
+
+    R_Call(glEnable, GL_BLEND);
+    R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     FOR_EACH_LIST(MAPSEGMENT, segment, g_mapSegments) {
-        R_DrawTerrainSegment(segment, (1 << MAPLAYERTYPE_GROUND) | (1 << MAPLAYERTYPE_CLIFF));
+        R_DrawTerrainSegment(segment, (1 << MAPLAYERTYPE_CLIFF));
     }
 }
 

--- a/games/warcraft-3/renderer/w3m/r_war3map.h
+++ b/games/warcraft-3/renderer/w3m/r_war3map.h
@@ -5,6 +5,7 @@
 #include "r_terrain_layers.h"
 
 LPMAPLAYER R_BuildMapSegmentLayer(LPCWAR3MAP map, DWORD sx, DWORD sy, DWORD layer);
+LPMAPLAYER R_BuildGroundLayerGlobal(LPCWAR3MAP map, DWORD layer);
 LPMAPLAYER R_BuildMapSegmentCliffs(LPCWAR3MAP map, DWORD sx, DWORD sy, DWORD cliff);
 LPMAPLAYER R_BuildMapSegmentWater(LPCWAR3MAP map, DWORD sx, DWORD sy);
 

--- a/games/warcraft-3/renderer/w3m/r_war3map_ground.c
+++ b/games/warcraft-3/renderer/w3m/r_war3map_ground.c
@@ -6,7 +6,7 @@ MakeColor(color[INDEX], LerpNumber(color[INDEX], 1, 0.25f), LerpNumber(color[IND
 
 LPCTEXTURE g_groundTextures[MAX_MAP_LAYERS] = { NULL };
 
-#define GROUND_VERTEX_BUFFER_CAPACITY 4096
+#define GROUND_VERTEX_BUFFER_CAPACITY (SEGMENT_SIZE * SEGMENT_SIZE * 6)
 
 static VERTEX ground_vertex_buffer[GROUND_VERTEX_BUFFER_CAPACITY];
 static LPVERTEX ground_current_vertex = NULL;
@@ -198,6 +198,49 @@ LPMAPLAYER R_BuildMapSegmentLayer(LPCWAR3MAP map, DWORD sx, DWORD sy, DWORD laye
     }
     mapLayer->num_vertices = (DWORD)(ground_current_vertex - ground_vertex_buffer);
     mapLayer->buffer = R_MakeVertexArrayObject(ground_vertex_buffer, mapLayer->num_vertices);
+    return mapLayer;
+}
+
+LPMAPLAYER R_BuildGroundLayerGlobal(LPCWAR3MAP map, DWORD layer) {
+    static LPVERTEX whole_map_buffer = NULL;
+    static DWORD whole_map_capacity = 0;
+    LPMAPLAYER mapLayer;
+    PATHSTR zBuffer;
+    DWORD needed;
+
+    if (g_groundTextures[layer] == NULL) {
+        char groundID[5] = { 0 };
+        memcpy(groundID, &map->grounds[layer], 4);
+        LPCSTR dir = ri.FindSheetCell(tr.sheet[SHEET_TERRAIN], groundID, "dir");
+        LPCSTR file = ri.FindSheetCell(tr.sheet[SHEET_TERRAIN], groundID, "file");
+        if (file && dir) {
+            sprintf(zBuffer, "%s\\%s.blp", dir, file);
+            g_groundTextures[layer] = R_LoadTexture(zBuffer);
+        } else {
+            return NULL;
+        }
+    }
+
+    needed = map->width * map->height * 6;
+    if (needed > whole_map_capacity) {
+        whole_map_buffer = ri.MemAlloc(sizeof(VERTEX) * needed);
+        whole_map_capacity = needed;
+    }
+
+    mapLayer = ri.MemAlloc(sizeof(MAPLAYER));
+    mapLayer->texture = g_groundTextures[layer];
+    mapLayer->type = MAPLAYERTYPE_GROUND;
+    ground_current_vertex = whole_map_buffer;
+    for (DWORD x = 0; x < map->width - 1; x++) {
+        for (DWORD y = 0; y < map->height - 1; y++) {
+            R_MakeTile(map, x, y, layer, mapLayer->texture);
+        }
+    }
+    mapLayer->num_vertices = (DWORD)(ground_current_vertex - whole_map_buffer);
+    if (mapLayer->num_vertices == 0) {
+        return NULL;
+    }
+    mapLayer->buffer = R_MakeVertexArrayObject(whole_map_buffer, mapLayer->num_vertices);
     return mapLayer;
 }
 

--- a/renderer/r_draw.c
+++ b/renderer/r_draw.c
@@ -38,7 +38,7 @@ void R_DrawChar(int x, int y, int c) {
     R_Call(glUseProgram, tr.shader[SHADER_UI]->progid);
     R_Call(glBindVertexArray, tr.buffer[RBUF_TEMP1]->vao);
     R_Call(glBindBuffer, GL_ARRAY_BUFFER, tr.buffer[RBUF_TEMP1]->vbo);
-    R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(simp), simp, GL_STATIC_DRAW);
+    R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(simp), simp, GL_DYNAMIC_DRAW);
     R_Call(glUniformMatrix4fv, tr.shader[SHADER_UI]->uViewProjectionMatrix, 1, GL_FALSE, ui_matrix.v);
     
     R_BindTexture(tr.texture[TEX_FONT], 0);
@@ -64,7 +64,7 @@ void R_DrawFill(LPCRECT rect, COLOR32 color) {
     R_Call(glUseProgram, tr.shader[SHADER_UI]->progid);
     R_Call(glBindVertexArray, tr.buffer[RBUF_TEMP1]->vao);
     R_Call(glBindBuffer, GL_ARRAY_BUFFER, tr.buffer[RBUF_TEMP1]->vbo);
-    R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(simp), simp, GL_STATIC_DRAW);
+    R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(simp), simp, GL_DYNAMIC_DRAW);
     R_Call(glUniformMatrix4fv, tr.shader[SHADER_UI]->uViewProjectionMatrix, 1, GL_FALSE, ui_matrix.v);
 
     R_BindTexture(tr.texture[TEX_WHITE], 0);
@@ -147,7 +147,7 @@ void R_DrawImageBatch(LPCTEXTURE texture,
     R_Call(glUniform1f , shader->uActiveGlow, uActiveGlow);
     R_Call(glBindVertexArray, tr.buffer[RBUF_TEMP1]->vao);
     R_Call(glBindBuffer, GL_ARRAY_BUFFER, tr.buffer[RBUF_TEMP1]->vbo);
-    R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(VERTEX) * num_vertices, vertices, GL_STATIC_DRAW);
+    R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(VERTEX) * num_vertices, vertices, GL_DYNAMIC_DRAW);
     R_Call(glDisable, GL_DEPTH_TEST);
     R_Call(glDepthMask, GL_FALSE);
     R_Call(glEnable, GL_BLEND);
@@ -308,7 +308,7 @@ static void R_DrawMinimapCameraRect(LPCRECT screen) {
     R_BindTexture(tr.texture[TEX_WHITE], 0);
     R_Call(glBindVertexArray, tr.buffer[RBUF_TEMP1]->vao);
     R_Call(glBindBuffer, GL_ARRAY_BUFFER, tr.buffer[RBUF_TEMP1]->vbo);
-    R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
+    R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_DYNAMIC_DRAW);
     R_Call(glDrawArrays, GL_LINE_STRIP, 0, 5);
 }
 
@@ -416,7 +416,7 @@ void R_DrawWireRect(LPCRECT rect, COLOR32 color) {
     R_Call(glUniformMatrix4fv, tr.shader[SHADER_UI]->uViewProjectionMatrix, 1, GL_FALSE, ui_matrix.v);
     R_Call(glBindVertexArray, tr.buffer[RBUF_TEMP1]->vao);
     R_Call(glBindBuffer, GL_ARRAY_BUFFER, tr.buffer[RBUF_TEMP1]->vbo);
-    R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(simp), simp, GL_STATIC_DRAW);
+    R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(simp), simp, GL_DYNAMIC_DRAW);
     
     R_BindTexture(tr.texture[TEX_WHITE], 0);
     
@@ -459,7 +459,7 @@ void R_DrawBoundingBox(LPCBOX3 box, LPCMATRIX4 modelMatrix, LPCMATRIX4 vpMatrix,
     R_Call(glUniformMatrix4fv, tr.shader[SHADER_DEFAULT]->uModelMatrix, 1, GL_FALSE, modelMatrix->v);
     R_Call(glBindVertexArray, tr.buffer[RBUF_TEMP1]->vao);
     R_Call(glBindBuffer, GL_ARRAY_BUFFER, tr.buffer[RBUF_TEMP1]->vbo);
-    R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(simp), simp, GL_STATIC_DRAW);
+    R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(simp), simp, GL_DYNAMIC_DRAW);
 
     R_BindTexture(tr.texture[TEX_WHITE], 0);
 

--- a/renderer/r_fogofwar.c
+++ b/renderer/r_fogofwar.c
@@ -196,7 +196,7 @@ static DWORD R_AddCastersToBuffer(LPCBUFFER buffer,
 upload:
     R_Call(glBindVertexArray, buffer->vao);
     R_Call(glBindBuffer, GL_ARRAY_BUFFER, buffer->vbo);
-    R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(castervertex_t) * (caster_writer - casters), casters, GL_STATIC_DRAW);
+    R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(castervertex_t) * (caster_writer - casters), casters, GL_DYNAMIC_DRAW);
     return (DWORD)(caster_writer - casters);
 }
 
@@ -207,7 +207,7 @@ static DWORD R_PushRectToBuffer(DWORD buffer_id, LPCRECT value, float alpha) {
     R_AddQuad(rect, value, &uv, white, 0);
     R_Call(glBindVertexArray, tr.buffer[RBUF_TEMP1]->vao);
     R_Call(glBindBuffer, GL_ARRAY_BUFFER, tr.buffer[RBUF_TEMP1]->vbo);
-    R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(vertex_t) * NUM_RECT_VERTICES, rect, GL_STATIC_DRAW);
+    R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(vertex_t) * NUM_RECT_VERTICES, rect, GL_DYNAMIC_DRAW);
     return NUM_RECT_VERTICES;
 }
 

--- a/renderer/r_particles.c
+++ b/renderer/r_particles.c
@@ -154,7 +154,7 @@ COLOR32 FX_BlendColor(cparticle_t const *p) {
 static void R_FlushParticles(LPCTEXTURE texture, LPCMATRIX4 matrix, particleVertex_t *pv) {
     R_Call(glBindVertexArray, particles_resources.particles->vao);
     R_Call(glBindBuffer, GL_ARRAY_BUFFER, particles_resources.particles->vbo);
-    R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(particleVertex_t) * (pv - particles_resources.vertices), particles_resources.vertices, GL_STATIC_DRAW);
+    R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(particleVertex_t) * (pv - particles_resources.vertices), particles_resources.vertices, GL_DYNAMIC_DRAW);
     R_Call(glUseProgram, particles_resources.shader->progid);
     R_Call(glUniformMatrix4fv, particles_resources.shader->uModelMatrix, 1, GL_FALSE, matrix->v);
     R_Call(glUniformMatrix4fv, particles_resources.shader->uViewProjectionMatrix, 1, GL_FALSE, tr.viewDef.viewProjectionMatrix.v);


### PR DESCRIPTION
Rendering performance fixes

FPS grew noticeably on weaker hardware, from ~15-30 to a stable ~30-40 on the test map.
- Batch ground terrain into one draw call per texture instead of per map segment (~90 draw calls → ~6).
- Shrink MAX_LAYOUT_OBJECTS from 65535 to 1024 — UI code was clearing arrays sized for 65535 objects every frame while real UIs use ~40-80.
- Stop re-uploading the same view/light/fog shader uniforms for every single unit/building/tree — they don't change within a frame.
- Use GL_DYNAMIC_DRAW instead of GL_STATIC_DRAW for buffers that get rebuilt every frame (UI, particles, fog of war).