### PR TITLE
wc3: prevent Holy Light from targeting the caster

### DIFF
--- a/games/warcraft-3/game/skills/s_holylight.c
+++ b/games/warcraft-3/game/skills/s_holylight.c
@@ -18,6 +18,9 @@ static BOOL holylight_selecttarget(LPEDICT clent, LPEDICT target) {
     FLOAT range = S_SpellRange(code, level);
     LPCSTR race;
 
+    if (target == caster) {
+        return false;
+    }
     if (!S_SpellIsAliveTarget(target)) {
         return false;
     }


### PR DESCRIPTION
Holy Light can no longer be cast on the caster - matches original WC3.