### PR TITLE
Add native Windows build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 build/
+build-win*/
+build-win*.log
 data/
 src/DerivedData/
 StormLib-master/

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,8 @@ ifeq ($(OS),Windows_NT)
     INSTALL_NAME =
     RPATH     :=
     LDFLAGS   := -L$(LIB_DIR)
-	LIBS      := -lSDL2main -lSDL2 -lm -lopengl32 -lgdi32
+	LIBS      := -lmingw32 -mwindows -lSDL2main -lSDL2 -lm -lepoxy -lopengl32 -lgdi32 -lws2_32
+	NET_LIBS  := -lws2_32
 else
     UNAME_S := $(shell uname -s)
     EXE_EXT :=
@@ -53,6 +54,7 @@ else
 		CFLAGS    += -DGL_SILENCE_DEPRECATION -I$(HOMEBREW_PREFIX)/include -arch $(ARCH)
 		LDFLAGS   := -L$(LIB_DIR) -L$(HOMEBREW_PREFIX)/lib -arch $(ARCH)
 		LIBS      := -lSDL2 -framework AppKit -framework OpenGL
+		NET_LIBS  :=
     else ifeq ($(UNAME_S),Linux)
         LIB_EXT   := .so
         LIB_FLAGS := -shared -fPIC
@@ -61,6 +63,7 @@ else
         CFLAGS    += -fPIC
         LDFLAGS   := -L$(LIB_DIR) -Wl,-z,defs
 		LIBS      := -lSDL2 -lEGL -lGL -lm
+		NET_LIBS  :=
     else ifeq ($(UNAME_S),OpenBSD)
         # BSD (OpenBSD): /usr/X11R6 for Mesa GL, clang as default CC
         ifeq ($(filter command line environment,$(origin CC)),)
@@ -75,6 +78,7 @@ else
         CFLAGS    += -fPIC -I/usr/local/include -I/usr/X11R6/include
         LDFLAGS   := -L$(LIB_DIR) -L/usr/local/lib -L/usr/X11R6/lib
 		LIBS      := -lSDL2 -lGL -lm
+		NET_LIBS  :=
     endif
 endif
 
@@ -302,12 +306,12 @@ $(ZIP_FILE):
 clean:
 	rm -rf build
 
-$(eval $(call test_schema,test-wow-appearance,,$(WOW_TEST_CFLAGS),$(BIN_DIR)/test_wow_appearance$(EXE_EXT),$(WOW_TEST_DIR)/test_wow_appearance.c common/msg.c common/net.c $(call CSRC,shared),-lm,))
+$(eval $(call test_schema,test-wow-appearance,,$(WOW_TEST_CFLAGS),$(BIN_DIR)/test_wow_appearance$(EXE_EXT),$(WOW_TEST_DIR)/test_wow_appearance.c common/msg.c common/net.c $(call CSRC,shared),-lm $(NET_LIBS),))
 $(eval $(call test_schema,test-wow-combat,,$(WOW_TEST_CFLAGS),$(BIN_DIR)/test_wow_combat$(EXE_EXT),$(WOW_TEST_DIR)/test_wow_combat.c $(WOW_DIR)/game/g_ai.c $(call CSRC,shared),-lm,))
 $(eval $(call test_schema,test-wow-abilities,,$(WOW_TEST_CFLAGS),$(BIN_DIR)/test_wow_abilities$(EXE_EXT),$(WOW_TEST_DIR)/test_wow_abilities.c $(WOW_DIR)/game/g_wow.c $(WOW_DIR)/game/g_world.c $(WOW_DIR)/game/g_ai.c $(WOW_DIR)/game/m_creature.c common/mpq.c $(call CSRC,shared),-lm -lz,))
 $(eval $(call test_schema,test-wow-game,,$(WOW_TEST_CFLAGS),$(BIN_DIR)/test_wow_game$(EXE_EXT),$(WOW_TEST_DIR)/test_wow_game.c $(WOW_DIR)/game/g_wow.c $(WOW_DIR)/game/g_world.c $(WOW_DIR)/game/g_ai.c $(WOW_DIR)/game/m_creature.c common/mpq.c $(call CSRC,shared),-lm -lz,))
 $(eval $(call test_schema,test-wow-ui,test-wow-assets,$(WOW_UI_TEST_CFLAGS),$(BIN_DIR)/test_wow_ui$(EXE_EXT),$(WOW_TEST_DIR)/test_wow_ui.c $(WOW_DIR)/ui/ui_main.c $(WOW_DIR)/ui/ui_lua.c $(WOW_DIR)/ui/ui_dbc.c $(WOW_DIR)/ui/ui_loading.c $(WOW_DIR)/ui/ui_xml.c common/mpq.c,-lshared $(LUA_LIBS) $(WOW_XML_LIBS) -lz,))
-$(eval $(call test_schema,test-sc2,test-sc2-assets $(SHARED_LIB) $(SHEET_LIB),$(SC2_TEST_CFLAGS),$(BIN_DIR)/test_sc2$(EXE_EXT),$(SC2_TEST_DIR)/test_sc2_main.c $(SC2_TEST_DIR)/test_sc2_map.c $(SC2_TEST_DIR)/test_sc2_layout.c $(SC2_TEST_DIR)/test_sc2_consoleui.c $(SC2_TEST_DIR)/stb_sc2layout_impl.c $(SC2_DIR)/common/sc2_map.c common/common.c common/cmd.c common/cvar.c common/msg.c common/net.c common/mpq.c,-lsheet -lshared -lm -lz $(SC2_XML_LIBS),))
+$(eval $(call test_schema,test-sc2,test-sc2-assets $(SHARED_LIB) $(SHEET_LIB),$(SC2_TEST_CFLAGS),$(BIN_DIR)/test_sc2$(EXE_EXT),$(SC2_TEST_DIR)/test_sc2_main.c $(SC2_TEST_DIR)/test_sc2_map.c $(SC2_TEST_DIR)/test_sc2_layout.c $(SC2_TEST_DIR)/test_sc2_consoleui.c $(SC2_TEST_DIR)/stb_sc2layout_impl.c $(SC2_DIR)/common/sc2_map.c common/common.c common/cmd.c common/cvar.c common/msg.c common/net.c common/mpq.c,-lsheet -lshared -lm -lz $(SC2_XML_LIBS) $(NET_LIBS),))
 
 test-sc2-assets: sc2fixturegen mpqtool sc2map | $(TESTS_DIR)
 	@echo "[test-sc2-assets] generating SC2 terrain fixtures"

--- a/client/cl_main.c
+++ b/client/cl_main.c
@@ -13,7 +13,7 @@
 #include "tr_public.h"
 #include "ui_layout.h"
 #include "sound/s_local.h"
-#include <arpa/inet.h>
+#include "common/net_platform.h"
 
 refExport_t re;
 uiExport_t ui;
@@ -548,6 +548,14 @@ static clVideoMode_t CL_VideoMode(void) {
     return cl_video_modes[mode];
 }
 
+static void CL_VideoApply_f(void) {
+    clVideoMode_t mode = CL_VideoMode();
+
+    if (re.SetWindowSize) {
+        re.SetWindowSize(mode.width, mode.height);
+    }
+}
+
 void CL_Init(void) {
     clVideoMode_t mode;
 
@@ -565,6 +573,8 @@ void CL_Init(void) {
         .CvarString = Cvar_String,
         .error = CON_printf,
     });
+
+    Cmd_AddCommand("vid_apply", CL_VideoApply_f);
     
     mode = CL_VideoMode();
     re.Init(mode.width, mode.height);

--- a/client/tr_public.h
+++ b/client/tr_public.h
@@ -187,6 +187,7 @@ typedef struct {
     LPMODEL (*LoadModel)(LPCSTR filename);
     LPFONT (*LoadFont)(LPCSTR filename, DWORD size);
     size2_t (*GetWindowSize)(void);
+    void (*SetWindowSize)(DWORD width, DWORD height);
     size2_t (*GetTextureSize)(LPCTEXTURE texture);
     void (*ReleaseTexture)(LPTEXTURE texture);
     void (*ReleaseModel)(LPMODEL model);

--- a/common/macos.c
+++ b/common/macos.c
@@ -1,6 +1,13 @@
 #include "common.h"
 #include <sys/stat.h>
+#ifdef _WIN32
+#include <direct.h>
+#endif
 
 void Sys_MkDir(LPCSTR directory){
+#ifdef _WIN32
+    _mkdir(directory);
+#else
     mkdir(directory, 0777);
+#endif
 }

--- a/common/main.c
+++ b/common/main.c
@@ -4,8 +4,13 @@
 #include <SDL2/SDL.h>
 #include <stdlib.h>
 #include <stdio.h>
+#ifdef _WIN32
+#include <conio.h>
+#include <direct.h>
+#else
 #include <sys/select.h>
 #include <unistd.h>
+#endif
 
 #if defined(__APPLE__)
 #define BZ_PLATFORM "Darwin"
@@ -61,6 +66,99 @@
 
 extern LPTEXTURE Texture;
 
+#ifdef _WIN32
+static BOOL Sys_FileExists(LPCSTR filename) {
+    FILE *file = fopen(filename, "rb");
+
+    if (!file) {
+        return false;
+    }
+    fclose(file);
+    return true;
+}
+
+static BOOL Sys_IsWarcraftDataDirectory(LPCSTR dirname) {
+    PATHSTR archive;
+
+    if (!dirname || !*dirname) {
+        return false;
+    }
+    snprintf(archive, sizeof(archive), "%s/war3.mpq", dirname);
+    return Sys_FileExists(archive);
+}
+
+static BOOL Sys_TryWarcraftDataDirectory(LPCSTR dirname,
+                                         LPSTR result,
+                                         size_t result_size) {
+    if (!Sys_IsWarcraftDataDirectory(dirname)) {
+        return false;
+    }
+    strlcpy(result, dirname, result_size);
+    return true;
+}
+
+static BOOL Sys_DiscoverWarcraftDataDirectory(LPSTR result, size_t result_size) {
+    static LPCSTR relative_candidates[] = {
+        ".",
+        "data",
+        "Warcraft III",
+        NULL
+    };
+    static LPCSTR drive_candidates[] = {
+        "%c:/Warcraft III",
+        "%c:/Games/Warcraft III",
+        "%c:/Program Files/Warcraft III",
+        "%c:/Program Files (x86)/Warcraft III",
+        NULL
+    };
+    LPCSTR environment_path = getenv("WARCRAFT_III_PATH");
+    LPSTR executable_path = SDL_GetBasePath();
+    unsigned long drives = _getdrives();
+    PATHSTR candidate;
+
+    if (Sys_TryWarcraftDataDirectory(environment_path, result, result_size)) {
+        SDL_free(executable_path);
+        return true;
+    }
+    if (executable_path) {
+        if (Sys_TryWarcraftDataDirectory(executable_path, result, result_size)) {
+            SDL_free(executable_path);
+            return true;
+        }
+        snprintf(candidate, sizeof(candidate), "%sdata", executable_path);
+        if (Sys_TryWarcraftDataDirectory(candidate, result, result_size)) {
+            SDL_free(executable_path);
+            return true;
+        }
+        SDL_free(executable_path);
+    }
+    for (LPCSTR *path = relative_candidates; *path; path++) {
+        if (Sys_TryWarcraftDataDirectory(*path, result, result_size)) {
+            return true;
+        }
+    }
+    for (int drive = 0; drive < 26; drive++) {
+        if (!(drives & (1UL << drive))) {
+            continue;
+        }
+        for (LPCSTR *format = drive_candidates; *format; format++) {
+            snprintf(candidate, sizeof(candidate), *format, 'A' + drive);
+            if (Sys_TryWarcraftDataDirectory(candidate, result, result_size)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+static void Sys_ShowStartupError(LPCSTR message) {
+    SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR,
+                             "OpenWarcraft3 could not start",
+                             message,
+                             NULL);
+}
+#endif
+
 static unsigned short Sys_GamePort(void) {
     int port = Cvar_Integer("game_port", PORT_SERVER);
 
@@ -84,14 +182,19 @@ void Sys_Quit(void) {
 static LPSTR Sys_ConsoleInput(void) {
     static char line[256];
     static char *pos = line;
-    fd_set fds;
-    struct timeval tv;
     int ch;
 
     if (!Cvar_Integer("dedicated", 0)) {
         return NULL;
     }
     /* Non-blocking check: is there data on stdin? */
+#ifdef _WIN32
+    if (!_kbhit()) {
+        return NULL;
+    }
+#else
+    fd_set fds;
+    struct timeval tv;
     FD_ZERO(&fds);
     FD_SET(STDIN_FILENO, &fds);
     tv.tv_sec = 0;
@@ -99,6 +202,7 @@ static LPSTR Sys_ConsoleInput(void) {
     if (select(STDIN_FILENO + 1, &fds, NULL, NULL, &tv) <= 0) {
         return NULL;
     }
+#endif
     while (1) {
         ch = fgetc(stdin);
         if (ch == EOF) {
@@ -118,6 +222,9 @@ static LPSTR Sys_ConsoleInput(void) {
 
 int main(int argc, LPSTR argv[]) {
     BOOL data = 0;
+#ifdef _WIN32
+    PATHSTR discovered_data_dir = { 0 };
+#endif
 
     fprintf(stderr,
             "\nOpenWarcraft3\n"
@@ -131,9 +238,29 @@ int main(int argc, LPSTR argv[]) {
     Com_Init(argc, (LPCSTR *)argv);
 
     LPCSTR data_dir = Cvar_String("data", "");
+#ifdef _WIN32
+    if ((!data_dir || !*data_dir) &&
+        Sys_DiscoverWarcraftDataDirectory(discovered_data_dir,
+                                          sizeof(discovered_data_dir))) {
+        Cvar_Set("data", discovered_data_dir);
+        /* The desktop entry point presents the Frozen Throne glue UI.  A
+         * first-run double-click therefore needs the expansion archives too;
+         * command-line launches retain their explicit -tft/-roc choice. */
+        Cvar_Set("fs_expansion", "1");
+        data_dir = Cvar_String("data", "");
+        fprintf(stderr, "Discovered Warcraft III data: %s\n", data_dir);
+    }
+#endif
     if (data_dir && *data_dir) {
         if (!FS_AddDataDirectory(data_dir)) {
             fprintf(stderr, "Failed to add data directory: %s\n", data_dir);
+#ifdef _WIN32
+            Sys_ShowStartupError(
+                "The configured Warcraft III folder is unavailable.\n\n"
+                "Start OpenWarcraft3 with:\n"
+                "  openwarcraft3.exe -data \"C:\\path\\to\\Warcraft III\"\n\n"
+                "The folder must contain war3.mpq.");
+#endif
             return 1;
         }
         data = 1;
@@ -146,6 +273,14 @@ int main(int argc, LPSTR argv[]) {
 
     if (!data) {
         printf(USAGE);
+#ifdef _WIN32
+        Sys_ShowStartupError(
+            "A compatible Warcraft III installation was not found.\n\n"
+            "Install Warcraft III Classic, put openwarcraft3.exe in its folder, "
+            "or start it with:\n"
+            "  openwarcraft3.exe -data \"C:\\path\\to\\Warcraft III\"\n\n"
+            "You can also set the WARCRAFT_III_PATH environment variable.");
+#endif
         return 1;
     }
 

--- a/common/net.c
+++ b/common/net.c
@@ -24,15 +24,9 @@
  */
 #include <stdarg.h>
 #include <stdlib.h>
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <arpa/inet.h>
-#include <netdb.h>
-#include <unistd.h>
-#include <fcntl.h>
-#include <errno.h>
 #include <string.h>
 
+#include "net_platform.h"
 #include "common.h"
 
 #define LOOPBACK_SIZE (1024 * 1024 * 8)
@@ -99,40 +93,77 @@ int NET_GetLoopPacket(NETSOURCE netsrc, netadr_t *from, LPSIZEBUF msg) {
  * UDP socket
  * -------------------------------------------------------------------------*/
 
-static int udp_sockets[2] = { -1, -1 };
+static net_socket_t udp_sockets[2] = { NET_INVALID_SOCKET, NET_INVALID_SOCKET };
+
+#ifdef _WIN32
+static BOOL winsock_initialized;
+#endif
+
+static int NET_SocketError(void) {
+#ifdef _WIN32
+    return WSAGetLastError();
+#else
+    return errno;
+#endif
+}
+
+static BOOL NET_ErrorWouldBlock(int error) {
+#ifdef _WIN32
+    return error == WSAEWOULDBLOCK;
+#else
+    return error == EAGAIN || error == EWOULDBLOCK;
+#endif
+}
+
+static void NET_CloseSocket(net_socket_t socket_handle) {
+#ifdef _WIN32
+    closesocket(socket_handle);
+#else
+    close(socket_handle);
+#endif
+}
 
 static LPCSTR NET_SourceName(NETSOURCE netsrc) {
     return netsrc == NS_CLIENT ? "client" : "server";
 }
 
-static int NET_UDPSocket(unsigned short port) {
-    int newsocket;
+static net_socket_t NET_UDPSocket(unsigned short port) {
+    net_socket_t newsocket;
     int flag = 1;
     struct sockaddr_in addr;
 
     newsocket = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
-    if (newsocket < 0) {
-        fprintf(stderr, "NET_UDPSocket: socket creation failed: %s\n", strerror(errno));
-        return -1;
+    if (newsocket == NET_INVALID_SOCKET) {
+        fprintf(stderr, "NET_UDPSocket: socket creation failed: %d\n", NET_SocketError());
+        return NET_INVALID_SOCKET;
     }
 
-    setsockopt(newsocket, SOL_SOCKET, SO_BROADCAST, &flag, sizeof(flag));
+    setsockopt(newsocket, SOL_SOCKET, SO_BROADCAST, (const char *)&flag, sizeof(flag));
 
     memset(&addr, 0, sizeof(addr));
     addr.sin_family = AF_INET;
     addr.sin_addr.s_addr = INADDR_ANY;
     addr.sin_port = htons(port);
 
-    if (bind(newsocket, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
-        fprintf(stderr, "NET_UDPSocket: bind failed on port %u: %s\n", port, strerror(errno));
-        close(newsocket);
-        return -1;
+    if (bind(newsocket, (struct sockaddr *)&addr, sizeof(addr)) == SOCKET_ERROR) {
+        fprintf(stderr, "NET_UDPSocket: bind failed on port %u: %d\n", port, NET_SocketError());
+        NET_CloseSocket(newsocket);
+        return NET_INVALID_SOCKET;
     }
 
+#ifdef _WIN32
+    u_long nonblocking = 1;
+    if (ioctlsocket(newsocket, FIONBIO, &nonblocking) == SOCKET_ERROR) {
+        fprintf(stderr, "NET_UDPSocket: nonblocking mode failed: %d\n", NET_SocketError());
+        NET_CloseSocket(newsocket);
+        return NET_INVALID_SOCKET;
+    }
+#else
     flag = fcntl(newsocket, F_GETFL, 0);
     if (flag >= 0) {
         fcntl(newsocket, F_SETFL, flag | O_NONBLOCK);
     }
+#endif
 
     if (port) {
         fprintf(stderr, "NET_UDPSocket: bound UDP 0.0.0.0:%u\n", (unsigned)port);
@@ -156,21 +187,21 @@ static unsigned short NET_GamePort(void) {
 }
 
 static void NET_OpenIP(NETSOURCE netsrc) {
-    if (netsrc == NS_SERVER && udp_sockets[NS_SERVER] < 0) {
+    if (netsrc == NS_SERVER && udp_sockets[NS_SERVER] == NET_INVALID_SOCKET) {
         unsigned short port = NET_GamePort();
         fprintf(stderr, "NET_OpenIP: opening server socket on UDP port %u\n", (unsigned)port);
         udp_sockets[NS_SERVER] = NET_UDPSocket(port);
     }
-    if (netsrc == NS_CLIENT && udp_sockets[NS_CLIENT] < 0) {
+    if (netsrc == NS_CLIENT && udp_sockets[NS_CLIENT] == NET_INVALID_SOCKET) {
         fprintf(stderr, "NET_OpenIP: opening client socket on ephemeral UDP port\n");
         udp_sockets[NS_CLIENT] = NET_UDPSocket(0);
     }
 }
 
 static void NET_SendUDPPacket(NETSOURCE netsrc, int length, const void *data, netadr_t to) {
-    int sock = udp_sockets[netsrc];
+    net_socket_t sock = udp_sockets[netsrc];
 
-    if (sock < 0) {
+    if (sock == NET_INVALID_SOCKET) {
         fprintf(stderr,
                 "NET_SendUDPPacket: %s socket is closed, dropping packet to %s\n",
                 NET_SourceName(netsrc),
@@ -192,29 +223,30 @@ static void NET_SendUDPPacket(NETSOURCE netsrc, int length, const void *data, ne
     }
     addr.sin_port = to.port;    // already in network byte order
 
-    if (sendto(sock, data, length, 0,
-               (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+    if (sendto(sock, (const char *)data, length, 0,
+               (struct sockaddr *)&addr, sizeof(addr)) == SOCKET_ERROR) {
         fprintf(stderr,
-                "NET_SendUDPPacket: sendto %s failed: %s\n",
+                "NET_SendUDPPacket: sendto %s failed: %d\n",
                 NET_AdrToString(&to),
-                strerror(errno));
+                NET_SocketError());
     }
 }
 
 static int NET_GetUDPPacket(NETSOURCE netsrc, netadr_t *from, LPSIZEBUF msg) {
-    int sock = udp_sockets[netsrc];
+    net_socket_t sock = udp_sockets[netsrc];
 
-    if (sock < 0)
+    if (sock == NET_INVALID_SOCKET)
         return 0;
 
     struct sockaddr_in srcaddr;
-    socklen_t addrlen = sizeof(srcaddr);
+    net_socklen_t addrlen = sizeof(srcaddr);
 
-    int bytes = recvfrom(sock, msg->data, msg->maxsize, 0,
+    int bytes = recvfrom(sock, (char *)msg->data, msg->maxsize, 0,
                          (struct sockaddr *)&srcaddr, &addrlen);
-    if (bytes < 0) {
-        if (errno != EAGAIN && errno != EWOULDBLOCK)
-            fprintf(stderr, "NET_GetUDPPacket: recvfrom failed: %d\n", errno);
+    if (bytes == SOCKET_ERROR) {
+        int const error = NET_SocketError();
+        if (!NET_ErrorWouldBlock(error))
+            fprintf(stderr, "NET_GetUDPPacket: recvfrom failed: %d\n", error);
         return 0;
     }
     if (bytes == msg->maxsize) {
@@ -237,6 +269,17 @@ static int NET_GetUDPPacket(NETSOURCE netsrc, netadr_t *from, LPSIZEBUF msg) {
  * -------------------------------------------------------------------------*/
 
 void NET_Init(void) {
+#ifdef _WIN32
+    WSADATA winsock_data;
+    if (!winsock_initialized) {
+        int const result = WSAStartup(MAKEWORD(2, 2), &winsock_data);
+        if (result != 0) {
+            fprintf(stderr, "NET_Init: WSAStartup failed: %d\n", result);
+            return;
+        }
+        winsock_initialized = true;
+    }
+#endif
     memset(loopbufs, 0, sizeof(loopbufs));
 }
 
@@ -256,10 +299,10 @@ void NET_ConfigSource(NETSOURCE netsrc, BOOL open) {
         return;
     }
     if (!open) {
-        if (udp_sockets[netsrc] >= 0) {
+        if (udp_sockets[netsrc] != NET_INVALID_SOCKET) {
             fprintf(stderr, "NET_Config: closing %s UDP socket\n", NET_SourceName(netsrc));
-            close(udp_sockets[netsrc]);
-            udp_sockets[netsrc] = -1;
+            NET_CloseSocket(udp_sockets[netsrc]);
+            udp_sockets[netsrc] = NET_INVALID_SOCKET;
         }
         return;
     }
@@ -267,11 +310,17 @@ void NET_ConfigSource(NETSOURCE netsrc, BOOL open) {
 }
 
 BOOL NET_IsConfigured(NETSOURCE netsrc) {
-    return netsrc <= NS_SERVER && udp_sockets[netsrc] >= 0;
+    return netsrc <= NS_SERVER && udp_sockets[netsrc] != NET_INVALID_SOCKET;
 }
 
 void NET_Shutdown(void) {
     NET_Config(false);
+#ifdef _WIN32
+    if (winsock_initialized) {
+        WSACleanup();
+        winsock_initialized = false;
+    }
+#endif
 }
 
 bool NET_StringToAdr(LPCSTR s, unsigned short default_port, netadr_t *adr) {

--- a/common/net_platform.h
+++ b/common/net_platform.h
@@ -1,0 +1,100 @@
+#ifndef net_platform_h
+#define net_platform_h
+
+#ifdef _WIN32
+/* The engine intentionally uses Win32-style names for its portable public
+ * types.  Shield those names while importing Winsock so the Windows SDK does
+ * not replace the engine's DWORD/RECT/etc. ABI in translation units that also
+ * include rendering and game headers. */
+typedef int WINBOOL;
+typedef int WINSDK_BOOL;
+typedef WINBOOL *PBOOL;
+typedef WINBOOL *LPBOOL;
+#define _DEF_WINBOOL_
+#define BYTE WINSDK_BYTE
+#define BOOL WINSDK_BOOL
+#define USHORT WINSDK_USHORT
+#define LONG WINSDK_LONG
+#define SHORT WINSDK_SHORT
+#define DWORD WINSDK_DWORD
+#define WORD WINSDK_WORD
+#define DWORD_PTR WINSDK_DWORD_PTR
+#define LONG_PTR WINSDK_LONG_PTR
+#define INT_PTR WINSDK_INT_PTR
+#define LONGLONG WINSDK_LONGLONG
+#define ULONGLONG WINSDK_ULONGLONG
+#define FLOAT WINSDK_FLOAT
+#define HANDLE WINSDK_HANDLE
+#define LPOVERLAPPED WINSDK_LPOVERLAPPED
+#define TCHAR WINSDK_TCHAR
+#define LCID WINSDK_LCID
+#define PLONG WINSDK_PLONG
+#define LPDWORD WINSDK_LPDWORD
+#define LPBYTE WINSDK_LPBYTE
+#define LPFLOAT WINSDK_LPFLOAT
+#define LPCTSTR WINSDK_LPCTSTR
+#define LPCSTR WINSDK_LPCSTR
+#define LPTSTR WINSDK_LPTSTR
+#define LPSTR WINSDK_LPSTR
+#define LPCVOID WINSDK_LPCVOID
+#define RECT WINSDK_RECT
+#define LPRECT WINSDK_LPRECT
+#define LPCRECT WINSDK_LPCRECT
+#define DrawText WINSDK_DrawText
+#define PlaySound WINSDK_PlaySound
+
+#include <winsock2.h>
+#include <ws2tcpip.h>
+
+#undef BYTE
+#undef BOOL
+#undef USHORT
+#undef LONG
+#undef SHORT
+#undef DWORD
+#undef WORD
+#undef DWORD_PTR
+#undef LONG_PTR
+#undef INT_PTR
+#undef LONGLONG
+#undef ULONGLONG
+#undef FLOAT
+#undef HANDLE
+#undef LPOVERLAPPED
+#undef TCHAR
+#undef LCID
+#undef PLONG
+#undef LPDWORD
+#undef LPBYTE
+#undef LPFLOAT
+#undef LPCTSTR
+#undef LPCSTR
+#undef LPTSTR
+#undef LPSTR
+#undef LPCVOID
+#undef RECT
+#undef LPRECT
+#undef LPCRECT
+#undef DrawText
+#undef PlaySound
+#undef MAKEFOURCC
+
+typedef SOCKET net_socket_t;
+typedef int net_socklen_t;
+#define NET_INVALID_SOCKET INVALID_SOCKET
+#else
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+
+typedef int net_socket_t;
+typedef socklen_t net_socklen_t;
+#define NET_INVALID_SOCKET (-1)
+#define SOCKET_ERROR (-1)
+#endif
+
+#endif /* net_platform_h */

--- a/common/shared.h
+++ b/common/shared.h
@@ -14,6 +14,19 @@
 #ifdef _WIN32
 #define strcasecmp _stricmp
 #define strncasecmp _strnicmp
+
+/* The Windows C runtime does not provide BSD strlcpy.  Keep call sites
+ * portable and preserve strlcpy's truncation/NUL-termination semantics. */
+static inline size_t bz_strlcpy(char *destination, const char *source, size_t size) {
+    size_t const source_length = strlen(source);
+    if (size > 0) {
+        size_t const copy_length = source_length < size - 1 ? source_length : size - 1;
+        memcpy(destination, source, copy_length);
+        destination[copy_length] = '\0';
+    }
+    return source_length;
+}
+#define strlcpy bz_strlcpy
 #endif
 
 #define MAX_PATHLEN 256

--- a/docs/windows-build.md
+++ b/docs/windows-build.md
@@ -1,0 +1,22 @@
+# Native Windows build
+
+OpenWarcraft3 uses GNU Make and a GCC-style unity build. On Windows, use an
+MSYS2 UCRT64 environment with these packages:
+
+```sh
+pacman -S --needed make \
+  mingw-w64-ucrt-x86_64-gcc \
+  mingw-w64-ucrt-x86_64-SDL2 \
+  mingw-w64-ucrt-x86_64-zlib \
+  mingw-w64-ucrt-x86_64-libepoxy
+```
+
+From PowerShell, `tools/build-windows.ps1` builds the native executable and
+copies the engine DLLs plus SDL2, zlib, and libepoxy into one runnable folder.
+It uses the standard `C:\msys64` installation and writes to `dist\windows` by
+default. Override `-MsysRoot` and `-PackageDir` when MSYS2 or the package belongs
+in a different location.
+
+The Windows renderer uses libepoxy for runtime OpenGL dispatch because the
+system `opengl32.dll` directly exports only OpenGL 1.1. Networking uses Winsock
+2 and retains the same loopback/UDP behavior as the POSIX implementation.

--- a/games/warcraft-3/game.mk
+++ b/games/warcraft-3/game.mk
@@ -159,7 +159,7 @@ test: test-assets $(SHARED_LIB) $(JASS_LIB) $(SHEET_LIB) | $(BIN_DIR)
 	@$(MAKE) test-wow-ui
 	@$(MAKE) test-ui
 
-$(eval $(call test_schema,test-commands,test-assets $(SHARED_LIB) $(SHEET_LIB),$(TEST_CFLAGS),$(BIN_DIR)/test_commands$(EXE_EXT),$(WC3_TEST_DIR)/test_commands_main.c $(WC3_TEST_DIR)/test_commands.c common/common.c common/cmd.c common/cvar.c common/msg.c common/net.c common/mpq.c,-lsheet -lshared -lm -lz,))
+$(eval $(call test_schema,test-commands,test-assets $(SHARED_LIB) $(SHEET_LIB),$(TEST_CFLAGS),$(BIN_DIR)/test_commands$(EXE_EXT),$(WC3_TEST_DIR)/test_commands_main.c $(WC3_TEST_DIR)/test_commands.c common/common.c common/cmd.c common/cvar.c common/msg.c common/net.c common/mpq.c,-lsheet -lshared -lm -lz $(NET_LIBS),))
 $(eval $(call test_schema,test-jass,$(SHARED_LIB) $(JASS_LIB) $(SHEET_LIB),$(TEST_CFLAGS),$(BIN_DIR)/test_jass$(EXE_EXT),$(WC3_TEST_DIR)/test_jass_main.c $(WC3_TEST_DIR)/test_jass.c $(WC3_TEST_DIR)/test_harness.c $(WC3_TEST_DIR)/test_client_stubs.c $(WC3_DIR)/game/g_metadata.c common/msg.c,-lsheet -lshared -ljass -lm,))
 $(eval $(call test_schema,test-ui,test-assets $(SHARED_LIB) $(JASS_LIB) $(SHEET_LIB),$(TEST_UI_CFLAGS),$(BIN_DIR)/test_openwarcraft3_ui$(EXE_EXT),$(TEST_UI_SRCS) $(TEST_GAME_SRCS) common/mpq.c $(call CSRC,$(WC3_DIR)/ui),-lsheet -lshared -ljass -lm -lz,))
 

--- a/games/warcraft-3/tests/test_ui_fdf.c
+++ b/games/warcraft-3/tests/test_ui_fdf.c
@@ -1450,6 +1450,9 @@ static void test_options_game_port_enter_applies_and_blurs(void) {
     ASSERT_STR_EQ(captured_command, "seta game_port 27911\n");
     ASSERT(!UI_EditHasFocus(editbox));
 
+    OptionsMenu_Apply();
+    ASSERT_STR_EQ(captured_command, "vid_apply\nwriteconfig\n");
+
     uiimport = saved;
 }
 

--- a/games/warcraft-3/ui/screens/options_menu.c
+++ b/games/warcraft-3/ui/screens/options_menu.c
@@ -391,6 +391,9 @@ void OptionsMenu_ShowKeys(void) {
 
 void OptionsMenu_Apply(void) {
     OptionsMenu_ApplyGamePort();
+    if (uiimport.Cmd_ExecuteText) {
+        uiimport.Cmd_ExecuteText("vid_apply\nwriteconfig\n");
+    }
 }
 
 uiScreen_t optionsMenuScreen = {

--- a/renderer/r_local.h
+++ b/renderer/r_local.h
@@ -17,6 +17,11 @@
 #define GL_GLEXT_PROTOTYPES 1
 #include <GL/gl.h>
 #include <GL/glext.h>
+#elif defined(_WIN32)
+/* Windows' OpenGL 1.1 import library does not expose the modern functions
+ * used by the renderer.  Epoxy provides runtime dispatch without pulling in
+ * windows.h, whose DWORD/RECT names collide with the engine's public types. */
+#include <epoxy/gl.h>
 #endif
 
 #ifdef DIAG_OUTPUT
@@ -252,6 +257,7 @@ LPMODEL R_LoadModel(LPCSTR modelFilename);
 void R_ReleaseModel(LPMODEL model);
 
 size2_t R_GetWindowSize(void);
+void R_SetWindowSize(DWORD width, DWORD height);
 size2_t R_GetTextureSize(LPCTEXTURE texture);
 
 // r_buffer.c

--- a/renderer/r_main.c
+++ b/renderer/r_main.c
@@ -644,6 +644,25 @@ size2_t R_GetWindowSize(void) {
     };
 }
 
+void R_SetWindowSize(DWORD width, DWORD height) {
+    if (!window || width == 0 || height == 0) {
+        return;
+    }
+    SDL_SetWindowFullscreen(window, 0);
+    SDL_SetWindowSize(window, (int)width, (int)height);
+    SDL_SetWindowPosition(window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
+    SDL_GL_GetDrawableSize(window,
+                           (int *)&tr.drawableSize.width,
+                           (int *)&tr.drawableSize.height);
+    R_Call(glViewport, 0, 0, tr.drawableSize.width, tr.drawableSize.height);
+    fprintf(stderr,
+            "Video mode applied: %ux%u (drawable %ux%u)\n",
+            (unsigned)width,
+            (unsigned)height,
+            (unsigned)tr.drawableSize.width,
+            (unsigned)tr.drawableSize.height);
+}
+
 size2_t R_GetTextureSize(LPCTEXTURE texture) {
     if (!texture) {
         return (size2_t) { 0, 0 };
@@ -699,6 +718,7 @@ refExport_t R_GetAPI(refImport_t imp) {
         .DrawChar = R_DrawChar,
         .DrawFill = R_DrawFill,
         .GetWindowSize = R_GetWindowSize,
+        .SetWindowSize = R_SetWindowSize,
         .GetTextureSize = R_GetTextureSize,
         .DrawSprite = R_DrawSprite,
         .SetEntityAnimFrame = R_SetEntityAnimFrame,

--- a/renderer/r_stdout.c
+++ b/renderer/r_stdout.c
@@ -124,6 +124,12 @@ static void RStd_Init(DWORD width, DWORD height) {
     printf(" window={w:%u,h:%u}\n", width, height);
 }
 
+static void RStd_SetWindowSize(DWORD width, DWORD height) {
+    stdout_window.width = width;
+    stdout_window.height = height;
+    printf("renderer_resize window={w:%u,h:%u}\n", width, height);
+}
+
 static void RStd_Shutdown(void) {
     while (stdout_fonts) {
         stdout_font_t *next = stdout_fonts->next;
@@ -463,6 +469,7 @@ refExport_t R_StdoutGetAPI(refImport_t imp) {
         .LoadModel = RStd_LoadModel,
         .LoadFont = RStd_LoadFont,
         .GetWindowSize = RStd_GetWindowSize,
+        .SetWindowSize = RStd_SetWindowSize,
         .GetTextureSize = RStd_GetTextureSize,
         .ReleaseTexture = RStd_ReleaseTexture,
         .ReleaseModel = RStd_ReleaseModel,

--- a/server/sv_game.c
+++ b/server/sv_game.c
@@ -1,5 +1,7 @@
 #include <stdarg.h>
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 
 #include "server.h"
 

--- a/server/sv_init.c
+++ b/server/sv_init.c
@@ -1,5 +1,5 @@
 #include "server.h"
-#include <arpa/inet.h>
+#include "common/net_platform.h"
 
 static BOOL SV_EnsureServerPort(void) {
     NET_ConfigSource(NS_SERVER, true);

--- a/server/sv_lan.c
+++ b/server/sv_lan.c
@@ -1,6 +1,6 @@
 #include "server.h"
 
-#include <arpa/inet.h>
+#include "common/net_platform.h"
 #include <stdlib.h>
 
 static DWORD SV_LanPlayerCount(void) {

--- a/tools/build-windows.ps1
+++ b/tools/build-windows.ps1
@@ -1,0 +1,48 @@
+param(
+    [string]$MsysRoot = 'C:\msys64',
+    [string]$PackageDir = '',
+    [int]$Jobs = 4
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..'))
+if (-not $PackageDir) {
+    $PackageDir = Join-Path $repoRoot 'dist\windows'
+}
+$bash = Join-Path $MsysRoot 'usr\bin\bash.exe'
+$ucrtBin = Join-Path $MsysRoot 'ucrt64\bin'
+
+if (-not (Test-Path -LiteralPath $bash -PathType Leaf)) {
+    throw "MSYS2 bash was not found at $bash"
+}
+
+$env:MSYSTEM = 'UCRT64'
+$env:CHERE_INVOKING = '1'
+# This project builds unity translation units and does not emit header dependency
+# files. Force the DLLs to rebuild so a header-only engine fix cannot leave stale
+# binaries in the Windows package.
+$buildCommand = "make -B -j$Jobs BIN_DIR=build-windows/bin LIB_DIR=build-windows/lib openwarcraft3"
+
+Push-Location $repoRoot
+try {
+    & $bash -lc $buildCommand
+    if ($LASTEXITCODE -ne 0) {
+        throw "OpenWarcraft3 Windows build failed with exit code $LASTEXITCODE"
+    }
+} finally {
+    Pop-Location
+}
+
+New-Item -ItemType Directory -Force -Path $PackageDir | Out-Null
+Copy-Item -LiteralPath (Join-Path $repoRoot 'build-windows\bin\openwarcraft3.exe') -Destination $PackageDir -Force
+Get-ChildItem -LiteralPath (Join-Path $repoRoot 'build-windows\lib') -Filter '*.dll' |
+    Copy-Item -Destination $PackageDir -Force
+
+foreach ($runtime in 'SDL2.dll', 'zlib1.dll', 'libepoxy-0.dll') {
+    Copy-Item -LiteralPath (Join-Path $ucrtBin $runtime) -Destination $PackageDir -Force
+}
+
+Copy-Item -LiteralPath (Join-Path $repoRoot 'share') -Destination $PackageDir -Recurse -Force
+
+Write-Host "Windows package created at $PackageDir"

--- a/tools/mpqtool.c
+++ b/tools/mpqtool.c
@@ -8,6 +8,9 @@
 #include <errno.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#ifdef _WIN32
+#include <direct.h>
+#endif
 
 #ifndef PATHSTR
 #define PATHSTR char[512]
@@ -639,14 +642,22 @@ static int mkpath(const char *path)
     for (char *p = tmp + 1; *p; p++) {
         if (*p == '/') {
             *p = '\0';
+#ifdef _WIN32
+            if (_mkdir(tmp) != 0 && errno != EEXIST) {
+#else
             if (mkdir(tmp, 0777) != 0 && errno != EEXIST) {
+#endif
                 return 1;
             }
             *p = '/';
         }
     }
 
+#ifdef _WIN32
+    if (_mkdir(tmp) != 0 && errno != EEXIST) {
+#else
     if (mkdir(tmp, 0777) != 0 && errno != EEXIST) {
+#endif
         return 1;
     }
     return 0;


### PR DESCRIPTION
## Summary

- add a native MSYS2 UCRT64 build path for Windows
- provide a Winsock-backed network abstraction while preserving the existing POSIX implementation
- use libepoxy for modern OpenGL dispatch on Windows
- add Windows-compatible filesystem, console input, and  data discovery behavior
- add a PowerShell build/package helper and Windows build documentation
- make the video mode Apply/OK flow resize the live SDL window and persist the selected configuration

## Why

The project assumed POSIX sockets, filesystem APIs, and OpenGL symbol availability, which prevented a native Windows build. The video options screen also updated its selection without applying the new size to the active renderer window.

## Impact

Windows contributors can build and package `openrealm.exe` from PowerShell using an MSYS2 UCRT64 toolchain. On startup, the executable can discover a local  installation or report a useful desktop error. Resolution changes now take effect immediately when the user applies the settings and remain saved for the next launch.

## Validation

- native Windows executable built and packaged from a clean checkout
- Warcraft III UI test gate: 422/422 assertions passed
- live SDL window and drawable viewport resize verified on Windows