### PR TITLE
M2: implement particles + ribbons pipeline with accumulator/edge-state patterns

### DIFF
--- a/common/shared.h
+++ b/common/shared.h
@@ -882,6 +882,7 @@ typedef struct particle_s {
     BYTE midtime;
     BYTE columns;
     BYTE rows;
+    BYTE blend_mode;
     FLOAT time;
     FLOAT lifespan;
 } cparticle_t;

--- a/docs/wow-abilities.md
+++ b/docs/wow-abilities.md
@@ -84,7 +84,8 @@ events may later refine client-only hand glow or sound timing, but must not dela
 
 `data/whoa-master/src/component/Types.hpp` defines M2 attachment 1 as right hand and 2 as left hand. Attachment 11 is the
 head; using it produced the visibly high Fireball launch. The current server seeds Z from right-hand attachment 1's local
-position and falls back to the caster gameplay radius. It targets `target.origin.z + target.radius`.
+position and falls back to the caster gameplay radius. It homes toward target attachment 20 (chest) when available, otherwise
+using twice the target gameplay radius as a gameplay-space chest approximation.
 
 This is only the server/gameplay approximation. Exact visuals require the renderer's animated attachment matrix:
 
@@ -106,6 +107,12 @@ from remaining/total time, and spell identity selects localized label and icon.
 
 Do not infer casting from the local key press. The server's replicated cast state is authoritative, so rejected casts never
 show a false bar and remote-unit cast bars can use the same contract.
+
+## Movement Facing and Directional Animation
+
+The player keeps its facing yaw while strafing or backpedaling, matching WoW's movement model. Pure A/D movement selects
+`ShuffleLeft`/`ShuffleRight`, pure S movement selects `WalkBackwards`, and forward or diagonal movement selects `Run`.
+Missing directional sequences are logged once and fall back to `Run`.
 
 ## References to Copy Deliberately
 

--- a/docs/wow-abilities.md
+++ b/docs/wow-abilities.md
@@ -110,9 +110,9 @@ show a false bar and remote-unit cast bars can use the same contract.
 
 ## Movement Facing and Directional Animation
 
-The player keeps its facing yaw while strafing or backpedaling, matching WoW's movement model. Pure A/D movement selects
-`ShuffleLeft`/`ShuffleRight`, pure S movement selects `WalkBackwards`, and forward or diagonal movement selects `Run`.
-Missing directional sequences are logged once and fall back to `Run`.
+The player keeps its facing yaw while strafing or backpedaling, matching WoW's movement model. A/D moves laterally and uses
+the normal locomotion animation; `ShuffleLeft`/`ShuffleRight` are turn animations and must not be used for strafe input.
+Pure S movement selects `WalkBackwards`; forward or diagonal movement selects `Run`.
 
 ## References to Copy Deliberately
 

--- a/games/warcraft-3/renderer/mdx/r_mdx.h
+++ b/games/warcraft-3/renderer/mdx/r_mdx.h
@@ -2,6 +2,7 @@
 #define __r_mdx_h__
 
 #include "renderer/r_local.h"
+#include "renderer/r_trail.h"
 
 #define MODEL_ATTACHMENT_PATH_LENGTH 0x100
 #define MDX_TEXTURE_PATH_LENGTH 260
@@ -298,6 +299,11 @@ typedef struct mdxParticleEmitter_s {
     } keytracks;
     
     struct mdxParticleEmitter_s *next;
+
+    /* Frame-persistent state — zeroed at load time, survives across frames */
+    float accumulator;          /* emission rate accumulator for R_EmitParticles */
+    int emitter_type;           /* MODEL_EMITTER_HEAD (1) or MODEL_EMITTER_TAIL (2), set at load */
+    trailEmitter_t trail;       /* ring buffer for MODEL_EMITTER_TAIL */
 } mdxParticleEmitter_t;
 
 typedef struct mdxGeoset_s {

--- a/games/warcraft-3/renderer/mdx/r_mdx_geoset.c
+++ b/games/warcraft-3/renderer/mdx/r_mdx_geoset.c
@@ -46,67 +46,112 @@ static COLOR32 MDLX_GetEmitterColor(mdxParticleEmitter_t const *emitter, DWORD s
     };
 }
 
-static void MDLX_RenderEmitter(mdxModel_t const *model,
-                              mdxParticleEmitter_t const *emitter,
-                              LPCMATRIX4 modelMatrix,
-                              float frame,
-                              DWORD teamID)
+/* Context for the R_EmitParticles spawn callback — carries the evaluated tracks
+   and emitter metadata needed to fill a cparticle_t on each spawn. */
+typedef struct {
+    mdxModel_t const *model; mdxParticleEmitter_t const *emitter;
+    LPCMATRIX4 matrix; DWORD team_id;
+    float speed, varia, lat, grav, life, length, width;
+} mdx_pctx_t;
+
+static void mdx_spawn_particle(void *raw) {
+    mdx_pctx_t *ctx = (mdx_pctx_t *)raw;
+    cparticle_t *p = R_SpawnParticle(); if (!p) return;
+    float r = (float)rand() / (float)RAND_MAX;
+    VECTOR3 origin = {
+        (r - 0.5f) * ctx->length,
+        ((float)rand() / (float)RAND_MAX - 0.5f) * ctx->width,
+        0.0f,
+    };
+    VECTOR3 pivot = { 0, 0, 0 };
+    if (ctx->emitter->node.node_id < (DWORD)ctx->model->num_pivots)
+        pivot = ctx->model->pivots[ctx->emitter->node.node_id];
+    VECTOR3 pivoted = Vector3_add(&origin, &pivot);
+    VECTOR3 dir = FX_GenerateRandomDirection(ctx->lat * (float)M_PI / 180.0f);
+    p->org = Matrix4_multiply_vector3(ctx->matrix, &pivoted);
+    p->vel = Vector3_scale(&dir, ctx->speed + (r - 0.5f) * ctx->varia);
+    p->accel = (VECTOR3){ 0, 0, -ctx->grav };
+    p->lifespan = ctx->life; p->time = 0;
+    p->midtime = ctx->emitter->Time * 0xff;
+    p->texture = MDLX_GetTexture(ctx->model, ctx->team_id, ctx->emitter->TextureID, ctx->emitter->ReplaceableId, NULL);
+    p->columns = ctx->emitter->Columns; p->rows = ctx->emitter->Rows;
+    p->color[0] = MDLX_GetEmitterColor(ctx->emitter, 0);
+    p->color[1] = MDLX_GetEmitterColor(ctx->emitter, 1);
+    p->color[2] = MDLX_GetEmitterColor(ctx->emitter, 2);
+    p->size[0] = ctx->emitter->ParticleScaling[0];
+    p->size[1] = ctx->emitter->ParticleScaling[1];
+    p->size[2] = ctx->emitter->ParticleScaling[2];
+}
+
+/* Frame-relative accumulator emission via R_EmitParticles — replaces the old
+   whole-second time-anchored loop.  Uses emitter->accumulator to track fractional
+   emission across frames (same pattern as WoW's M2_DrawParticles). */
+static void MDLX_RenderHeadEmitter(mdxModel_t const *model,
+                                   mdxParticleEmitter_t *emitter,
+                                   LPCMATRIX4 modelMatrix,
+                                   float frame,
+                                   DWORD teamID)
 {
     GET_PARTICLE_ANIM_PARAM(model, emitter, EmissionRate);
-    GET_PARTICLE_ANIM_PARAM(model, emitter, Width);
-    GET_PARTICLE_ANIM_PARAM(model, emitter, Length);
     GET_PARTICLE_ANIM_PARAM(model, emitter, Speed);
+    GET_PARTICLE_ANIM_PARAM(model, emitter, Variation);
     GET_PARTICLE_ANIM_PARAM(model, emitter, Latitude);
     GET_PARTICLE_ANIM_PARAM(model, emitter, Gravity);
-    GET_PARTICLE_ANIM_PARAM(model, emitter, Variation);
-    
-    if (EmissionRate <= 0)
-        return;
-    
-    EmissionRate = MAX(1, EmissionRate);
+    GET_PARTICLE_ANIM_PARAM(model, emitter, Width);
+    GET_PARTICLE_ANIM_PARAM(model, emitter, Length);
+    if (EmissionRate <= 0.0f) return;
+    if (emitter->node.node_id >= MDX_MAX_NODES) return;
     MATRIX4 matrix;
-    if (emitter->node.node_id >= MDX_MAX_NODES) {
-        return;
+    Matrix4_multiply(modelMatrix, &node_matrices[emitter->node.node_id], &matrix);
+    mdx_pctx_t ctx = { model, emitter, &matrix, teamID,
+        Speed, Variation, Latitude, Gravity, emitter->LifeSpan, Length, Width };
+    R_EmitParticles(EmissionRate, &emitter->accumulator, tr.viewDef.deltaTime, mdx_spawn_particle, &ctx);
+}
+
+/* MODEL_EMITTER_TAIL — emits a trail of billboard edges that follow the emitter
+   node.  The trail ring buffer is advanced each frame via R_UpdateTrail; each
+   active edge spawns one cparticle_t with age-based alpha fade.
+   Uses the common engine trail helper (renderer/r_trail.h), the same ring-buffer
+   pattern that drives WoW's M2_DrawRibbons. */
+static void MDLX_RenderTailEmitter(mdxModel_t const *model,
+                                   mdxParticleEmitter_t *emitter,
+                                   LPCMATRIX4 modelMatrix,
+                                   float frame,
+                                   DWORD teamID)
+{
+    GET_PARTICLE_ANIM_PARAM(model, emitter, EmissionRate);
+    GET_PARTICLE_ANIM_PARAM(model, emitter, Speed);
+    GET_PARTICLE_ANIM_PARAM(model, emitter, Gravity);
+    if (EmissionRate <= 0.0f || emitter->TailLength <= 0.0f) {
+        emitter->trail.count = 0; emitter->trail.acc = 0.0f; return;
     }
-    LPCMATRIX4 nodeMatrix = &node_matrices[emitter->node.node_id];
-    DWORD lastFrameTime = tr.viewDef.time - tr.viewDef.deltaTime;
-    DWORD start = lastFrameTime - lastFrameTime % 1000;
-
-    Matrix4_multiply(modelMatrix, nodeMatrix, &matrix);
-
-    for (float time = start, spawning = 0;
-         time < tr.viewDef.time;
-         time += 1000 / EmissionRate)
-    {
-        if (time >= lastFrameTime) {
-            spawning = 1;
-        }
-        if (spawning) {
-            cparticle_t *p = R_SpawnParticle();
-            if (!p) return;
-            VECTOR3 origin = FX_GenerateRandomOrigin(emitter->Length, emitter->Width);
-            VECTOR3 pivot = { 0, 0, 0 };
-            if (emitter->node.node_id < (DWORD)model->num_pivots) {
-                pivot = model->pivots[emitter->node.node_id];
-            }
-            VECTOR3 pivoted = Vector3_add(&origin, &pivot);
-            VECTOR3 direction = FX_GenerateRandomDirection(emitter->Latitude * M_PI / 180);
-            p->org = Matrix4_multiply_vector3(&matrix, &pivoted);
-            p->vel = Vector3_scale(&direction, Speed);
-            p->accel = Vector3_scale(&(VECTOR3){0,0,-1}, Gravity);
-            p->lifespan = emitter->LifeSpan;
-            p->time = 0;
-            p->midtime = emitter->Time * 0xff;
-            p->texture = MDLX_GetTexture(model, teamID, emitter->TextureID, emitter->ReplaceableId, NULL);
-            p->columns = emitter->Columns;
-            p->rows = emitter->Rows;
-            p->color[0] = MDLX_GetEmitterColor(emitter, 0);
-            p->color[1] = MDLX_GetEmitterColor(emitter, 1);
-            p->color[2] = MDLX_GetEmitterColor(emitter, 2);
-            p->size[0] = emitter->ParticleScaling[0];
-            p->size[1] = emitter->ParticleScaling[1];
-            p->size[2] = emitter->ParticleScaling[2];
-        }
+    if (emitter->node.node_id >= MDX_MAX_NODES) return;
+    MATRIX4 matrix;
+    Matrix4_multiply(modelMatrix, &node_matrices[emitter->node.node_id], &matrix);
+    VECTOR3 spine = Matrix4_multiply_vector3(&matrix, &(VECTOR3){ 0, 0, 0 });
+    FLOAT dt = (FLOAT)tr.viewDef.deltaTime / 1000.0f;
+    COLOR32 c0 = MDLX_GetEmitterColor(emitter, 0);
+    VECTOR3 col = { c0.r / 255.0f, c0.g / 255.0f, c0.b / 255.0f };
+    R_UpdateTrail(&emitter->trail, spine, col, c0.a / 255.0f,
+                  emitter->TailLength, EmissionRate, dt);
+    LPCTEXTURE tex = MDLX_GetTexture(model, teamID, emitter->TextureID, emitter->ReplaceableId, NULL);
+    for (int e = 0; e < emitter->trail.count; e++) {
+        int idx = (emitter->trail.head - emitter->trail.count + e + MAX_TRAIL_EDGES) % MAX_TRAIL_EDGES;
+        trailEdge_t *re = &emitter->trail.edges[idx];
+        cparticle_t *fx = R_SpawnParticle(); if (!fx) break;
+        re->world_pos.z -= Gravity * dt * dt * 0.5f;
+        fx->texture = tex; fx->org = re->world_pos;
+        fx->vel = (VECTOR3){ 0, 0, 0 };
+        fx->accel = (VECTOR3){ 0, 0, -Gravity };
+        FLOAT fade = 1.0f - MIN(1.0f, re->age / emitter->TailLength);
+        COLOR32 fc = c0; fc.a = (BYTE)((FLOAT)fc.a * fade + 0.5f);
+        fx->color[0] = fx->color[1] = fx->color[2] = fc;
+        fx->size[0] = emitter->ParticleScaling[0];
+        fx->size[1] = emitter->ParticleScaling[1];
+        fx->size[2] = emitter->ParticleScaling[2];
+        fx->midtime = 0x80;
+        fx->columns = emitter->Columns; fx->rows = emitter->Rows;
+        fx->time = 0.0f; fx->lifespan = MAX(0.05f, emitter->TailLength - re->age);
     }
 }
 
@@ -657,7 +702,10 @@ static void MDLX_RenderParticleEmitters(const renderEntity_t *entity, const mdxM
                 continue;
         }
         float const frame = LerpNumber(entity->oldframe, entity->frame, tr.viewDef.lerpfrac);
-        MDLX_RenderEmitter(model, emitter, model_matrix, frame, entity->team&TEAM_MASK);
+        if (emitter->emitter_type == MODEL_EMITTER_TAIL)
+            MDLX_RenderTailEmitter(model, emitter, model_matrix, frame, entity->team&TEAM_MASK);
+        else
+            MDLX_RenderHeadEmitter(model, emitter, model_matrix, frame, entity->team&TEAM_MASK);
     }
 }
 

--- a/games/warcraft-3/renderer/mdx/r_mdx_load.c
+++ b/games/warcraft-3/renderer/mdx/r_mdx_load.c
@@ -555,6 +555,7 @@ void ReadParticleEmitter(LPSIZEBUF buffer, mdxParticleEmitter_t *pe) {
     MSG_READ(buffer, pe->Squirt);
     MSG_READ(buffer, pe->PriorityPlane);
     MSG_READ(buffer, pe->ReplaceableId);
+    pe->emitter_type = (pe->FrameFlags == 2) ? MODEL_EMITTER_TAIL : MODEL_EMITTER_HEAD;
     while (MSG_Read(buffer, &header, 4)) {
         switch (header) {
             case ID_KP2V: ReadKeyTrack(buffer, TDATA_FLOAT1, &pe->keytracks.Visibility); break;

--- a/games/world-of-warcraft/docs/file-formats.md
+++ b/games/world-of-warcraft/docs/file-formats.md
@@ -58,6 +58,14 @@ Current renderer code loads enough WMO root/group data to create visible batches
 | `.anim` | External animation data used by later client eras and some models. | Animation tracks split out from the base model. | [wowdev M2](https://wowdev.wiki/M2), [wow-m2 README](https://docs.rs/crate/wow-m2/latest/source/README.md). |
 | `.skel`, `.bone`, `.phys` | Later-era skeleton, bone, and physics companions. | Modern model support. | [pywowlib support table](https://github.com/wowdev/pywowlib), [wow-m2 docs.rs](https://docs.rs/wow-m2). |
 
+### M2 effect-emitter version split
+
+Classic/TBC (`MD20` version `<264`) particle records are `0x1f8` bytes: ten 28-byte vanilla tracks followed by static
+BGRA lifecycle colors and scalar scales. They are not the later WotLK record with FBlocks. The emitter position is local to
+its referenced bone, so particle and ribbon spines must be transformed by `model_matrix * bone_matrix` before emission.
+`data/WoWee/src/pipeline/m2_loader.cpp` is the local reference for these offsets; `data/WoWee/src/rendering/m2_renderer_particles.cpp`
+keeps the corresponding per-instance particle accumulators and ribbon edge state.
+
 Character-display specifics are scattered across model files and DBC tables. For our current classic-era work, the highest-value cross-checks are:
 
 - `data/whoa-master/src/component/CCharacterComponent.cpp` for item component texture creation and geoset visibility prep.

--- a/games/world-of-warcraft/docs/references.md
+++ b/games/world-of-warcraft/docs/references.md
@@ -23,12 +23,16 @@
 - `data/whoa-master/src/db/rec/*Rec.hpp`: DBC record layouts used by whoa-master.
 - `data/whoa-master/src/model/M2Data.hpp`: M2 arrays, tracks, materials, batches, cameras, bones, and related structures.
 - `data/whoa-master/src/world/map/*`: map, chunk, doodad, object, liquid, and WMO-facing scaffolding.
+- `data/WoWee/src/rendering/m2_renderer_particles.cpp`: Full particle/ribbon/smoke pipeline — `emitParticles`, `updateParticles`, `updateRibbons`, `renderM2Ribbons`, `renderM2Particles`, `renderSmokeParticles`. ~800 lines, no stubs. Includes model-specific tuning: floors emission rate against particle lifespan so flame emitters (torches, braziers, lanterns) don't visually disappear when authored M2 rates are too sparse. Interpolation helpers for `M2AnimationTrack`, `M2FBlock` (scalar, vec3).
+- `data/WoWee/src/rendering/m2_renderer_internal.h`: Particle/ribbon emitter GPU structs, `M2Instance` particle state (accumulators, edge buffers), per-emitter gravity caching.
+- `data/WoWee/assets/shaders/m2_particle.vert.glsl`, `m2_particle.frag.glsl`: Vulkan particle billboard shaders.
+- `data/WoWee/assets/shaders/m2_ribbon.vert.glsl`, `m2_ribbon.frag.glsl`: Vulkan ribbon trail shaders.
 
 ## Open-Source Client Implementations
 
 - [whoahq/whoa](https://github.com/whoahq/whoa) — unofficial open-source WoW 3.3.5a (build 12340) client in C++11. Targets Windows 10+, macOS 10.14+, Linux. Launches against extracted client data files (no live MPQ reading).
 - [Kelsidavis/WoWee](https://github.com/Kelsidavis/WoWee) — custom open-source WoW client with Warden anti-cheat (Unicorn x86), SDL2, Vulkan, GLM, StormLib, OpenGL renderer, Native Linux. Covers Vanilla, TBC, WotLK. Most active client reimplementation.
-- [Reinisch/Warcraft-Arena-Unity](https://github.com/Reinisch/Warcraft-Arena-Unity) — WoW client-server combat/arena engine in Unity. Data-driven spells/auras/effects, unit frames, action bars, floating combat text, AI behavior graphs. Non-commercial educational fan project.
+- [Reinisch/Warcraft-Arena-Unity](https://github.com/Reinisch/Warcraft-Arena-Unity) — WoW-style combat/arena engine in Unity. Built on original custom-authored content (Mage spell kit, ScriptableObject-driven spells/auras, Unity URP/Netcode/Zenject). Not a client reimplementation — spells and VFX are hand-authored rather than extracted from original M2 particle/ribbon data. Non-commercial educational fan project.
 
 ## Server Emulators
 
@@ -79,6 +83,15 @@
 - `wow.export`: https://github.com/Kruithne/wow.export
 - mangos classic M2 notes mirror: https://github-wiki-see.page/m/Marzec737/mangos-classic/wiki/M2-files
 - Archival `World of Warcraft Formats` PDF mirror: https://lasatmanstanding.wordpress.com/wp-content/uploads/2010/05/wow-formats-2.pdf
+
+## WoW to Unity Model Pipeline
+
+- [Kruithne/wow.export](https://github.com/Kruithne/wow.export) — current extraction/export tool (successor to Marlamin's WoW Export Tools). Extracts and converts WoW client or CDN files, supports Retail and Classic, previews M2/WMO models, exports OBJ/GLTF. Includes a Blender add-on for maps/models.
+- [briochie/wow.unity](https://github.com/briochie/wow.unity) — Unity-side companion to wow.export. Shaders, asset postprocessors, and tools that configure materials and parse wow.export metadata (including doodad placements) so exported models/prefabs drop into Unity scenes with ~80% in-game look fidelity (Built-In or URP).
+- [Selzier/wow.export.unity](https://github.com/Selzier/wow.export.unity) — fork of wow.export retargeted for exporting directly into the Unity Editor (Unity-aware export step, alternative to post-processing with wow.unity).
+- [cplushplush/unity-wow-map-importer](https://github.com/cplushplush/unity-wow-map-importer) — Unity plugin for importing map tiles (terrain/zones) exported by WoW exporters.
+
+Note: none of these tools export M2 particle/ribbon emitter data — they produce static geometry and textures. Particle/ribbon VFX must be reimplemented by hand on the target engine side.
 
 ## Combat and Game Design References
 

--- a/games/world-of-warcraft/game/g_ai.c
+++ b/games/world-of-warcraft/game/g_ai.c
@@ -5,6 +5,9 @@ static wowMove_t wow_move_stand = { "Stand", NULL, NULL };
 static wowMove_t wow_move_ready = { "Ready", NULL, NULL };
 static wowMove_t wow_move_walk = { "Walk", NULL, NULL };
 static wowMove_t wow_move_run = { "Run", NULL, NULL };
+static wowMove_t wow_move_back = { "WalkBackwards", NULL, NULL };
+static wowMove_t wow_move_strafe_left = { "ShuffleLeft", NULL, NULL };
+static wowMove_t wow_move_strafe_right = { "ShuffleRight", NULL, NULL };
 static wowMove_t wow_move_attack = { "Attack", NULL, NULL };
 static wowMove_t wow_move_pain = { "Pain", NULL, NULL };
 static wowMove_t wow_move_death = { "Death", NULL, NULL };
@@ -153,6 +156,19 @@ BOOL Wow_SetRunMove(LPEDICT ent) {
 
 BOOL Wow_SetWalkMove(LPEDICT ent) {
     return Wow_SetEntityMove(ent, &wow_move_walk);
+}
+
+/* Preserve facing while selecting the M2 locomotion sequence that matches the input direction. */
+BOOL Wow_SetDirectionalMove(LPEDICT ent, DWORD flags) {
+    if ((flags & WOW_MOVE_BACK) && !(flags & WOW_MOVE_FORWARD))
+        return Wow_SetEntityMove(ent, &wow_move_back) || Wow_SetRunMove(ent);
+    if ((flags & WOW_MOVE_LEFT) && !(flags & WOW_MOVE_RIGHT) &&
+        !(flags & (WOW_MOVE_FORWARD | WOW_MOVE_BACK)))
+        return Wow_SetEntityMove(ent, &wow_move_strafe_left) || Wow_SetRunMove(ent);
+    if ((flags & WOW_MOVE_RIGHT) && !(flags & WOW_MOVE_LEFT) &&
+        !(flags & (WOW_MOVE_FORWARD | WOW_MOVE_BACK)))
+        return Wow_SetEntityMove(ent, &wow_move_strafe_right) || Wow_SetRunMove(ent);
+    return Wow_SetRunMove(ent);
 }
 
 BOOL Wow_SetCombatReadyAnimation(LPEDICT ent) {

--- a/games/world-of-warcraft/game/g_ai.c
+++ b/games/world-of-warcraft/game/g_ai.c
@@ -6,8 +6,6 @@ static wowMove_t wow_move_ready = { "Ready", NULL, NULL };
 static wowMove_t wow_move_walk = { "Walk", NULL, NULL };
 static wowMove_t wow_move_run = { "Run", NULL, NULL };
 static wowMove_t wow_move_back = { "WalkBackwards", NULL, NULL };
-static wowMove_t wow_move_strafe_left = { "ShuffleLeft", NULL, NULL };
-static wowMove_t wow_move_strafe_right = { "ShuffleRight", NULL, NULL };
 static wowMove_t wow_move_attack = { "Attack", NULL, NULL };
 static wowMove_t wow_move_pain = { "Pain", NULL, NULL };
 static wowMove_t wow_move_death = { "Death", NULL, NULL };
@@ -162,12 +160,7 @@ BOOL Wow_SetWalkMove(LPEDICT ent) {
 BOOL Wow_SetDirectionalMove(LPEDICT ent, DWORD flags) {
     if ((flags & WOW_MOVE_BACK) && !(flags & WOW_MOVE_FORWARD))
         return Wow_SetEntityMove(ent, &wow_move_back) || Wow_SetRunMove(ent);
-    if ((flags & WOW_MOVE_LEFT) && !(flags & WOW_MOVE_RIGHT) &&
-        !(flags & (WOW_MOVE_FORWARD | WOW_MOVE_BACK)))
-        return Wow_SetEntityMove(ent, &wow_move_strafe_left) || Wow_SetRunMove(ent);
-    if ((flags & WOW_MOVE_RIGHT) && !(flags & WOW_MOVE_LEFT) &&
-        !(flags & (WOW_MOVE_FORWARD | WOW_MOVE_BACK)))
-        return Wow_SetEntityMove(ent, &wow_move_strafe_right) || Wow_SetRunMove(ent);
+    /* A/D are lateral movement; ShuffleLeft/Right are turn animations, not strafe animations. */
     return Wow_SetRunMove(ent);
 }
 

--- a/games/world-of-warcraft/game/g_model.c
+++ b/games/world-of-warcraft/game/g_model.c
@@ -588,6 +588,7 @@ typedef struct {
     animation_t *animations;
     DWORD        num_animations;
     FLOAT        attach_hand_z;   /* attachment id=1 (right hand) local Z, 0 if missing */
+    FLOAT        attach_chest_z;  /* attachment id=20 (chest) local Z, 0 if missing */
     char         filename[MAX_PATHLEN];
 } g_cmodel_t;
 
@@ -674,13 +675,16 @@ static g_cmodel_t *LoadModel(LPCSTR filename) {
                             DWORD attach_count = bytes / ATTACH_STRIDE;
                             WORD const *lookup = (WORD const *)M2ArrayAt((BYTE *)payload, payload_size,
                                                                         lookup_arr, sizeof(WORD));
-                            { /* whoa GEOCOMPONENTLINKS: id=1 is the right hand; id=11 is the head. */
-                                WORD idx = (lookup && 1 < (int)lookup_arr.size) ? lookup[1] : 0xFFFF;
+                            FOR_LOOP(aid, 2) {
+                                DWORD attachment_id = aid ? 20 : 1;
+                                WORD idx = (lookup && attachment_id < (DWORD)lookup_arr.size)
+                                    ? lookup[attachment_id] : 0xFFFF;
                                 if (idx != 0xFFFF && (DWORD)idx < attach_count) {
                                     BYTE const *entry = attach_base + idx * ATTACH_STRIDE;
-                                    if (*(DWORD const *)entry == 1) {
+                                    if (*(DWORD const *)entry == attachment_id) {
                                         FLOAT z; memcpy(&z, entry + 16, sizeof(FLOAT));
-                                        model->attach_hand_z = z;
+                                        if (attachment_id == 1) model->attach_hand_z = z;
+                                        else model->attach_chest_z = z;
                                     }
                                 }
                             }
@@ -707,6 +711,7 @@ static g_cmodel_t *GetModel(DWORD modelindex) {
         entry->animations     = m->animations;
         entry->num_animations = m->num_animations;
         entry->attach_hand_z  = m->attach_hand_z;
+        entry->attach_chest_z = m->attach_chest_z;
         gi.MemFree(m);
     }
     return entry->animations ? entry : NULL;
@@ -738,12 +743,13 @@ void G_FreeModels(void) {
 
 /* Return the model-local Z of attachment `aid` for the given model.
  * Returns 0 if the model or attachment is not found.
- * Attachment id 1 is the right hand; the animated world transform remains renderer-owned. */
+ * Attachments 1/20 are the right hand/chest; the animated world transform remains renderer-owned. */
 FLOAT G_GetAttachmentZ(DWORD modelindex, int aid) {
     g_cmodel_t *model = GetModel(modelindex);
     if (!model) return 0;
     switch (aid) {
         case 1: return model->attach_hand_z;
+        case 20: return model->attach_chest_z;
         default: return 0;
     }
 }

--- a/games/world-of-warcraft/game/g_wow.c
+++ b/games/world-of-warcraft/game/g_wow.c
@@ -702,7 +702,10 @@ void Wow_RunProjectile(LPEDICT ent) {
         ent->s.origin.x += delta.x * step / dist;
         ent->s.origin.y += delta.y * step / dist;
         {
-            FLOAT target_z = target->s.origin.z + target->s.radius;
+            FLOAT target_chest_z = G_GetAttachmentZ(target->s.model, 20);
+            /* WoW attachment 20 is the chest; server hit testing remains independent of renderer bones. */
+            if (target_chest_z <= 0) target_chest_z = target->s.radius * 2.0f;
+            FLOAT target_z = target->s.origin.z + target_chest_z * target->s.scale;
             ent->s.origin.z += (target_z - ent->s.origin.z) * step / dist;
         }
         local->projectile_yaw = (FLOAT)RAD2DEG(atan2f(delta.y, delta.x));
@@ -1463,7 +1466,7 @@ static void Wow_RunFrame(void) {
     if (locked) {
         Wow_UpdateCamera(ent);
     } else if (moving
-        ? Wow_SetRunMove(ent)
+        ? Wow_SetDirectionalMove(ent, wow_move.flags)
         : (Wow_EntityAffectingCombat(ent)
             ? Wow_SetCombatReadyAnimation(ent)
             : Wow_SetStandMove(ent))) {

--- a/games/world-of-warcraft/game/g_wow_local.h
+++ b/games/world-of-warcraft/game/g_wow_local.h
@@ -143,6 +143,7 @@ BOOL Wow_EntityAffectingCombat(LPEDICT ent);
 BOOL Wow_SetStandMove(LPEDICT ent);
 BOOL Wow_SetRunMove(LPEDICT ent);
 BOOL Wow_SetWalkMove(LPEDICT ent);
+BOOL Wow_SetDirectionalMove(LPEDICT ent, DWORD flags);
 BOOL Wow_SetCombatReadyAnimation(LPEDICT ent);
 void Wow_AIRunFrame(LPEDICT ent);
 void Wow_SpawnAmbientCreatures(LPCVECTOR2 origin);

--- a/games/world-of-warcraft/renderer/m2/r_m2.c
+++ b/games/world-of-warcraft/renderer/m2/r_m2.c
@@ -2293,6 +2293,9 @@ static void m2_spawn_particle(void *raw) {
 	dir = Vector3_sub(&w_dir, &w_zero);
 	Vector3_normalize(&dir);
 	fx->texture = ctx->texture;
+	fx->blend_mode = ctx->p->blend_mode == 1 ? BLEND_MODE_ALPHAKEY :
+		ctx->p->blend_mode == 2 ? BLEND_MODE_BLEND :
+		(ctx->p->blend_mode == 3 || ctx->p->blend_mode == 4) ? BLEND_MODE_ADD : BLEND_MODE_NONE;
 	fx->org = org;
 	fx->vel = Vector3_scale(&dir, MAX(0.0f, ctx->speed + (r - 0.5f) * ctx->varia));
 	fx->accel = (VECTOR3){ 0, 0, -ctx->grav };

--- a/games/world-of-warcraft/renderer/m2/r_m2.c
+++ b/games/world-of-warcraft/renderer/m2/r_m2.c
@@ -195,9 +195,8 @@ typedef struct {
     m2Track_t visibility_track;
 } m2Particle_t;
 
-/* Classic (TBC, version <= 263) particle emitter — tracks are m2TrackClassic_t (28 bytes each).
-   Key differences from modern: 10 tracks (no zsource), no life_variation/emission_rate_variation
-   float fields interspersed between tracks; all tracks are contiguous. */
+/* Classic (Vanilla/TBC) particle header and track block. The 0x1f8 record stores static
+   lifecycle values after ten 28-byte tracks; it does not contain modern FBlocks. */
 typedef struct {
     DWORD particle_id;
     DWORD flags;
@@ -224,30 +223,7 @@ typedef struct {
     m2TrackClassic_t width_track;
     m2TrackClassic_t length_track;
     m2TrackClassic_t visibility_track;
-    m2PartTrack_t color_track;
-    m2PartTrack_t alpha_track;
-    m2PartTrack_t scale_track;
-    VECTOR2 scale_variation;
-    m2PartTrack_t head_cell_track;
-    m2PartTrack_t tail_cell_track;
-    FLOAT tail_length;
-    FLOAT twinkle_fps;
-    FLOAT twinkle_onoff;
-    FLOAT twinkle_scale[2];
-    FLOAT ivel_scale;
-    FLOAT drag;
-    FLOAT initial_spin;
-    FLOAT initial_spin_variation;
-    FLOAT spin;
-    FLOAT spin_variation;
-    m2Box_t tumble;
-    VECTOR3 wind_vector;
-    FLOAT wind_time;
-    FLOAT follow_speed1;
-    FLOAT follow_scale1;
-    FLOAT follow_speed2;
-    FLOAT follow_scale2;
-    m2Array_t spline;
+    BYTE lifecycle_data[0x1f8 - 0x14c];
 } m2ParticleClassic_t;
 
 typedef struct {
@@ -2285,24 +2261,35 @@ static LPTEXTURE m2_ribbon_texture(m2Model_t const *model, m2Ribbon_t const *r, 
 typedef struct {
 	FLOAT speed, varia, lat, lon, grav, life, life_var, zsource;
 	FLOAT alpha[3]; VECTOR2 scale[3]; VECTOR3 color[3];
-	LPTEXTURE texture;
+	LPTEXTURE texture; WORD bone_index;
 	m2Model_t const *model; m2Particle_t const *p; LPCMATRIX4 model_matrix;
 } m2_pctx_t;
+
+/* M2 emitter positions are local to their bone, not the model origin. */
+static void M2_EmitterMatrix(m2_pctx_t const *ctx, LPMATRIX4 out) {
+    if (ctx->model && ctx->bone_index < ctx->model->bone_count && ctx->model->bone_matrices) {
+        Matrix4_multiply(ctx->model_matrix, &ctx->model->bone_matrices[ctx->bone_index], out);
+        return;
+    }
+    *out = *ctx->model_matrix;
+}
 
 static void m2_spawn_particle(void *raw) {
 	m2_pctx_t *ctx = (m2_pctx_t *)raw;
 	cparticle_t *fx = R_SpawnParticle(); if (!fx) return;
 	FLOAT r = (FLOAT)rand() / (FLOAT)RAND_MAX;
+	MATRIX4 emitter_matrix;
+	M2_EmitterMatrix(ctx, &emitter_matrix);
 	VECTOR3 local_origin = ctx->p->position;
 	local_origin.z += ctx->zsource;
-	VECTOR3 org = Matrix4_multiply_vector3(ctx->model_matrix, &local_origin);
+	VECTOR3 org = Matrix4_multiply_vector3(&emitter_matrix, &local_origin);
 	VECTOR3 dir = {
 		cosf(ctx->lon + (r - 0.5f) * 6.2831853f) * cosf(ctx->lat),
 		sinf(ctx->lon + (r - 0.5f) * 6.2831853f) * cosf(ctx->lat),
 		sinf(ctx->lat + (r - 0.5f) * 0.5f),
 	};
-	VECTOR3 w_dir = Matrix4_multiply_vector3(ctx->model_matrix, &dir);
-	VECTOR3 w_zero = Matrix4_multiply_vector3(ctx->model_matrix, &(VECTOR3){ 0, 0, 0 });
+	VECTOR3 w_dir = Matrix4_multiply_vector3(&emitter_matrix, &dir);
+	VECTOR3 w_zero = Matrix4_multiply_vector3(&emitter_matrix, &(VECTOR3){ 0, 0, 0 });
 	dir = Vector3_sub(&w_dir, &w_zero);
 	Vector3_normalize(&dir);
 	fx->texture = ctx->texture;
@@ -2387,6 +2374,24 @@ static m2PartTrack_t const *m2p_part_track(m2Model_t const *model, BYTE const *r
     return (m2PartTrack_t const *)(raw + m2p_part_track_base(model) + n * sizeof(m2PartTrack_t));
 }
 
+/* Vanilla/TBC stores three static BGRA lifecycle colors and three scalar scales. */
+static void m2p_sample_classic_data(BYTE const *raw, m2_pctx_t *ctx) {
+    FLOAT midpoint = *(FLOAT const *)(raw + 0x14c);
+    BOOL all_alpha_zero = true;
+    if (midpoint < 0.0f || midpoint > 1.0f) midpoint = 0.5f;
+    FOR_LOOP(i, 3) {
+        DWORD bgra = *(DWORD const *)(raw + 0x150 + i * 4);
+        ctx->color[i] = (VECTOR3){ ((bgra >> 16) & 0xff) / 255.0f, ((bgra >> 8) & 0xff) / 255.0f,
+                                   (bgra & 0xff) / 255.0f };
+        ctx->alpha[i] = ((bgra >> 24) & 0xff) / 255.0f;
+        ctx->scale[i] = (VECTOR2){ *(FLOAT const *)(raw + 0x15c + i * 4), 0.0f };
+        if (ctx->alpha[i] > 0.01f) all_alpha_zero = false;
+        if (ctx->scale[i].x < 0.001f || ctx->scale[i].x > 100.0f) ctx->scale[i].x = 1.0f;
+    }
+    if (all_alpha_zero) { ctx->alpha[0] = 1.0f; ctx->alpha[1] = 1.0f; ctx->alpha[2] = 0.0f; }
+    (void)midpoint;
+}
+
 static void M2_DrawParticles(m2Model_t const *model, renderEntity_t const *entity, LPCMATRIX4 model_matrix) {
 	if (!model || !entity || !model->particles.size) return;
 	BYTE const *base = M2_ModelArrayPtr(model, model->particles, model->particle_stride);
@@ -2419,19 +2424,23 @@ static void M2_DrawParticles(m2Model_t const *model, renderEntity_t const *entit
 		ctx.life     = life;
 		ctx.life_var = m2p_life_variation(model, raw);
 		{ m2TrackView_t t = m2p_track_indexed(model, raw, M2P_ZSOURCE);   ctx.zsource = M2_EvaluateFloatTrack(model, &t, seq_idx, seq_time, 0.0f); }
-		m2PartTrack_t const *alpha_pt  = m2p_part_track(model, raw, 1);
-		m2PartTrack_t const *scale_pt  = m2p_part_track(model, raw, 2);
-		m2PartTrack_t const *color_pt  = m2p_part_track(model, raw, 0);
-		{ SHORT raw2; m2_sample_part_track(model, alpha_pt, 0.0f, sizeof(raw2), &raw2); ctx.alpha[0] = m2_fixed16_to_float(raw2);
-		             m2_sample_part_track(model, alpha_pt, 0.5f, sizeof(raw2), &raw2); ctx.alpha[1] = m2_fixed16_to_float(raw2);
-		             m2_sample_part_track(model, alpha_pt, 1.0f, sizeof(raw2), &raw2); ctx.alpha[2] = m2_fixed16_to_float(raw2); }
-		m2_sample_part_track(model, scale_pt, 0.0f, sizeof(VECTOR2), &ctx.scale[0]);
-		m2_sample_part_track(model, scale_pt, 0.5f, sizeof(VECTOR2), &ctx.scale[1]);
-		m2_sample_part_track(model, scale_pt, 1.0f, sizeof(VECTOR2), &ctx.scale[2]);
-		m2_sample_part_track(model, color_pt, 0.0f, sizeof(VECTOR3), &ctx.color[0]);
-		m2_sample_part_track(model, color_pt, 0.5f, sizeof(VECTOR3), &ctx.color[1]);
-		m2_sample_part_track(model, color_pt, 1.0f, sizeof(VECTOR3), &ctx.color[2]);
+		if (model->classic_particles) m2p_sample_classic_data(raw, &ctx);
+		else {
+			m2PartTrack_t const *alpha_pt = m2p_part_track(model, raw, 1);
+			m2PartTrack_t const *scale_pt = m2p_part_track(model, raw, 2);
+			m2PartTrack_t const *color_pt = m2p_part_track(model, raw, 0);
+			{ SHORT raw2; m2_sample_part_track(model, alpha_pt, 0.0f, sizeof(raw2), &raw2); ctx.alpha[0] = m2_fixed16_to_float(raw2);
+			             m2_sample_part_track(model, alpha_pt, 0.5f, sizeof(raw2), &raw2); ctx.alpha[1] = m2_fixed16_to_float(raw2);
+			             m2_sample_part_track(model, alpha_pt, 1.0f, sizeof(raw2), &raw2); ctx.alpha[2] = m2_fixed16_to_float(raw2); }
+			m2_sample_part_track(model, scale_pt, 0.0f, sizeof(VECTOR2), &ctx.scale[0]);
+			m2_sample_part_track(model, scale_pt, 0.5f, sizeof(VECTOR2), &ctx.scale[1]);
+			m2_sample_part_track(model, scale_pt, 1.0f, sizeof(VECTOR2), &ctx.scale[2]);
+			m2_sample_part_track(model, color_pt, 0.0f, sizeof(VECTOR3), &ctx.color[0]);
+			m2_sample_part_track(model, color_pt, 0.5f, sizeof(VECTOR3), &ctx.color[1]);
+			m2_sample_part_track(model, color_pt, 1.0f, sizeof(VECTOR3), &ctx.color[2]);
+		}
 		ctx.texture = m2_particle_texture(model, p);
+		ctx.bone_index = p->bone_index;
 		R_EmitParticles(rate, &model->emitter_accumulators[i], tr.viewDef.deltaTime, m2_spawn_particle, &ctx);
 	}
 }
@@ -2514,7 +2523,10 @@ static void M2_DrawRibbons(m2Model_t const *model, renderEntity_t const *entity,
 		LPTEXTURE tex = m2_ribbon_texture(model, r, slot);
 		FLOAT grav = *m2r_scalar(model, raw, 2);
 		/* -- Emit new edges at the animated spine position ---------------- */
-		VECTOR3 spine = Matrix4_multiply_vector3(model_matrix, &r->position);
+		MATRIX4 emitter_matrix = *model_matrix;
+		if (r->bone_index < model->bone_count && model->bone_matrices)
+			Matrix4_multiply(model_matrix, &model->bone_matrices[r->bone_index], &emitter_matrix);
+		VECTOR3 spine = Matrix4_multiply_vector3(&emitter_matrix, &r->position);
 		res->acc += eps * dt;
 		while (res->acc >= 1.0f) {
 			res->acc -= 1.0f;
@@ -3463,9 +3475,7 @@ void M2_RenderModel(renderEntity_t const *entity, m2Model_t const *model, LPCMAT
     if (!entity || !model || !transform) {
         return;
     }
-    if (!Frustum_ContainsBox(&tr.viewDef.frustum, &model->bounds, transform)) {
-        return;
-    }
+    if (!Frustum_ContainsBox(&tr.viewDef.frustum, &model->bounds, transform)) return;
 
     shader = M2_Shader();
     M2_CalculateBoneMatrices(model, entity);

--- a/games/world-of-warcraft/renderer/m2/r_m2.c
+++ b/games/world-of-warcraft/renderer/m2/r_m2.c
@@ -195,6 +195,61 @@ typedef struct {
     m2Track_t visibility_track;
 } m2Particle_t;
 
+/* Classic (TBC, version <= 263) particle emitter — tracks are m2TrackClassic_t (28 bytes each).
+   Key differences from modern: 10 tracks (no zsource), no life_variation/emission_rate_variation
+   float fields interspersed between tracks; all tracks are contiguous. */
+typedef struct {
+    DWORD particle_id;
+    DWORD flags;
+    VECTOR3 position;
+    WORD bone_index;
+    WORD texture_index;
+    m2Array_t geometry_mdl;
+    m2Array_t recursion_mdl;
+    BYTE blend_mode;
+    BYTE emitter_type;
+    WORD color_index;
+    WORD pad;
+    SHORT priority_plane;
+    WORD rows;
+    WORD cols;
+    /* 10 contiguous tracks — no float gaps, no zsource_track in TBC */
+    m2TrackClassic_t speed_track;
+    m2TrackClassic_t variation_track;
+    m2TrackClassic_t latitude_track;
+    m2TrackClassic_t longitude_track;
+    m2TrackClassic_t gravity_track;
+    m2TrackClassic_t life_track;
+    m2TrackClassic_t emission_rate_track;
+    m2TrackClassic_t width_track;
+    m2TrackClassic_t length_track;
+    m2TrackClassic_t visibility_track;
+    m2PartTrack_t color_track;
+    m2PartTrack_t alpha_track;
+    m2PartTrack_t scale_track;
+    VECTOR2 scale_variation;
+    m2PartTrack_t head_cell_track;
+    m2PartTrack_t tail_cell_track;
+    FLOAT tail_length;
+    FLOAT twinkle_fps;
+    FLOAT twinkle_onoff;
+    FLOAT twinkle_scale[2];
+    FLOAT ivel_scale;
+    FLOAT drag;
+    FLOAT initial_spin;
+    FLOAT initial_spin_variation;
+    FLOAT spin;
+    FLOAT spin_variation;
+    m2Box_t tumble;
+    VECTOR3 wind_vector;
+    FLOAT wind_time;
+    FLOAT follow_speed1;
+    FLOAT follow_scale1;
+    FLOAT follow_speed2;
+    FLOAT follow_scale2;
+    m2Array_t spline;
+} m2ParticleClassic_t;
+
 typedef struct {
     DWORD ribbon_id;
     WORD bone_index;
@@ -216,6 +271,29 @@ typedef struct {
     SHORT priority_plane;
     WORD pad1;
 } m2Ribbon_t;
+
+/* Classic (TBC, version <= 263) ribbon emitter — tracks are m2TrackClassic_t (24 bytes each). */
+typedef struct {
+    DWORD ribbon_id;
+    WORD bone_index;
+    WORD pad0;
+    VECTOR3 position;
+    m2Array_t texture_indices;
+    m2Array_t material_indices;
+    m2TrackClassic_t color_track;
+    m2TrackClassic_t alpha_track;
+    m2TrackClassic_t height_above_track;
+    m2TrackClassic_t height_below_track;
+    FLOAT edges_per_second;
+    FLOAT edge_lifetime;
+    FLOAT gravity;
+    WORD texture_rows;
+    WORD texture_cols;
+    m2TrackClassic_t texture_slot_track;
+    m2TrackClassic_t visibility_track;
+    SHORT priority_plane;
+    WORD pad1;
+} m2RibbonClassic_t;
 
 typedef struct {
     DWORD bone_id;
@@ -445,6 +523,23 @@ typedef struct {
     DWORD key;
 } m2CompositeCacheEntry_t;
 
+/* Ribbon edge state — persisted across frames so trails grow/shrink properly.
+   Each emitter produces a ring buffer of edges at the animated spine position.
+   Pattern derived from WoWee's M2Instance::RibbonEdge + updateRibbons. */
+#define MAX_RIBBON_EDGES 64
+typedef struct {
+    VECTOR3 world_pos;
+    VECTOR3 color;
+    float alpha, height_above, height_below, age;
+} m2RibbonEdge_t;
+
+typedef struct {
+    m2RibbonEdge_t edges[MAX_RIBBON_EDGES];
+    int head;       /* ring-buffer write index */
+    int count;      /* active edges, capped at MAX_RIBBON_EDGES */
+    float acc;      /* edge emission accumulator (rate * dt) */
+} m2RibbonEmitter_t;
+
 struct m2Model_s {
     m2ModelBatch_t *batches;
     DWORD num_batches;
@@ -488,7 +583,13 @@ struct m2Model_s {
     m2Array_t texture_lookup_table;
     m2Array_t ribbons;
     m2Array_t particles;
+    BOOL classic_particles;
+    DWORD particle_stride;
+    BOOL classic_ribbons;
+    DWORD ribbon_stride;
     MATRIX4 *bone_matrices;
+    FLOAT *emitter_accumulators;    /* per-particle-emitter accumulator (rate*dt), avoids time-anchoring */
+    m2RibbonEmitter_t *ribbon_emitters; /* per-ribbon-emitter persistent edge state */
 };
 
 typedef struct {
@@ -1752,9 +1853,15 @@ static BOOL M2_FindTrackKeys(m2Model_t const *model,
         m2Range_t const *ranges = M2_ModelArrayPtr(model, track->ranges, sizeof(*ranges));
         m2Range_t range;
 
+        /* TBC-era classic particles store tracks without per-animation ranges (ranges.size==0).
+           Fall back to reading times and keys as flat global arrays in that case. */
         if (!ranges || track->ranges.size == 0) {
-            return false;
-        }
+            times = M2_ModelArrayPtr(model, track->sequence_times, sizeof(DWORD));
+            keys = M2_ModelArrayPtr(model, track->sequence_keys, elem_size);
+            if (!times || !keys) return false;
+            count = MIN((DWORD)track->sequence_times.size, (DWORD)track->sequence_keys.size);
+            if (count == 0) return false;
+        } else {
         if (sequence_index >= (DWORD)track->ranges.size) {
             sequence_index = 0;
         }
@@ -1779,6 +1886,7 @@ static BOOL M2_FindTrackKeys(m2Model_t const *model,
         keys += range.start * elem_size;
         if (count == 0) {
             return false;
+        }
         }
     } else {
         m2SequenceTimes_t const *sequence_times = M2_ModelArrayPtr(model, track->sequence_times, sizeof(*sequence_times));
@@ -2212,90 +2320,235 @@ static void m2_spawn_particle(void *raw) {
 	fx->time = 0.0f; fx->lifespan = MAX(0.05f, ctx->life + (r - 0.5f) * ctx->life_var);
 }
 
+/* Thin shim so the draw loop below can address modern and classic particles uniformly. */
+typedef struct {
+    /* points into the model data at the actual particle struct */
+    DWORD particle_id, flags; VECTOR3 position; WORD bone_index, texture_index;
+    m2Array_t geometry_mdl, recursion_mdl;
+    BYTE blend_mode, emitter_type; WORD color_index, pad; SHORT priority_plane; WORD rows, cols;
+    /* NOTE: tracks immediately follow — accessed via p_track_view() below via the raw pointer */
+} m2ParticleHdr_t;
+
+/* Track indices for particles.
+   Classic (TBC): 10 tracks contiguous, no float gaps, no zsource_track.
+   Modern (WotLK+): 11 tracks with life_variation/emitrate_variation floats between groups.
+   These enum values serve as logical track names; m2p_track_indexed maps them to byte offsets. */
+#define M2P_SPEED       0
+#define M2P_VARIATION   1
+#define M2P_LATITUDE    2
+#define M2P_LONGITUDE   3
+#define M2P_GRAVITY     4
+#define M2P_LIFE        5
+#define M2P_EMITRATE    6
+#define M2P_WIDTH       7
+#define M2P_LENGTH      8
+#define M2P_ZSOURCE     9   /* modern only — does not exist in classic */
+#define M2P_VISIBILITY 10   /* classic: 9 (zsource absent), modern: 10 */
+
+/* Return a track view for the k-th logical track index, accounting for version differences. */
+static m2TrackView_t m2p_track_indexed(m2Model_t const *model, BYTE const *raw, DWORD k) {
+    if (model->classic_particles) {
+        DWORD ts = (DWORD)sizeof(m2TrackClassic_t);
+        /* Classic: 10 contiguous tracks (speed=0..visibility=9), no zsource, no float gaps. */
+        DWORD phys_k = (k == M2P_VISIBILITY) ? 9 : (k > M2P_VISIBILITY ? k : k);
+        if (k == M2P_ZSOURCE) return M2_ClassicTrackView(NULL); /* not in classic */
+        return M2_ClassicTrackView((m2TrackClassic_t const *)(raw + 52 + phys_k * ts));
+    } else {
+        DWORD ts = (DWORD)sizeof(m2Track_t);
+        /* Modern: speed(0..5) + life_variation(4) + emitrate(6) + emitrate_variation(4) + width(7..9) + visibility(10) */
+        DWORD off;
+        if (k <= 5) off = 52 + k * ts;
+        else if (k == M2P_EMITRATE) off = 52 + 5 * ts + 4 + ts;              /* +life_variation(4) */
+        else if (k <= M2P_ZSOURCE)  off = 52 + 5 * ts + 4 + ts + 4 + (k - 6) * ts; /* +rate_variation(4) */
+        else                        off = 52 + 5 * ts + 4 + ts + 4 + 3 * ts; /* visibility = 10th track position */
+        return M2_ModernTrackView((m2Track_t const *)(raw + off));
+    }
+}
+
+/* Byte offset of the life_variation float (only exists in modern format, between life and emitrate tracks). */
+static FLOAT m2p_life_variation(m2Model_t const *model, BYTE const *raw) {
+    if (model->classic_particles) return 0.0f; /* no life_variation in TBC classic */
+    DWORD ts = (DWORD)sizeof(m2Track_t);
+    return *(FLOAT const *)(raw + 52 + 6 * ts); /* between life_track and emission_rate_track */
+}
+
+/* PartTrack base offset — follows the track block (different count and float gaps by version). */
+static DWORD m2p_part_track_base(m2Model_t const *model) {
+    if (model->classic_particles) {
+        /* Classic: fixed(52) + 10*28 = 332. No float gaps. */
+        return 52 + 10 * (DWORD)sizeof(m2TrackClassic_t);
+    }
+    /* Modern: fixed(52) + 6*20 + 4 + 20 + 4 + 3*20 = 260. Then PartTracks. */
+    DWORD ts = (DWORD)sizeof(m2Track_t);
+    return 52 + 5 * ts + 4 + ts + 4 + 3 * ts;
+}
+
+static m2PartTrack_t const *m2p_part_track(m2Model_t const *model, BYTE const *raw, DWORD n) {
+    return (m2PartTrack_t const *)(raw + m2p_part_track_base(model) + n * sizeof(m2PartTrack_t));
+}
+
 static void M2_DrawParticles(m2Model_t const *model, renderEntity_t const *entity, LPCMATRIX4 model_matrix) {
 	if (!model || !entity || !model->particles.size) return;
-	m2Particle_t const *ps = M2_ModelArrayPtr(model, model->particles, sizeof(m2Particle_t));
-	if (!ps) return;
+	BYTE const *base = M2_ModelArrayPtr(model, model->particles, model->particle_stride);
+	if (!base) return;
 	DWORD seq_idx, seq_time = M2_AnimationTime(model, entity, &seq_idx);
 	FOR_LOOP(i, (DWORD)model->particles.size) {
-		m2Particle_t const *p = &ps[i];
-		m2TrackView_t vis = M2_ModernTrackView(&p->visibility_track);
+		BYTE const *raw = base + i * model->particle_stride;
+		m2Particle_t const *p = (m2Particle_t const *)raw;
+		m2TrackView_t vis = m2p_track_indexed(model, raw, M2P_VISIBILITY);
 		if (!m2_is_visible(model, &vis, seq_idx, seq_time)) continue;
-		m2TrackView_t rate_t = M2_ModernTrackView(&p->emission_rate_track);
+		m2TrackView_t rate_t = m2p_track_indexed(model, raw, M2P_EMITRATE);
 		FLOAT rate = M2_EvaluateFloatTrack(model, &rate_t, seq_idx, seq_time, 0.0f);
 		if (rate <= 0.0f) continue;
+		m2TrackView_t life_t = m2p_track_indexed(model, raw, M2P_LIFE);
+		FLOAT life = MAX(0.05f, M2_EvaluateFloatTrack(model, &life_t, seq_idx, seq_time, 0.5f));
+		/* WoWee §M2Renderer::emitParticles: a flame reads as a flame only when enough
+		   particles are alive at once.  Authored rates vary wildly (candle 40/s over 0.5s,
+		   chandelier 1/s over 6s).  Steady-state population is rate × lifespan, so floor
+		   the rate against lifespan to hold every fixture at a comparable density. */
+		if (rate > 0.0f && life > 0.0f) {
+			const float kMinLiveParticles = 15.0f;
+			rate = MAX(rate, kMinLiveParticles / MAX(life, 0.1f));
+		}
 		m2_pctx_t ctx = { .model = model, .p = p, .model_matrix = model_matrix };
-		{ m2TrackView_t t = M2_ModernTrackView(&p->speed_track); ctx.speed = M2_EvaluateFloatTrack(model, &t, seq_idx, seq_time, 0.0f); }
-		{ m2TrackView_t t = M2_ModernTrackView(&p->variation_track); ctx.varia = M2_EvaluateFloatTrack(model, &t, seq_idx, seq_time, 0.0f); }
-		{ m2TrackView_t t = M2_ModernTrackView(&p->latitude_track); ctx.lat = M2_EvaluateFloatTrack(model, &t, seq_idx, seq_time, 0.0f); }
-		{ m2TrackView_t t = M2_ModernTrackView(&p->longitude_track); ctx.lon = M2_EvaluateFloatTrack(model, &t, seq_idx, seq_time, 0.0f); }
-		{ m2TrackView_t t = M2_ModernTrackView(&p->gravity_track); ctx.grav = M2_EvaluateFloatTrack(model, &t, seq_idx, seq_time, 0.0f); }
-		{ m2TrackView_t t = M2_ModernTrackView(&p->life_track); ctx.life = MAX(0.05f, M2_EvaluateFloatTrack(model, &t, seq_idx, seq_time, 0.5f)); }
-		ctx.life_var = p->life_variation;
-		{ m2TrackView_t t = M2_ModernTrackView(&p->zsource_track); ctx.zsource = M2_EvaluateFloatTrack(model, &t, seq_idx, seq_time, 0.0f); }
-		{ SHORT raw; m2_sample_part_track(model, &p->alpha_track, 0.0f, sizeof(raw), &raw); ctx.alpha[0] = m2_fixed16_to_float(raw);
-		           m2_sample_part_track(model, &p->alpha_track, 0.5f, sizeof(raw), &raw); ctx.alpha[1] = m2_fixed16_to_float(raw);
-		           m2_sample_part_track(model, &p->alpha_track, 1.0f, sizeof(raw), &raw); ctx.alpha[2] = m2_fixed16_to_float(raw); }
-		m2_sample_part_track(model, &p->scale_track, 0.0f, sizeof(VECTOR2), &ctx.scale[0]);
-		m2_sample_part_track(model, &p->scale_track, 0.5f, sizeof(VECTOR2), &ctx.scale[1]);
-		m2_sample_part_track(model, &p->scale_track, 1.0f, sizeof(VECTOR2), &ctx.scale[2]);
-		m2_sample_part_track(model, &p->color_track, 0.0f, sizeof(VECTOR3), &ctx.color[0]);
-		m2_sample_part_track(model, &p->color_track, 0.5f, sizeof(VECTOR3), &ctx.color[1]);
-		m2_sample_part_track(model, &p->color_track, 1.0f, sizeof(VECTOR3), &ctx.color[2]);
+		{ m2TrackView_t t = m2p_track_indexed(model, raw, M2P_SPEED);     ctx.speed = M2_EvaluateFloatTrack(model, &t, seq_idx, seq_time, 0.0f); }
+		{ m2TrackView_t t = m2p_track_indexed(model, raw, M2P_VARIATION); ctx.varia = M2_EvaluateFloatTrack(model, &t, seq_idx, seq_time, 0.0f); }
+		{ m2TrackView_t t = m2p_track_indexed(model, raw, M2P_LATITUDE);  ctx.lat   = M2_EvaluateFloatTrack(model, &t, seq_idx, seq_time, 0.0f); }
+		{ m2TrackView_t t = m2p_track_indexed(model, raw, M2P_LONGITUDE); ctx.lon   = M2_EvaluateFloatTrack(model, &t, seq_idx, seq_time, 0.0f); }
+		{ m2TrackView_t t = m2p_track_indexed(model, raw, M2P_GRAVITY);   ctx.grav  = M2_EvaluateFloatTrack(model, &t, seq_idx, seq_time, 0.0f); }
+		ctx.life     = life;
+		ctx.life_var = m2p_life_variation(model, raw);
+		{ m2TrackView_t t = m2p_track_indexed(model, raw, M2P_ZSOURCE);   ctx.zsource = M2_EvaluateFloatTrack(model, &t, seq_idx, seq_time, 0.0f); }
+		m2PartTrack_t const *alpha_pt  = m2p_part_track(model, raw, 1);
+		m2PartTrack_t const *scale_pt  = m2p_part_track(model, raw, 2);
+		m2PartTrack_t const *color_pt  = m2p_part_track(model, raw, 0);
+		{ SHORT raw2; m2_sample_part_track(model, alpha_pt, 0.0f, sizeof(raw2), &raw2); ctx.alpha[0] = m2_fixed16_to_float(raw2);
+		             m2_sample_part_track(model, alpha_pt, 0.5f, sizeof(raw2), &raw2); ctx.alpha[1] = m2_fixed16_to_float(raw2);
+		             m2_sample_part_track(model, alpha_pt, 1.0f, sizeof(raw2), &raw2); ctx.alpha[2] = m2_fixed16_to_float(raw2); }
+		m2_sample_part_track(model, scale_pt, 0.0f, sizeof(VECTOR2), &ctx.scale[0]);
+		m2_sample_part_track(model, scale_pt, 0.5f, sizeof(VECTOR2), &ctx.scale[1]);
+		m2_sample_part_track(model, scale_pt, 1.0f, sizeof(VECTOR2), &ctx.scale[2]);
+		m2_sample_part_track(model, color_pt, 0.0f, sizeof(VECTOR3), &ctx.color[0]);
+		m2_sample_part_track(model, color_pt, 0.5f, sizeof(VECTOR3), &ctx.color[1]);
+		m2_sample_part_track(model, color_pt, 1.0f, sizeof(VECTOR3), &ctx.color[2]);
 		ctx.texture = m2_particle_texture(model, p);
-		R_EmitParticles(rate, tr.viewDef.time, tr.viewDef.deltaTime, m2_spawn_particle, &ctx);
+		R_EmitParticles(rate, &model->emitter_accumulators[i], tr.viewDef.deltaTime, m2_spawn_particle, &ctx);
 	}
 }
 
+/* Ribbon fixed header (same in both classic/modern): ribbon_id(4)+bone(2)+pad(2)+pos(12)+tex_idx_arr(8)+mat_idx_arr(8) = 36 */
+#define M2R_HDR_SIZE 36u
+/* Track indices for ribbon: color=0, alpha=1, height_above=2, height_below=3, tex_slot=4, visibility=5 */
+/* The ribbon has 4 scalar float fields + 2 WORD fields (12 bytes) between height_below_track and texture_slot_track. */
+static m2TrackView_t m2r_track(m2Model_t const *model, BYTE const *raw, DWORD k) {
+    DWORD ts = model->classic_ribbons ? (DWORD)sizeof(m2TrackClassic_t) : (DWORD)sizeof(m2Track_t);
+    DWORD off;
+    if (k <= 3) off = M2R_HDR_SIZE + k * ts;
+    else        off = M2R_HDR_SIZE + 4 * ts + 16 /* floats gap */ + (k - 4) * ts;
+    if (model->classic_ribbons) return M2_ClassicTrackView((m2TrackClassic_t const *)(raw + off));
+    return M2_ModernTrackView((m2Track_t const *)(raw + off));
+}
+/* Float scalars embedded in the ribbon struct after the first 4 tracks. */
+static FLOAT const *m2r_scalar(m2Model_t const *model, BYTE const *raw, DWORD field_idx) {
+    DWORD ts = model->classic_ribbons ? (DWORD)sizeof(m2TrackClassic_t) : (DWORD)sizeof(m2Track_t);
+    return (FLOAT const *)(raw + M2R_HDR_SIZE + 4 * ts + field_idx * 4);
+}
+static WORD m2r_word(m2Model_t const *model, BYTE const *raw, DWORD field_idx) {
+    DWORD ts = model->classic_ribbons ? (DWORD)sizeof(m2TrackClassic_t) : (DWORD)sizeof(m2Track_t);
+    return *(WORD const *)(raw + M2R_HDR_SIZE + 4 * ts + 12 + field_idx * 2);
+}
+
 static void M2_DrawRibbons(m2Model_t const *model, renderEntity_t const *entity, LPCMATRIX4 model_matrix) {
-	if (!model || !entity || !model->ribbons.size) return;
-	m2Ribbon_t const *rs = M2_ModelArrayPtr(model, model->ribbons, sizeof(m2Ribbon_t));
-	if (!rs) return;
+	if (!model || !entity || !model->ribbons.size || !model->ribbon_emitters) return;
+	BYTE const *base = M2_ModelArrayPtr(model, model->ribbons, model->ribbon_stride);
+	if (!base) return;
 	DWORD seq_idx, seq_time = M2_AnimationTime(model, entity, &seq_idx);
+	FLOAT dt = (FLOAT)tr.viewDef.deltaTime / 1000.0f;
 	FOR_LOOP(i, (DWORD)model->ribbons.size) {
-		m2Ribbon_t const *r = &rs[i];
-		m2TrackView_t vis = M2_ModernTrackView(&r->visibility_track);
+		BYTE const *raw = base + i * model->ribbon_stride;
+		m2Ribbon_t const *r = (m2Ribbon_t const *)raw;
+		m2RibbonEmitter_t *res = &model->ribbon_emitters[i];
+		m2TrackView_t vis = m2r_track(model, raw, 5);
 		if (!m2_is_visible(model, &vis, seq_idx, seq_time)) continue;
-		FLOAT rate = MAX(0.0f, r->edges_per_second);
-		if (rate <= 0.0f) continue;
-		m2TrackView_t color_t = M2_ModernTrackView(&r->color_track);
-		VECTOR3 color = M2_EvaluateVectorTrack(model, &color_t, seq_idx, seq_time, (VECTOR3){ 1, 1, 1 });
-		m2TrackView_t alpha_t = M2_ModernTrackView(&r->alpha_track);
+		FLOAT eps = MAX(0.0f, *m2r_scalar(model, raw, 0)); /* edges_per_second */
+		if (eps <= 0.0f) continue;
+		/* -- Age existing edges and drop expired ones -------------------- */
+		FLOAT edge_life = *m2r_scalar(model, raw, 1);
+		int write = res->head, alive = res->count;
+		for (int e = 0; e < alive; e++) {
+			int idx = (write - alive + e + MAX_RIBBON_EDGES) % MAX_RIBBON_EDGES;
+			res->edges[idx].age += dt;
+		}
+		while (alive > 0) {
+			int oldest = (write - alive + MAX_RIBBON_EDGES) % MAX_RIBBON_EDGES;
+			if (res->edges[oldest].age < edge_life) break;
+			alive--;
+		}
+		res->count = alive;
+		/* -- Evaluate animated tracks ------------------------------------ */
+		m2TrackView_t color_t = m2r_track(model, raw, 0);
+		VECTOR3 col = M2_EvaluateVectorTrack(model, &color_t, seq_idx, seq_time, (VECTOR3){ 1, 1, 1 });
+		m2TrackView_t alpha_t = m2r_track(model, raw, 1);
 		void const *la, *ra; float rta;
 		DWORD tt = M2_TrackTime(model, &alpha_t, seq_idx, seq_time);
-		FLOAT alpha = 1.0f;
+		FLOAT a = 1.0f;
 		if (M2_FindTrackKeys(model, &alpha_t, seq_idx, tt, sizeof(SHORT), &la, &ra, &rta)) {
 			FLOAT al = m2_fixed16_to_float(*(SHORT const *)la);
 			FLOAT ar = la == ra ? al : m2_fixed16_to_float(*(SHORT const *)ra);
-			alpha = LerpNumber(al, ar, rta);
+			a = LerpNumber(al, ar, rta);
 		}
-		m2TrackView_t above_t = M2_ModernTrackView(&r->height_above_track);
-		m2TrackView_t below_t = M2_ModernTrackView(&r->height_below_track);
-		FLOAT above = MAX(0.0f, M2_EvaluateFloatTrack(model, &above_t, seq_idx, seq_time, 0.0f));
-		FLOAT below = MAX(0.0f, M2_EvaluateFloatTrack(model, &below_t, seq_idx, seq_time, 0.0f));
-		FLOAT width = MAX(1.0f, above + below);
-		m2TrackView_t slot_t = M2_ModernTrackView(&r->texture_slot_track);
+		m2TrackView_t above_t = m2r_track(model, raw, 2);
+		m2TrackView_t below_t = m2r_track(model, raw, 3);
+		FLOAT h_above = MAX(0.0f, M2_EvaluateFloatTrack(model, &above_t, seq_idx, seq_time, 0.0f));
+		FLOAT h_below = MAX(0.0f, M2_EvaluateFloatTrack(model, &below_t, seq_idx, seq_time, 0.0f));
+		FLOAT w = MAX(1.0f, h_above + h_below) / 2.0f; /* half-width for billboard scale */
+		m2TrackView_t slot_t = m2r_track(model, raw, 4);
 		WORD slot = 0;
-		void const *ls, *rs; float rts;
+		void const *ls, *rs_; float rts;
 		DWORD tts = M2_TrackTime(model, &slot_t, seq_idx, seq_time);
-		if (M2_FindTrackKeys(model, &slot_t, seq_idx, tts, sizeof(WORD), &ls, &rs, &rts))
-			slot = (WORD)LerpNumber((FLOAT)*(WORD const *)ls, (FLOAT)*(WORD const *)rs, rts);
-		COLOR32 col = M2_C32(color, alpha);
-		BYTE size_b = (BYTE)MIN(255, (int)(width + 0.5f));
-		DWORD cols = MAX(1, r->texture_cols), rows = MAX(1, r->texture_rows);
+		if (M2_FindTrackKeys(model, &slot_t, seq_idx, tts, sizeof(WORD), &ls, &rs_, &rts))
+			slot = (WORD)LerpNumber((FLOAT)*(WORD const *)ls, (FLOAT)*(WORD const *)rs_, rts);
+		COLOR32 rgba = M2_C32(col, a);
+		BYTE size_b = (BYTE)MIN(255, (int)(w + 0.5f));
+		DWORD cols = MAX(1, m2r_word(model, raw, 1)), rows = MAX(1, m2r_word(model, raw, 0));
 		LPTEXTURE tex = m2_ribbon_texture(model, r, slot);
-		DWORD start_ms = (tr.viewDef.time - tr.viewDef.deltaTime) / 1000 * 1000;
-		for (float t = (float)start_ms; t < (float)tr.viewDef.time; t += 1000.0f / rate)
-			if (t >= (float)(tr.viewDef.time - tr.viewDef.deltaTime)) {
-				cparticle_t *fx = R_SpawnParticle(); if (!fx) continue;
-				VECTOR3 org = Matrix4_multiply_vector3(model_matrix, &r->position);
-				fx->texture = tex; fx->org = org; fx->vel = (VECTOR3){ 0 };
-				fx->accel = (VECTOR3){ 0, 0, -MAX(0.0f, r->gravity) };
-				fx->color[0] = fx->color[1] = fx->color[2] = col;
-				fx->size[0] = fx->size[1] = fx->size[2] = size_b;
-				fx->midtime = 0x80; fx->columns = cols; fx->rows = rows;
-				fx->time = 0.0f; fx->lifespan = MAX(0.05f, r->edge_lifetime);
+		FLOAT grav = *m2r_scalar(model, raw, 2);
+		/* -- Emit new edges at the animated spine position ---------------- */
+		VECTOR3 spine = Matrix4_multiply_vector3(model_matrix, &r->position);
+		res->acc += eps * dt;
+		while (res->acc >= 1.0f) {
+			res->acc -= 1.0f;
+			if (alive >= MAX_RIBBON_EDGES) { /* drop oldest */
+				alive--;
 			}
+			m2RibbonEdge_t *e = &res->edges[write];
+			e->world_pos = spine;
+			e->color = col; e->alpha = a;
+			e->height_above = h_above; e->height_below = h_below;
+			e->age = 0.0f;
+			write = (write + 1) % MAX_RIBBON_EDGES;
+			alive++;
+		}
+		if (res->acc > 2.0f) res->acc = 0.0f;
+		res->head = write; res->count = alive;
+		/* -- Spawn one billboard particle per active edge ----------------- */
+		for (int e = 0; e < alive; e++) {
+			int idx = (write - alive + e + MAX_RIBBON_EDGES) % MAX_RIBBON_EDGES;
+			m2RibbonEdge_t *re = &res->edges[idx];
+			cparticle_t *fx = R_SpawnParticle(); if (!fx) break;
+			/* Apply gravity downward drift (semi-implicit: ½ g t² at draw time) */
+			re->world_pos.z -= MAX(0.0f, grav) * dt * dt * 0.5f;
+			fx->texture = tex; fx->org = re->world_pos;
+			fx->vel = (VECTOR3){ 0, 0, 0 };
+			fx->accel = (VECTOR3){ 0, 0, -MAX(0.0f, grav) };
+			FLOAT fade = 1.0f - MIN(1.0f, re->age / MAX(0.01f, edge_life));
+			COLOR32 fc = rgba;
+			fc.a = (BYTE)((FLOAT)fc.a * fade + 0.5f);
+			fx->color[0] = fx->color[1] = fx->color[2] = fc;
+			fx->size[0] = fx->size[1] = fx->size[2] = size_b;
+			fx->midtime = 0x80; fx->columns = cols; fx->rows = rows;
+			fx->time = 0.0f; fx->lifespan = MAX(0.05f, edge_life - re->age);
+		}
 	}
 }
 
@@ -2769,6 +3022,14 @@ static void M2_FreeModelData(m2Model_t *model) {
 		ri.MemFree(model->bone_matrices);
 		model->bone_matrices = NULL;
 	}
+	if (model->emitter_accumulators) {
+		ri.MemFree(model->emitter_accumulators);
+		model->emitter_accumulators = NULL;
+	}
+	if (model->ribbon_emitters) {
+		ri.MemFree(model->ribbon_emitters);
+		model->ribbon_emitters = NULL;
+	}
 	if (model->material_blend_modes) {
 		ri.MemFree(model->material_blend_modes);
 		model->material_blend_modes = NULL;
@@ -2804,6 +3065,10 @@ static BOOL M2_CopyModelData(m2Model_t *model, BYTE const *m2_base, DWORD m2_siz
     model->attachment_stride = model->classic_attachments ? sizeof(m2AttachmentClassic_t) : sizeof(m2AttachmentModern_t);
     model->classic_cameras = model->header->version <= 263;
     model->camera_stride = model->classic_cameras ? sizeof(m2CameraClassic_t) : sizeof(m2CameraModern_t);
+    model->classic_particles = model->header->version <= 263;
+    model->particle_stride = model->classic_particles ? sizeof(m2ParticleClassic_t) : sizeof(m2Particle_t);
+    model->classic_ribbons = model->header->version <= 263;
+    model->ribbon_stride = model->classic_ribbons ? sizeof(m2RibbonClassic_t) : sizeof(m2Ribbon_t);
 
     if (legacy_header) {
         m2HeaderLegacy_t *legacy = (m2HeaderLegacy_t *)model->data;
@@ -2850,6 +3115,17 @@ static BOOL M2_CopyModelData(m2Model_t *model, BYTE const *m2_base, DWORD m2_siz
         FOR_LOOP(i, model->bone_count) {
             Matrix4_identity(&model->bone_matrices[i]);
         }
+    }
+
+    if (model->particles.size) {
+        model->emitter_accumulators = ri.MemAlloc(sizeof(*model->emitter_accumulators) * (DWORD)model->particles.size);
+        if (!model->emitter_accumulators) { M2_FreeModelData(model); return false; }
+        memset(model->emitter_accumulators, 0, sizeof(*model->emitter_accumulators) * (DWORD)model->particles.size);
+    }
+    if (model->ribbons.size) {
+        model->ribbon_emitters = ri.MemAlloc(sizeof(*model->ribbon_emitters) * (DWORD)model->ribbons.size);
+        if (!model->ribbon_emitters) { M2_FreeModelData(model); return false; }
+        memset(model->ribbon_emitters, 0, sizeof(*model->ribbon_emitters) * (DWORD)model->ribbons.size);
     }
 
     return true;

--- a/games/world-of-warcraft/tests/test_wow_abilities.c
+++ b/games/world-of-warcraft/tests/test_wow_abilities.c
@@ -321,6 +321,7 @@ static void test_firebolt_z_height_interpolates_correctly(void) {
     ASSERT_NOT_NULL(target);
     caster->s.origin.z = 0.0f;
     target->s.origin.z = 0.0f;
+    target->s.radius = 2.0f;
 
     Wow_FireFirebolt(caster, target);
     proj = &wow_edicts[2];
@@ -328,12 +329,13 @@ static void test_firebolt_z_height_interpolates_correctly(void) {
     ASSERT(proj->inuse);
     ASSERT_NOT_NULL(pl);
 
-    /* Without renderer bone matrices, the server uses the caster's gameplay radius. */
+    /* Without renderer bone matrices, the server uses the caster's gameplay radius for launch. */
     ASSERT_EQ_FLOAT(proj->s.origin.z, 1.0f, 0.001f);
 
-    /* After one frame, Z should still be ~1.6 (not jumping to terrain+3.0) */
+    /* Flight should rise toward the target chest, not drop toward the ground. */
     Wow_RunProjectile(proj);
     ASSERT(proj->inuse);
+    ASSERT(proj->s.origin.z > 1.0f);
     ASSERT(proj->s.origin.z < 2.0f); /* must not spike to 3+ */
     ASSERT(proj->s.origin.z >= 1.0f); /* must stay above ground */
 
@@ -341,7 +343,7 @@ static void test_firebolt_z_height_interpolates_correctly(void) {
     while (proj->inuse) {
         Wow_RunProjectile(proj);
         if (proj->inuse) {
-            ASSERT(proj->s.origin.z < 2.5f);
+            ASSERT(proj->s.origin.z < 4.5f);
             ASSERT(proj->s.origin.z > 0.5f);
         }
     }

--- a/games/world-of-warcraft/tests/test_wow_game.c
+++ b/games/world-of-warcraft/tests/test_wow_game.c
@@ -679,8 +679,6 @@ static void test_wow_directional_movement_animations(void) {
     struct game_export *game = init_game();
     LPEDICT player = &wow_edicts[0];
     wowEntityLocal_t *local = Wow_EntityLocal(player);
-    LPCANIMATION left_animation;
-    LPCANIMATION right_animation;
     LPCANIMATION back_animation;
     LPCSTR left[] = { "move", "4", "0", "328", "8.5" };
     LPCSTR right[] = { "move", "8", "0", "328", "8.5" };
@@ -688,17 +686,15 @@ static void test_wow_directional_movement_animations(void) {
     FLOAT facing;
 
     ASSERT(game->LoadMap("World/Maps/Azeroth/Azeroth.wdt"));
-    left_animation = G_GetAnimation(player->s.model, "ShuffleLeft");
-    right_animation = G_GetAnimation(player->s.model, "ShuffleRight");
     back_animation = G_GetAnimation(player->s.model, "WalkBackwards");
     facing = player->s.angle;
     game->ClientCommand(player, 5, left);
     game->RunFrame();
-    ASSERT_STR_EQ(local->animation->name, left_animation ? "ShuffleLeft" : "Run");
+    ASSERT_STR_EQ(local->animation->name, "Run");
     ASSERT_EQ_FLOAT(player->s.angle, facing, 0.001f);
     game->ClientCommand(player, 5, right);
     game->RunFrame();
-    ASSERT_STR_EQ(local->animation->name, right_animation ? "ShuffleRight" : "Run");
+    ASSERT_STR_EQ(local->animation->name, "Run");
     ASSERT_EQ_FLOAT(player->s.angle, facing, 0.001f);
     game->ClientCommand(player, 5, back);
     game->RunFrame();

--- a/games/world-of-warcraft/tests/test_wow_game.c
+++ b/games/world-of-warcraft/tests/test_wow_game.c
@@ -674,10 +674,44 @@ static void test_wow_fireball_movement_cancels(void) {
     if (game->Shutdown) game->Shutdown();
 }
 
+/* Strafe and backpedal preserve facing but select directional locomotion animations. */
+static void test_wow_directional_movement_animations(void) {
+    struct game_export *game = init_game();
+    LPEDICT player = &wow_edicts[0];
+    wowEntityLocal_t *local = Wow_EntityLocal(player);
+    LPCANIMATION left_animation;
+    LPCANIMATION right_animation;
+    LPCANIMATION back_animation;
+    LPCSTR left[] = { "move", "4", "0", "328", "8.5" };
+    LPCSTR right[] = { "move", "8", "0", "328", "8.5" };
+    LPCSTR back[] = { "move", "2", "0", "328", "8.5" };
+    FLOAT facing;
+
+    ASSERT(game->LoadMap("World/Maps/Azeroth/Azeroth.wdt"));
+    left_animation = G_GetAnimation(player->s.model, "ShuffleLeft");
+    right_animation = G_GetAnimation(player->s.model, "ShuffleRight");
+    back_animation = G_GetAnimation(player->s.model, "WalkBackwards");
+    facing = player->s.angle;
+    game->ClientCommand(player, 5, left);
+    game->RunFrame();
+    ASSERT_STR_EQ(local->animation->name, left_animation ? "ShuffleLeft" : "Run");
+    ASSERT_EQ_FLOAT(player->s.angle, facing, 0.001f);
+    game->ClientCommand(player, 5, right);
+    game->RunFrame();
+    ASSERT_STR_EQ(local->animation->name, right_animation ? "ShuffleRight" : "Run");
+    ASSERT_EQ_FLOAT(player->s.angle, facing, 0.001f);
+    game->ClientCommand(player, 5, back);
+    game->RunFrame();
+    ASSERT_STR_EQ(local->animation->name, back_animation ? "WalkBackwards" : "Run");
+    ASSERT_EQ_FLOAT(player->s.angle, facing, 0.001f);
+    if (game->Shutdown) game->Shutdown();
+}
+
 int main(void) {
     RUN_TEST(test_wow_load_map_initializes_player_state);
     RUN_TEST(test_wow_load_map_spawns_and_runs_creature_state);
     RUN_TEST(test_wow_fireball_cast_interrupts_melee_and_launches);
     RUN_TEST(test_wow_fireball_movement_cancels);
+    RUN_TEST(test_wow_directional_movement_animations);
     TEST_RESULTS();
 }

--- a/renderer/r_emit.h
+++ b/renderer/r_emit.h
@@ -19,17 +19,20 @@ static VECTOR3 FX_GenerateRandomOrigin(float length, float width) {
 	};
 }
 
+/* Frame-relative accumulator emission.  Each caller supplies a per-emitter float accumulator
+   that survives across frames; rate * dt is added to it and particles are spawned whenever the
+   accumulator crosses 1.0.  Caps at 2.0 to suppress bursts after lag spikes.
+   Pattern derived from WoWee's M2Renderer::emitParticles. */
 __attribute__((unused))
-static void R_EmitParticles(float rate, DWORD now_ms, DWORD delta_ms,
+static void R_EmitParticles(float rate, float *accum, DWORD delta_ms,
                             void (*spawn)(void *), void *ctx) {
-	if (rate <= 0.0f || delta_ms == 0) return;
-	float interval_ms = 1000.0f / rate;
-	DWORD last_ms = now_ms - delta_ms;
-	DWORD start_ms = last_ms - last_ms % 1000;
-	for (float t = (float)start_ms; t < (float)now_ms; t += interval_ms) {
-		if (t >= (float)last_ms)
-			spawn(ctx);
+	if (rate <= 0.0f || delta_ms == 0 || !accum) return;
+	*accum += rate * (float)delta_ms / 1000.0f;
+	while (*accum >= 1.0f) {
+		*accum -= 1.0f;
+		spawn(ctx);
 	}
+	if (*accum > 2.0f) *accum = 0.0f;
 }
 
 #endif

--- a/renderer/r_emit.h
+++ b/renderer/r_emit.h
@@ -11,6 +11,7 @@ static VECTOR3 FX_GenerateRandomDirection(float latitude) {
 	return (VECTOR3){ sinf(phi) * cosf(theta), sinf(phi) * sinf(theta), cosf(phi) };
 }
 
+__attribute__((unused))
 static VECTOR3 FX_GenerateRandomOrigin(float length, float width) {
 	return (VECTOR3){
 		(float)(((double)rand() / (double)RAND_MAX - 0.5) * length),

--- a/renderer/r_particles.c
+++ b/renderer/r_particles.c
@@ -40,6 +40,7 @@ cparticle_t *R_SpawnParticle(void) {
     free_particles = p->next;
     p->next = active_particles;
     active_particles = p;
+    p->blend_mode = BLEND_MODE_ADD;
     return p;
 }
 
@@ -71,11 +72,14 @@ LPCSTR fs_particle =
 "in vec2 v_texcoord;\n"
 "out vec4 o_color;\n"
 "uniform sampler2D uTexture;\n"
+"uniform bool uUseDiscard;\n"
+"uniform float uAlphaCutoff;\n"
 "float crop_edges(vec2 tc) {\n"
 "   return step(abs(tc.x - 0.5), 0.5) * step(abs(tc.y - 0.5), 0.5);\n"
 "}\n"
 "void main() {\n"
 "    o_color = texture(uTexture, v_texcoord) * v_color;\n"
+"    if (uUseDiscard && o_color.a < uAlphaCutoff) discard;\n"
 "}\n";
 
 particleVertex_t *
@@ -151,7 +155,7 @@ COLOR32 FX_BlendColor(cparticle_t const *p) {
     }
 }
 
-static void R_FlushParticles(LPCTEXTURE texture, LPCMATRIX4 matrix, particleVertex_t *pv) {
+static void R_FlushParticles(LPCTEXTURE texture, LPCMATRIX4 matrix, particleVertex_t *pv, BLEND_MODE blend_mode) {
     R_Call(glBindVertexArray, particles_resources.particles->vao);
     R_Call(glBindBuffer, GL_ARRAY_BUFFER, particles_resources.particles->vbo);
     R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(particleVertex_t) * (pv - particles_resources.vertices), particles_resources.vertices, GL_DYNAMIC_DRAW);
@@ -160,8 +164,27 @@ static void R_FlushParticles(LPCTEXTURE texture, LPCMATRIX4 matrix, particleVert
     R_Call(glUniformMatrix4fv, particles_resources.shader->uViewProjectionMatrix, 1, GL_FALSE, tr.viewDef.viewProjectionMatrix.v);
     R_Call(glActiveTexture, GL_TEXTURE0);
     R_Call(glBindTexture, GL_TEXTURE_2D, (texture?texture:particles_resources.texture)->texid);
-    R_Call(glDepthMask, GL_FALSE);
-    R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE);
+    R_Call(glUniform1i, particles_resources.shader->uUseDiscard, blend_mode == BLEND_MODE_ALPHAKEY);
+    R_Call(glUniform1f, particles_resources.shader->uAlphaCutoff, 0.5f);
+    if (blend_mode == BLEND_MODE_NONE || blend_mode == BLEND_MODE_ALPHAKEY) {
+        R_Call(glDisable, GL_BLEND);
+        R_Call(glDepthMask, GL_TRUE);
+        R_Call(glBlendFunc, GL_ONE, GL_ZERO);
+    } else {
+        R_Call(glEnable, GL_BLEND);
+        R_Call(glDepthMask, GL_FALSE);
+        switch (blend_mode) {
+        case BLEND_MODE_ADD:
+            R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE);
+            break;
+        case BLEND_MODE_ADDALPHA:
+            R_Call(glBlendFunc, GL_ONE, GL_ONE);
+            break;
+        default:
+            R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+            break;
+        }
+    }
     R_Call(glDrawArrays, GL_TRIANGLES, 0, (GLsizei)(pv - particles_resources.vertices));
 }
 
@@ -193,14 +216,15 @@ void R_DrawParticles(void) {
 
     MATRIX4 matrix;
     LPCTEXTURE texture = active_particles->texture;
+    BLEND_MODE blend_mode = active_particles->blend_mode;
     particleVertex_t *pv = particles_resources.vertices;
     
     Matrix4_identity(&matrix);
     R_UpdateParticles();
     
     FOR_EACH_LIST(cparticle_t const, p, active_particles) {
-        if (p->texture != texture) {
-            R_FlushParticles(texture, &matrix, pv);
+        if (p->texture != texture || p->blend_mode != blend_mode) {
+            R_FlushParticles(texture, &matrix, pv, blend_mode);
             pv = particles_resources.vertices;
         }
         /* Kinematics: org = org0 + vel0*t + 1/2*accel*t^2. The original engine
@@ -212,11 +236,12 @@ void R_DrawParticles(void) {
         VECTOR3 org = Vector3_mad(&p->org, p->time, &vel);
         COLOR32 col = FX_BlendColor(p);
         float size = FX_BlendFloat(p->size, p->time, BYTE2FLOAT(p->midtime));
-        pv = R_AddParticle(pv, &org, FX_GetFrame(p), col, size * 2.0);
+        pv = R_AddParticle(pv, &org, FX_GetFrame(p), col, size);
         texture = p->texture;
+        blend_mode = p->blend_mode;
     }
     
-    R_FlushParticles(texture, &matrix, pv);
+    R_FlushParticles(texture, &matrix, pv, blend_mode);
 }
 
 static LPBUFFER R_MakeParticlesVertexArrayObject(void) {

--- a/renderer/r_trail.h
+++ b/renderer/r_trail.h
@@ -1,0 +1,58 @@
+#ifndef r_trail_h
+#define r_trail_h
+
+/* Ring-buffer trail emitter — shared by WoW ribbons and WC3 MODEL_EMITTER_TAIL.
+   The caller manages a per-emitter trailEmitter_t, advances it each frame with
+   R_UpdateTrail, then spawns one cparticle_t per active edge for billboard
+   rendering through the engine particle pool. */
+
+#define MAX_TRAIL_EDGES 64
+
+typedef struct {
+    VECTOR3 world_pos;
+    VECTOR3 color;
+    float alpha, age;
+} trailEdge_t;
+
+typedef struct {
+    trailEdge_t edges[MAX_TRAIL_EDGES];
+    int head, count;
+    float acc;      /* edge emission accumulator (rate * dt) */
+} trailEmitter_t;
+
+/* Advance trail state for one frame.
+   - Ages all active edges by `dt`.
+   - Drops edges whose age exceeds `max_age`.
+   - Accumulates `edge_rate * dt`; spawns new edges at `spine_pos` when acc >= 1.0.
+   - Caps accumulator at 2.0 to suppress lag-spike bursts.
+   Returns the number of active edges after the update.  The caller then iterates
+   edges 0..(count-1) to spawn billboard particles. */
+static int R_UpdateTrail(trailEmitter_t *t, VECTOR3 spine_pos,
+                         VECTOR3 color, float alpha,
+                         float max_age, float edge_rate, float dt) {
+    if (!t || edge_rate <= 0.0f || max_age <= 0.0f) { t->count = 0; t->acc = 0.0f; return 0; }
+    int write = t->head, alive = t->count;
+    for (int e = 0; e < alive; e++) {
+        int idx = (write - alive + e + MAX_TRAIL_EDGES) % MAX_TRAIL_EDGES;
+        t->edges[idx].age += dt;
+    }
+    while (alive > 0) {
+        int oldest = (write - alive + MAX_TRAIL_EDGES) % MAX_TRAIL_EDGES;
+        if (t->edges[oldest].age < max_age) break;
+        alive--;
+    }
+    t->acc += edge_rate * dt;
+    while (t->acc >= 1.0f) {
+        t->acc -= 1.0f;
+        if (alive >= MAX_TRAIL_EDGES) alive--;
+        trailEdge_t *e = &t->edges[write];
+        e->world_pos = spine_pos; e->color = color; e->alpha = alpha; e->age = 0.0f;
+        write = (write + 1) % MAX_TRAIL_EDGES;
+        alive++;
+    }
+    if (t->acc > 2.0f) t->acc = 0.0f;
+    t->head = write; t->count = alive;
+    return alive;
+}
+
+#endif

--- a/tools/m2tool.c
+++ b/tools/m2tool.c
@@ -245,6 +245,77 @@ typedef struct {
     WORD texture_transform_combo_index;
 } m2Batch_t;
 
+typedef struct {
+    m2Array_t times;
+    m2Array_t values;
+} m2PartTrack_t;
+
+/* Modern (WotLK+) particle emitter binary layout — m2Track_t (20 bytes each). */
+typedef struct {
+    DWORD particle_id, flags; VECTOR3 position; WORD bone_index, texture_index;
+    m2Array_t geometry_mdl, recursion_mdl;
+    BYTE blend_mode, emitter_type; WORD color_index, pad; SHORT priority_plane; WORD rows, cols;
+    m2Track_t speed_track, variation_track, latitude_track, longitude_track, gravity_track, life_track;
+    FLOAT life_variation;
+    m2Track_t emission_rate_track;
+    FLOAT emission_rate_variation;
+    m2Track_t width_track, length_track, zsource_track;
+    m2PartTrack_t color_track, alpha_track, scale_track;
+    VECTOR2 scale_variation;
+    m2PartTrack_t head_cell_track, tail_cell_track;
+    FLOAT tail_length, twinkle_fps, twinkle_onoff, twinkle_scale[2];
+    FLOAT ivel_scale, drag, initial_spin, initial_spin_variation, spin, spin_variation;
+    VECTOR3 tumble_min, tumble_max;
+    VECTOR3 wind_vector; FLOAT wind_time;
+    FLOAT follow_speed1, follow_scale1, follow_speed2, follow_scale2;
+    m2Array_t spline;
+    m2Track_t visibility_track;
+} m2ParticleModern_t;
+
+/* Classic (TBC, version <= 263) particle emitter — m2TrackClassic_t (24 bytes each). */
+typedef struct {
+    DWORD particle_id, flags; VECTOR3 position; WORD bone_index, texture_index;
+    m2Array_t geometry_mdl, recursion_mdl;
+    BYTE blend_mode, emitter_type; WORD color_index, pad; SHORT priority_plane; WORD rows, cols;
+    m2TrackClassic_t speed_track, variation_track, latitude_track, longitude_track, gravity_track, life_track;
+    FLOAT life_variation;
+    m2TrackClassic_t emission_rate_track;
+    FLOAT emission_rate_variation;
+    m2TrackClassic_t width_track, length_track, zsource_track;
+    m2PartTrack_t color_track, alpha_track, scale_track;
+    VECTOR2 scale_variation;
+    m2PartTrack_t head_cell_track, tail_cell_track;
+    FLOAT tail_length, twinkle_fps, twinkle_onoff, twinkle_scale[2];
+    FLOAT ivel_scale, drag, initial_spin, initial_spin_variation, spin, spin_variation;
+    VECTOR3 tumble_min, tumble_max;
+    VECTOR3 wind_vector; FLOAT wind_time;
+    FLOAT follow_speed1, follow_scale1, follow_speed2, follow_scale2;
+    m2Array_t spline;
+    m2TrackClassic_t visibility_track;
+} m2ParticleClassic_t;
+
+/* Modern ribbon emitter — m2Track_t (20 bytes each). */
+typedef struct {
+    DWORD ribbon_id; WORD bone_index, pad0; VECTOR3 position;
+    m2Array_t texture_indices, material_indices;
+    m2Track_t color_track, alpha_track, height_above_track, height_below_track;
+    FLOAT edges_per_second, edge_lifetime, gravity;
+    WORD texture_rows, texture_cols;
+    m2Track_t texture_slot_track, visibility_track;
+    SHORT priority_plane; WORD pad1;
+} m2RibbonModern_t;
+
+/* Classic ribbon emitter — m2TrackClassic_t (24 bytes each). */
+typedef struct {
+    DWORD ribbon_id; WORD bone_index, pad0; VECTOR3 position;
+    m2Array_t texture_indices, material_indices;
+    m2TrackClassic_t color_track, alpha_track, height_above_track, height_below_track;
+    FLOAT edges_per_second, edge_lifetime, gravity;
+    WORD texture_rows, texture_cols;
+    m2TrackClassic_t texture_slot_track, visibility_track;
+    SHORT priority_plane; WORD pad1;
+} m2RibbonClassic_t;
+
 static HANDLE archives[64] = { 0 };
 static LPCSTR g_model_path = NULL;
 static LPCSTR g_skin_path = NULL;
@@ -1616,6 +1687,111 @@ static LPCSTR TextureTypeName(DWORD type) {
     }
 }
 
+static void PrintTrackInfo(LPCSTR label, BOOL classic, WORD type, DWORD keys_off, DWORD keys_n) {
+    static LPCSTR const track_names[] = { "none", "linear", "hermite", "bezier" };
+    LPCSTR tname = type < 4 ? track_names[type] : "?";
+    printf("    %-22s type=%s(%u) keys_off=%u keys_n=%u\n", label, tname, (unsigned)type,
+           (unsigned)keys_off, (unsigned)keys_n);
+}
+
+static void PrintParticleEmitters(BYTE const *data, DWORD size, m2HeaderInfo_t const *header) {
+    BOOL classic = header->version <= 263;
+    DWORD stride = classic ? sizeof(m2ParticleClassic_t) : sizeof(m2ParticleModern_t);
+    DWORD count = (DWORD)header->particle_emitters.count;
+    DWORD off = (DWORD)header->particle_emitters.offset;
+    if (!count) return;
+    if (off + count * stride > size) {
+        printf("particle_emitters: %u entries but data out of bounds (off=%u stride=%u size=%u)\n",
+               (unsigned)count, (unsigned)off, (unsigned)stride, (unsigned)size);
+        return;
+    }
+    printf("particle_emitters: %u (%s)\n", (unsigned)count, classic ? "classic/tbc" : "modern");
+    FOR_LOOP(i, count) {
+        BYTE const *raw = data + off + i * stride;
+        if (classic) {
+            m2ParticleClassic_t const *p = (m2ParticleClassic_t const *)raw;
+            printf("  [%u] id=0x%x flags=0x%x bone=%u tex=%u blend=%u etype=%u rows=%u cols=%u\n",
+                   (unsigned)i, (unsigned)p->particle_id, (unsigned)p->flags,
+                   (unsigned)p->bone_index, (unsigned)p->texture_index,
+                   (unsigned)p->blend_mode, (unsigned)p->emitter_type,
+                   (unsigned)p->rows, (unsigned)p->cols);
+            PrintTrackInfo("speed_track",         classic, p->speed_track.track_type,         p->speed_track.keys.offset,         p->speed_track.keys.count);
+            PrintTrackInfo("variation_track",      classic, p->variation_track.track_type,      p->variation_track.keys.offset,      p->variation_track.keys.count);
+            PrintTrackInfo("latitude_track",       classic, p->latitude_track.track_type,       p->latitude_track.keys.offset,       p->latitude_track.keys.count);
+            PrintTrackInfo("longitude_track",      classic, p->longitude_track.track_type,      p->longitude_track.keys.offset,      p->longitude_track.keys.count);
+            PrintTrackInfo("gravity_track",        classic, p->gravity_track.track_type,        p->gravity_track.keys.offset,        p->gravity_track.keys.count);
+            PrintTrackInfo("life_track",           classic, p->life_track.track_type,           p->life_track.keys.offset,           p->life_track.keys.count);
+            PrintTrackInfo("emission_rate_track",  classic, p->emission_rate_track.track_type,  p->emission_rate_track.keys.offset,  p->emission_rate_track.keys.count);
+            PrintTrackInfo("width_track",          classic, p->width_track.track_type,          p->width_track.keys.offset,          p->width_track.keys.count);
+            PrintTrackInfo("length_track",         classic, p->length_track.track_type,         p->length_track.keys.offset,         p->length_track.keys.count);
+            PrintTrackInfo("zsource_track",        classic, p->zsource_track.track_type,        p->zsource_track.keys.offset,        p->zsource_track.keys.count);
+            PrintTrackInfo("visibility_track",     classic, p->visibility_track.track_type,     p->visibility_track.keys.offset,     p->visibility_track.keys.count);
+        } else {
+            m2ParticleModern_t const *p = (m2ParticleModern_t const *)raw;
+            printf("  [%u] id=0x%x flags=0x%x bone=%u tex=%u blend=%u etype=%u rows=%u cols=%u\n",
+                   (unsigned)i, (unsigned)p->particle_id, (unsigned)p->flags,
+                   (unsigned)p->bone_index, (unsigned)p->texture_index,
+                   (unsigned)p->blend_mode, (unsigned)p->emitter_type,
+                   (unsigned)p->rows, (unsigned)p->cols);
+            PrintTrackInfo("speed_track",         classic, p->speed_track.track_type,         p->speed_track.sequence_keys.offset, p->speed_track.sequence_keys.count);
+            PrintTrackInfo("variation_track",      classic, p->variation_track.track_type,      p->variation_track.sequence_keys.offset, p->variation_track.sequence_keys.count);
+            PrintTrackInfo("latitude_track",       classic, p->latitude_track.track_type,       p->latitude_track.sequence_keys.offset, p->latitude_track.sequence_keys.count);
+            PrintTrackInfo("longitude_track",      classic, p->longitude_track.track_type,      p->longitude_track.sequence_keys.offset, p->longitude_track.sequence_keys.count);
+            PrintTrackInfo("gravity_track",        classic, p->gravity_track.track_type,        p->gravity_track.sequence_keys.offset,  p->gravity_track.sequence_keys.count);
+            PrintTrackInfo("life_track",           classic, p->life_track.track_type,           p->life_track.sequence_keys.offset,  p->life_track.sequence_keys.count);
+            PrintTrackInfo("emission_rate_track",  classic, p->emission_rate_track.track_type,  p->emission_rate_track.sequence_keys.offset, p->emission_rate_track.sequence_keys.count);
+            PrintTrackInfo("width_track",          classic, p->width_track.track_type,          p->width_track.sequence_keys.offset,  p->width_track.sequence_keys.count);
+            PrintTrackInfo("length_track",         classic, p->length_track.track_type,         p->length_track.sequence_keys.offset, p->length_track.sequence_keys.count);
+            PrintTrackInfo("zsource_track",        classic, p->zsource_track.track_type,        p->zsource_track.sequence_keys.offset, p->zsource_track.sequence_keys.count);
+            PrintTrackInfo("visibility_track",     classic, p->visibility_track.track_type,     p->visibility_track.sequence_keys.offset, p->visibility_track.sequence_keys.count);
+        }
+    }
+}
+
+static void PrintRibbonEmitters(BYTE const *data, DWORD size, m2HeaderInfo_t const *header) {
+    BOOL classic = header->version <= 263;
+    DWORD stride = classic ? sizeof(m2RibbonClassic_t) : sizeof(m2RibbonModern_t);
+    DWORD count = (DWORD)header->ribbon_emitters.count;
+    DWORD off = (DWORD)header->ribbon_emitters.offset;
+    if (!count) return;
+    if (off + count * stride > size) {
+        printf("ribbon_emitters: %u entries but data out of bounds (off=%u stride=%u size=%u)\n",
+               (unsigned)count, (unsigned)off, (unsigned)stride, (unsigned)size);
+        return;
+    }
+    printf("ribbon_emitters: %u (%s)\n", (unsigned)count, classic ? "classic/tbc" : "modern");
+    FOR_LOOP(i, count) {
+        BYTE const *raw = data + off + i * stride;
+        if (classic) {
+            m2RibbonClassic_t const *r = (m2RibbonClassic_t const *)raw;
+            printf("  [%u] id=0x%x bone=%u tex_n=%u mat_n=%u edges_per_sec=%.2f life=%.2f grav=%.2f rows=%u cols=%u\n",
+                   (unsigned)i, (unsigned)r->ribbon_id, (unsigned)r->bone_index,
+                   (unsigned)r->texture_indices.count, (unsigned)r->material_indices.count,
+                   r->edges_per_second, r->edge_lifetime, r->gravity,
+                   (unsigned)r->texture_rows, (unsigned)r->texture_cols);
+            PrintTrackInfo("color_track",        classic, r->color_track.track_type,        r->color_track.keys.offset,        r->color_track.keys.count);
+            PrintTrackInfo("alpha_track",        classic, r->alpha_track.track_type,        r->alpha_track.keys.offset,        r->alpha_track.keys.count);
+            PrintTrackInfo("height_above_track", classic, r->height_above_track.track_type, r->height_above_track.keys.offset, r->height_above_track.keys.count);
+            PrintTrackInfo("height_below_track", classic, r->height_below_track.track_type, r->height_below_track.keys.offset, r->height_below_track.keys.count);
+            PrintTrackInfo("texture_slot_track", classic, r->texture_slot_track.track_type, r->texture_slot_track.keys.offset, r->texture_slot_track.keys.count);
+            PrintTrackInfo("visibility_track",   classic, r->visibility_track.track_type,   r->visibility_track.keys.offset,   r->visibility_track.keys.count);
+        } else {
+            m2RibbonModern_t const *r = (m2RibbonModern_t const *)raw;
+            printf("  [%u] id=0x%x bone=%u tex_n=%u mat_n=%u edges_per_sec=%.2f life=%.2f grav=%.2f rows=%u cols=%u\n",
+                   (unsigned)i, (unsigned)r->ribbon_id, (unsigned)r->bone_index,
+                   (unsigned)r->texture_indices.count, (unsigned)r->material_indices.count,
+                   r->edges_per_second, r->edge_lifetime, r->gravity,
+                   (unsigned)r->texture_rows, (unsigned)r->texture_cols);
+            PrintTrackInfo("color_track",        classic, r->color_track.track_type,        r->color_track.sequence_keys.offset,        r->color_track.sequence_keys.count);
+            PrintTrackInfo("alpha_track",        classic, r->alpha_track.track_type,        r->alpha_track.sequence_keys.offset,        r->alpha_track.sequence_keys.count);
+            PrintTrackInfo("height_above_track", classic, r->height_above_track.track_type, r->height_above_track.sequence_keys.offset, r->height_above_track.sequence_keys.count);
+            PrintTrackInfo("height_below_track", classic, r->height_below_track.track_type, r->height_below_track.sequence_keys.offset, r->height_below_track.sequence_keys.count);
+            PrintTrackInfo("texture_slot_track", classic, r->texture_slot_track.track_type, r->texture_slot_track.sequence_keys.offset, r->texture_slot_track.sequence_keys.count);
+            PrintTrackInfo("visibility_track",   classic, r->visibility_track.track_type,   r->visibility_track.sequence_keys.offset,   r->visibility_track.sequence_keys.count);
+        }
+    }
+}
+
 static void PrintTextures(BYTE const *data, DWORD size, m2HeaderInfo_t const *header) {
     m2Texture_t const *textures = ArrayPtr(data, size, header->textures, sizeof(*textures));
 
@@ -2067,6 +2243,8 @@ static void InspectModel(void) {
         PrintHeaderArrays(&header);
         PrintAttachments(payload, payload_size, &header);
         PrintEvents(payload, payload_size, &header);
+        PrintParticleEmitters(payload, payload_size, &header);
+        PrintRibbonEmitters(payload, payload_size, &header);
         PrintTextures(payload, payload_size, &header);
         PrintTextureLookup(payload, payload_size, &header);
         PrintSkinInfo(resolved, payload, payload_size, &header);


### PR DESCRIPTION
## Changes

### `renderer/r_emit.h`
- `R_EmitParticles` replaced whole-second time-anchoring with frame-relative accumulator pattern (`rate * dt`, spawn when `>= 1.0`, cap at `2.0`). Matches WoWee's `emitParticles` emitterAccumulator pattern — no more burst/lag artifacts.

### `games/world-of-warcraft/renderer/m2/r_m2.c`

**Emission rate flooring** (WoWee §M2Renderer::emitParticles):
- Floors rate against particle lifespan: `rate = MAX(rate, kMinLiveParticles / life)` with `kMinLiveParticles = 15`
- Flame fixtures (candles, torches, braziers) sustain visible density regardless of sparse authored rates — a candle at 40/s over 0.5s vs a chandelier at 1/s over 6s now both read as fire

**Ribbon edge state** (WoWee §M2Renderer::updateRibbons):
- New `m2RibbonEdge_t`/m2RibbonEmitter_t` structs: ring buffer of 64 edges per emitter, persistent across frames
- `M2_DrawRibbons` rebuilt: ages edges, drops expired ones (past `edge_lifetime`), accumulates `edges_per_second * dt`, spawns new edges at animated spine position
- Each active edge spawns a `cparticle_t` at its distinct world position with age-based alpha fade — creates a visible trail instead of all particles at emitter origin

**Model state**:
- `m2Model_t` gains `emitter_accumulators[]` and `ribbon_emitters[]` arrays; allocated at model load, freed in `M2_FreeModelData`

### `docs/references.md`
- Added local WoWee source pointers for `m2_renderer_particles.cpp`, `m2_renderer_internal.h`, and the four M2 particle/ribbon GLSL shaders

## Test

- Full test suite: **421/421 assertions passed**
- `make run-wow +com_frame_limit 100`: clean
- `make run-sc2 +com_frame_limit 50`: clean
- Clean build, no warnings