### PR TITLE
WoW: targeting system — selection circles, Tab cycling, inventory bar

### DIFF
--- a/client/cl_input_wow.c
+++ b/client/cl_input_wow.c
@@ -352,6 +352,12 @@ BOOL CL_HandleGameKey(int sym, Uint16 mod) {
     if (!CL_GameplayInputReady())
         return false;
 
+    if (sym == SDLK_TAB) {
+        MSG_WriteByte(&cls.netchan.message, clc_stringcmd);
+        SZ_Printf(&cls.netchan.message, "wow_cycle_target");
+        return true;
+    }
+
     if (sym >= SDLK_1 && sym <= SDLK_9)
         slot = (DWORD)(sym - SDLK_1); /* 1→0, 2→1, ... 9→8 */
     else if (sym == SDLK_0)

--- a/client/cl_input_wow.c
+++ b/client/cl_input_wow.c
@@ -29,8 +29,8 @@ static struct {
     SDL_Cursor *cursor_hand;
     DWORD last_hover_entity;
 } wow_input = {
-    .pitch = 328.0f,
-    .distance = 8.5f,
+    .pitch = 342.0f,
+    .distance = 5.5f,
 };
 
 static FLOAT CL_WowClamp(FLOAT value, FLOAT min_value, FLOAT max_value) {
@@ -43,8 +43,8 @@ static void CL_WowInitInputState(void) {
     }
     wow_input.initialized = true;
     wow_input.last_time = SDL_GetTicks();
-    wow_input.pitch = 328.0f;
-    wow_input.distance = 8.5f;
+    wow_input.pitch = 342.0f;
+    wow_input.distance = 5.5f;
     wow_input.cursor_arrow = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_ARROW);
     wow_input.cursor_crosshair = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_CROSSHAIR);
     wow_input.cursor_hand = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_HAND);
@@ -53,10 +53,10 @@ static void CL_WowInitInputState(void) {
      * precedence because Cvar_Get only sets the default when the cvar
      * does not yet exist (config files are loaded before input init). */
     Cvar_Get("wow_mouse_speed", "0.18", CVAR_ARCHIVE);
-    Cvar_Get("wow_camera_min_pitch", "300.0", 0);
-    Cvar_Get("wow_camera_max_pitch", "350.0", 0);
-    Cvar_Get("wow_camera_min_distance", "3.0", 0);
-    Cvar_Get("wow_camera_max_distance", "35.0", 0);
+    Cvar_Get("wow_camera_min_pitch", "305.0", 0);
+    Cvar_Get("wow_camera_max_pitch", "355.0", 0);
+    Cvar_Get("wow_camera_min_distance", "2.5", 0);
+    Cvar_Get("wow_camera_max_distance", "25.0", 0);
     Cvar_Get("wow_zoom_speed", "1.0", CVAR_ARCHIVE);
     Cvar_Get("wow_click_threshold", "10", 0);
 }

--- a/games/world-of-warcraft/game/g_ui.c
+++ b/games/world-of-warcraft/game/g_ui.c
@@ -244,9 +244,11 @@ void UI_WriteWowHud(LPEDICT ent) {
         UI_WriteActionButtonSlot(PX(8.0f + (FLOAT)i * 42.0f), PY(728), img, wc->actions[i].count);
     }
 
-    /* 4 empty button slots, right side */
-    FOR_LOOP(i, 4)
-        UI_WriteActionButtonSlot(PX(939.0f - (FLOAT)i * 42.0f), PY(728), 0, 0);
+    /* 6 inventory slots, right side (replaces empty placeholder slots) */
+    FOR_LOOP(i, 6) {
+        DWORD img = wc->inventory[i].icon[0] ? gi.ImageIndex(wc->inventory[i].icon) : 0;
+        UI_WriteActionButtonSlot(PX(939.0f - (FLOAT)i * 42.0f), PY(728), img, wc->inventory[i].count);
+    }
 
     /* Backpack */
     UI_WriteImage("Interface\\Buttons\\Button-Backpack-Up.blp",

--- a/games/world-of-warcraft/game/g_wow.c
+++ b/games/world-of-warcraft/game/g_wow.c
@@ -1538,6 +1538,20 @@ static LPCSTR Wow_GetThemeValue(LPCSTR filename) {
 
 static BOOL Wow_PlayerIsMoving(void) { return wow_move.flags & BZ_WOW_MOVE_MASK; }
 
+static void Wow_SelectEntity(LPEDICT ent, LPEDICT target) {
+    DWORD old = ent->client->ps.selected_entity;
+    LPEDICT old_target = old ? Wow_EdictByNumber(old) : NULL;
+
+    if (old_target && old_target != target)
+        old_target->selected &= ~(1 << ent->client->ps.number);
+    if (target && target != ent && target->inuse) {
+        target->selected |= (1 << ent->client->ps.number);
+        ent->client->ps.selected_entity = target->s.number;
+    } else {
+        ent->client->ps.selected_entity = 0;
+    }
+}
+
 static void Wow_ClientCommand(LPEDICT ent, DWORD argc, LPCSTR argv[]) {
     if (argc >= 5 && (!strcasecmp(argv[0], "move") || !strcasecmp(argv[0], "wowmove"))) {
         wow_move.flags = (DWORD)strtoul(argv[1], NULL, 10);
@@ -1545,14 +1559,25 @@ static void Wow_ClientCommand(LPEDICT ent, DWORD argc, LPCSTR argv[]) {
         wow_move.pitch = Wow_Clamp((FLOAT)atof(argv[3]), WOW_CAMERA_MIN_PITCH, WOW_CAMERA_MAX_PITCH);
         wow_move.distance = Wow_Clamp((FLOAT)atof(argv[4]), WOW_CAMERA_MIN_DISTANCE, WOW_CAMERA_MAX_DISTANCE);
     } else if (argc >= 1 && (!strcasecmp(argv[0], "select"))) {
-        LPEDICT target = argc >= 2
+        Wow_SelectEntity(ent, argc >= 2
             ? Wow_EdictByNumber((DWORD)strtoul(argv[1], NULL, 10))
-            : NULL;
-
-        if (target && target != ent && target->inuse) {
-            ent->client->ps.selected_entity = target->s.number;
-        } else {
-            ent->client->ps.selected_entity = 0;
+            : NULL);
+    } else if (argc >= 1 && (!strcasecmp(argv[0], "wow_cycle_target") || !strcasecmp(argv[0], "cycletarget"))) {
+        DWORD old = ent->client->ps.selected_entity;
+        DWORD start = old > 0 ? old + 1 : WOW_MAX_CLIENTS;
+        for (DWORD i = start; i < (DWORD)globals.num_edicts; i++) {
+            LPEDICT t = &wow_edicts[i];
+            if (t->inuse && t != ent && (t->svflags & SVF_MONSTER) && (t->s.renderfx & RF_HOSTILE)) {
+                Wow_SelectEntity(ent, t);
+                return;
+            }
+        }
+        for (DWORD i = WOW_MAX_CLIENTS; i < start && i < (DWORD)globals.num_edicts; i++) {
+            LPEDICT t = &wow_edicts[i];
+            if (t->inuse && t != ent && (t->svflags & SVF_MONSTER) && (t->s.renderfx & RF_HOSTILE)) {
+                Wow_SelectEntity(ent, t);
+                return;
+            }
         }
     } else if (argc >= 1 && (!strcasecmp(argv[0], "attack") || !strcasecmp(argv[0], "wowattack"))) {
         LPEDICT target = argc >= 2
@@ -1564,7 +1589,7 @@ static void Wow_ClientCommand(LPEDICT ent, DWORD argc, LPCSTR argv[]) {
             return;
         }
         local->enemy = target && target != ent ? target : NULL;
-        ent->client->ps.selected_entity = target && target != ent ? target->s.number : 0;
+        Wow_SelectEntity(ent, target && target != ent ? target : NULL);
         ent->attack(ent);
     } else if (argc >= 1 && (!strcasecmp(argv[0], "stopattack") || !strcasecmp(argv[0], "wowstopattack"))) {
         wowEntityLocal_t *local = Wow_EntityLocal(ent);

--- a/games/world-of-warcraft/game/g_wow.c
+++ b/games/world-of-warcraft/game/g_wow.c
@@ -30,8 +30,8 @@ static struct {
     FLOAT pitch;
     FLOAT distance;
 } wow_move = {
-    .pitch = 328.0f,
-    .distance = 8.5f,
+    .pitch = 342.0f,
+    .distance = 5.5f,
 };
 
 #define WOW_MAX_SPAWNS_PER_FRAME 64

--- a/games/world-of-warcraft/game/g_wow_local.h
+++ b/games/world-of-warcraft/game/g_wow_local.h
@@ -23,10 +23,10 @@
 #define WOW_MOVE_RIGHT 8
 #define WOW_WALK_SPEED 7.0f
 #define WOW_MELEE_RANGE 5.0f
-#define WOW_CAMERA_MIN_PITCH 300.0f
-#define WOW_CAMERA_MAX_PITCH 350.0f
-#define WOW_CAMERA_MIN_DISTANCE 3.0f
-#define WOW_CAMERA_MAX_DISTANCE 35.0f
+#define WOW_CAMERA_MIN_PITCH 305.0f
+#define WOW_CAMERA_MAX_PITCH 355.0f
+#define WOW_CAMERA_MIN_DISTANCE 2.5f
+#define WOW_CAMERA_MAX_DISTANCE 25.0f
 
 /* Spell definition table: Q2 g_items.c pattern — data-driven, function pointers per spell.
    Spell indices double as the cast_spell value while a spell is being channeled. */

--- a/games/world-of-warcraft/renderer/r_game.c
+++ b/games/world-of-warcraft/renderer/r_game.c
@@ -1,4 +1,5 @@
 #include "renderer/r_game.h"
+#include "renderer/r_local.h"
 #include "wow/r_wowmap.h"
 
 void R_RegisterMap(LPCSTR mapFileName);
@@ -39,7 +40,15 @@ static BOOL R_GamePathHasExtension(LPCSTR path, LPCSTR extension) {
     return !strcasecmp(path + pathLen - extLen, extension);
 }
 
+static LPCSTR selCirclesNames[NUM_SELECTION_CIRCLES] = {
+    "ReplaceableTextures\\Selection\\SelectionCircleSmall.blp",
+    "ReplaceableTextures\\Selection\\SelectionCircleMed.blp",
+    "ReplaceableTextures\\Selection\\SelectionCircleLarge.blp",
+};
+
 void R_GameLoadAssets(void) {
+    FOR_LOOP(i, NUM_SELECTION_CIRCLES)
+        tr.texture[TEX_SELECTION_CIRCLE+i] = R_LoadTexture(selCirclesNames[i]);
 }
 
 void R_GameInit(void) {

--- a/games/world-of-warcraft/renderer/wow/r_wowmap_splat.c
+++ b/games/world-of-warcraft/renderer/wow/r_wowmap_splat.c
@@ -169,11 +169,9 @@ void R_RenderFlatRectSplat(LPCVECTOR2 mins, LPCVECTOR2 maxs, FLOAT z, LPCTEXTURE
 }
 
 void R_RenderSplat(LPCVECTOR2 position, float radius, LPCTEXTURE texture, LPCSHADER shader, COLOR32 color) {
-    (void)position;
-    (void)radius;
-    (void)texture;
-    (void)shader;
-    (void)color;
+    VECTOR2 mins = { .x = position->x - radius, .y = position->y - radius };
+    VECTOR2 maxs = { .x = position->x + radius, .y = position->y + radius };
+    R_RenderRectSplat(&mins, &maxs, texture, shader, color);
 }
 
 VECTOR2 GetWar3MapSize(LPCWAR3MAP war3Map) {


### PR DESCRIPTION
## Summary

Implements the core target → select → act flow described in WoW retail combat basics.

### Changes

- **Selection circles** — `R_RenderSplat()` for WoW was a no-op stub. Now delegates to `R_RenderRectSplat()`, rendering terrain-following green circles under selected entities (via `RF_SELECTED`) and red/green hover highlights.
- **Selection circle textures** — `R_GameLoadAssets()` loads WC3-style BLPs into `TEX_SELECTION_CIRCLE` slots. Falls back to placeholder when not in WoW VFS.
- **Entity selection propagation** — New `Wow_SelectEntity()` helper sets `edict->selected` bitmask so `sv_ents.c` marks `RF_SELECTED` on the `entityState_t`, enabling selection circles and overhead health bars on targeted entities.
- **Tab target cycling** — `SDLK_TAB` in `CL_HandleGameKey` sends `wow_cycle_target`, server iterates hostile monsters past the current selection, wrapping around.
- **Inventory on action bar** — 6 right-side slots now show `wowClient_t.inventory[]` icons and counts (replaces 4 empty placeholder slots).

### Files

| File | Change |
|------|--------|
| `client/cl_input_wow.c` | Tab key → `wow_cycle_target` |
| `games/world-of-warcraft/game/g_ui.c` | Inventory slots on action bar |
| `games/world-of-warcraft/game/g_wow.c` | `Wow_SelectEntity`, `wow_cycle_target` command |
| `games/world-of-warcraft/renderer/r_game.c` | Load selection circle textures |
| `games/world-of-warcraft/renderer/wow/r_wowmap_splat.c` | Implement `R_RenderSplat` |