### PR TITLE
feat(#97): Core spell plumbing — skill points, buff stacking, channeling

### DIFF
--- a/common/shared.h
+++ b/common/shared.h
@@ -829,6 +829,7 @@ typedef struct {
     DWORD intel;        // intelligence attribute
     DWORD xp;           // accumulated experience points
     BOOL  suspend_xp;   // when true, XP gains are suspended
+    DWORD skillpoints;  // available skill points for hero ability learning
 } doodadHero_t;
 
 typedef struct {

--- a/games/warcraft-3/game/g_local.h
+++ b/games/warcraft-3/game/g_local.h
@@ -414,9 +414,14 @@ typedef struct {
     struct ability_s *ability;
 } umove_t;
 
+#define ABILITY_PASSIVE  (1 << 0)
+#define ABILITY_TOGGLE   (1 << 1)
+#define ABILITY_CHANNEL  (1 << 2)
+
 typedef struct ability_s {
     void (*init)(LPCSTR, struct ability_s *);
     void (*cmd)(LPEDICT);
+    DWORD flags;
 } ability_t;
 
 typedef struct {
@@ -547,6 +552,7 @@ struct edict_s {
     BOOL paused;        // unit AI and movement suspended when true
     BOOL stunned;       // unit AI and movement suspended by timed status
     BOOL no_pathing;    // pathfinding disabled when true
+    DWORD channel_code; // ability code being channeled (0 = none)
     DWORD unit_color;   // explicit per-unit color override (0 = use owner color)
     VECTOR2 old_origin;
     VECTOR2 move_last_origin;
@@ -942,6 +948,9 @@ void G_HeroApplyLevel(LPEDICT, DWORD level);
 void G_HeroSetXP(LPEDICT, DWORD xp);
 void G_GrantKillXP(LPEDICT victim, LPEDICT killer);
 void G_ReviveHero(LPEDICT, FLOAT x, FLOAT y);
+BOOL G_UnitIsHero(LPCEDICT ent);
+BOOL S_SpellCooldownReady(LPEDICT caster, DWORD code);
+LPCSTR S_SpellString(DWORD code, LPCSTR field, DWORD level);
 
 void order_attack(LPEDICT, LPEDICT);
 void order_move(LPEDICT, LPEDICT);

--- a/games/warcraft-3/game/m_unit.c
+++ b/games/warcraft-3/game/m_unit.c
@@ -7,7 +7,7 @@ void unit_begin_decay(LPEDICT self);
 void unit_decay_think(LPEDICT self);
 void unit_cooldown(LPEDICT self);
 void unit_stand(LPEDICT self);
-static BOOL G_UnitIsHero(LPCEDICT ent);
+BOOL G_UnitIsHero(LPCEDICT ent);
 
 /* WC3 corpse lifetime: DecayTime (flesh, 2s) + BoneDecayTime (bone, 88s) = 90s
  * after the death animation, then the corpse is removed (MiscData.txt). */
@@ -279,6 +279,7 @@ void unit_addtimedstatus(LPEDICT ent, LPCSTR skill, DWORD level, FLOAT duration)
     DWORD code;
     DWORD now;
     heroabilitystatus_t *slot = NULL;
+    LPCSTR stacktype;
 
     if (!ent || !skill || !*skill || level == 0) {
         return;
@@ -286,11 +287,32 @@ void unit_addtimedstatus(LPEDICT ent, LPCSTR skill, DWORD level, FLOAT duration)
 
     code = *((DWORD const *)skill);
     now = gi.GetTime();
+    stacktype = S_SpellString(code, "BuffStackType", 0);
+
     FOR_LOOP(i, MAX_UNIT_STATUSES) {
         heroabilitystatus_t *status = ent->abilstatus + i;
         if (status->level && status->code == code) {
-            slot = status;
-            break;
+            /* Existing buff of same code found — apply stacking rule. */
+            if (stacktype && !strcmp(stacktype, "Stack")) {
+                status->level += level;
+                if (duration > 0) {
+                    status->timestamp = now + (DWORD)(duration * 1000.0f);
+                }
+            } else if (stacktype && !strcmp(stacktype, "Refresh")) {
+                if (duration > 0) {
+                    status->timestamp = now + (DWORD)(duration * 1000.0f);
+                }
+            } else {
+                /* "Replace" (default): overwrite level and timestamp. */
+                status->level = level;
+                if (duration > 0) {
+                    status->timestamp = now + (DWORD)(duration * 1000.0f);
+                } else {
+                    status->timestamp = 0;
+                }
+            }
+            unit_refreshstatusflags(ent);
+            return;
         }
         if (!status->level && !slot) {
             slot = status;
@@ -469,7 +491,7 @@ static FLOAT G_MiscListNum(LPCSTR key, DWORD n, FLOAT fallback) {
     return val;
 }
 
-static BOOL G_UnitIsHero(LPCEDICT ent) {
+BOOL G_UnitIsHero(LPCEDICT ent) {
     DWORD const cls = ent->class_id;
     return UNIT_STRENGTH(cls) > 0 || UNIT_AGILITY(cls) > 0 || UNIT_INTELLIGENCE(cls) > 0;
 }

--- a/games/warcraft-3/game/skills/s_selectskill.c
+++ b/games/warcraft-3/game/skills/s_selectskill.c
@@ -1,14 +1,18 @@
 #include "s_skills.h"
 
-void selectskill_menu_selected(LPEDICT ent, DWORD building_id) {
-//    entityState_t cursor;
-//    FillUnitData(&cursor, building_id, "stand");
-//    UI_AddCancelButton(ent);
-//    gi.WriteByte(svc_cursor);
-//    gi.WriteEntity(&cursor);
-//    gi.unicast(ent);
-//    ent->client->menu.on_location_selected = build_menu_send_builder;
-//    ent->build_project = building_id;
+static void selectskill_menu_selected(LPEDICT clent, DWORD classname) {
+    LPEDICT ent = G_GetMainSelectedUnit(clent->client);
+    DWORD abilcode = classname;
+
+    if (!ent || !G_UnitIsHero(ent)) {
+        return;
+    }
+    if (ent->hero.skillpoints <= 0) {
+        return;
+    }
+    unit_learnability(ent, abilcode);
+    ent->hero.skillpoints--;
+    Get_Commands_f(clent);
 }
 
 void ui_selectskill(LPGAMECLIENT client) {

--- a/games/warcraft-3/game/skills/s_skills.h
+++ b/games/warcraft-3/game/skills/s_skills.h
@@ -94,5 +94,7 @@ void S_SpellHeal(LPEDICT target, FLOAT amount);
 void S_SpellSpawnTargetArt(LPEDICT target, LPCSTR art);
 void S_SpellCursorSplat(LPEDICT clent, FLOAT radius);
 void S_SpellCodeString(DWORD code, LPSTR out);
+BOOL S_SpellIsChanneling(LPEDICT caster);
+void S_SpellCancelChannel(LPEDICT caster);
 
 #endif

--- a/games/warcraft-3/game/skills/s_spell.c
+++ b/games/warcraft-3/game/skills/s_spell.c
@@ -324,3 +324,17 @@ void S_SpellCursorSplat(LPEDICT clent, FLOAT radius) {
     gi.Write(PF_FLOAT, &radius);
     gi.unicast(clent);
 }
+
+BOOL S_SpellIsChanneling(LPEDICT caster) {
+    return caster && caster->channel_code != 0;
+}
+
+void S_SpellCancelChannel(LPEDICT caster) {
+    if (!caster || !caster->channel_code) {
+        return;
+    }
+    caster->channel_code = 0;
+    if (caster->stand) {
+        caster->stand(caster);
+    }
+}


### PR DESCRIPTION
Implements #97.

## Changes
- ****: Add  to  for hero ability learning
- ****: Add ability flags (//),  to , declare 
- ****: Complete hero skill selection menu — validates skill points, calls , decrements points
- ****: Add buff stacking rules to  — supports Replace (default), Stack (increment level), Refresh (reset timer) via  SLK field
- ****: Add  /  helpers for channeling spell infrastructure
- ****: Declare new channeling functions

## Verified
- Build compiles clean
- All existing tests pass (pre-existing pathfinding/SLK failures unchanged)