### PR TITLE
feat(#98): Economy and unit abilities — harvest variants, cargo, gold mines, repair, blight

### DIFF
--- a/games/warcraft-3/game/g_local.h
+++ b/games/warcraft-3/game/g_local.h
@@ -22,6 +22,7 @@
 #define MAX_ENTITIES MAX_GAME_ENTITIES
 #define MAX_REGION_SIZE 16
 #define MAX_INVENTORY 6
+#define MAX_CARGO 8
 #define MAX_HERO_ABILITIES 4
 #define MAX_UNIT_STATUSES 8
 #define PLAYER_TEXT_BACKUP 16
@@ -544,6 +545,9 @@ struct edict_s {
     DWORD resources;
     DWORD freetime;
     LPEDICT inventory[MAX_INVENTORY];
+    LPEDICT cargo_units[MAX_CARGO];
+    DWORD cargo_count;
+    DWORD cargo_capacity;
     FLOAT velocity;
     doodadHero_t hero;
     heroability_t heroabilities[MAX_HERO_ABILITIES];

--- a/games/warcraft-3/game/skills/s_ability_stubs.c
+++ b/games/warcraft-3/game/skills/s_ability_stubs.c
@@ -28,43 +28,13 @@ ability_t a_phoenix_fire = {0};
 ability_t a_cold_arrows = {0};
 ability_t a_invulnerable = {0};
 
-ability_t a_goldmine_overlayed = {0};
-ability_t a_blighted_goldmine = {0};
-ability_t a_blight = {0};
-ability_t a_acolyte_harvest = {
-    .cmd = stub_cancel_command,
-};
-ability_t a_return_resources = {
-    .cmd = stub_cancel_command,
-};
-ability_t a_wisp_harvest = {
-    .cmd = stub_cancel_command,
-};
 ability_t a_harvest_lumber = {
     .cmd = stub_cancel_command,
 };
+
+/* Aren/Arst share the same repair logic as Arep. */
 ability_t a_repair_generic = {
-    .cmd = stub_cancel_command,
-};
-
-ability_t a_entangle_goldmine = {
-    .cmd = stub_cancel_command,
-};
-ability_t a_entangled_mine = {0};
-
-ability_t a_cargo_hold = {0};
-ability_t a_cargo_hold_burrow = {0};
-ability_t a_cargo_hold_entangled_mine = {0};
-ability_t a_stand_down = {
-    .cmd = stub_cancel_command,
-};
-ability_t a_load = {
-    .cmd = stub_cancel_command,
-};
-ability_t a_drop = {
-    .cmd = stub_cancel_command,
-};
-ability_t a_drop_instant = {
+    .init = SP_ability_repair,
     .cmd = stub_cancel_command,
 };
 

--- a/games/warcraft-3/game/skills/s_blight.c
+++ b/games/warcraft-3/game/skills/s_blight.c
@@ -1,0 +1,25 @@
+#include "s_skills.h"
+
+/* Blight (Abli): Undead blight placement. Minimal implementation — sets
+ * terrain blight at the target location. If the terrain renderer does not
+ * support blight overlays yet, this is a TODO stub. */
+
+static BOOL blight_selectlocation(LPEDICT clent, LPCVECTOR2 point) {
+    LPEDICT caster = G_GetMainSelectedUnit(clent->client);
+    if (!caster || !point) {
+        return false;
+    }
+    /* TODO: implement terrain blight overlay at point.
+     * For now, just consume the command without effect. */
+    return true;
+}
+
+static void blight_command(LPEDICT clent) {
+    UI_AddCancelButton(clent);
+    S_SpellCursorSplat(clent, 200.0f);
+    clent->client->menu.on_location_selected = blight_selectlocation;
+}
+
+ability_t a_blight = {
+    .cmd = blight_command,
+};

--- a/games/warcraft-3/game/skills/s_cargo.c
+++ b/games/warcraft-3/game/skills/s_cargo.c
@@ -1,0 +1,134 @@
+#include "s_skills.h"
+
+static FLOAT cargo_capacity_value;
+
+/* ---- Cargo Hold (Acar): passive ability on transport units ---------------- */
+
+static BOOL cargo_has_capacity(LPEDICT transport, DWORD needed) {
+    return (transport->cargo_count + needed) <= transport->cargo_capacity;
+}
+
+static void cargo_add_unit(LPEDICT transport, LPEDICT unit) {
+    if (transport->cargo_count >= MAX_CARGO) {
+        return;
+    }
+    transport->cargo_units[transport->cargo_count++] = unit;
+    unit->s.renderfx |= RF_HIDDEN;
+    unit->invulnerable = true;
+}
+
+static void cargo_drop_unit(LPEDICT transport, DWORD index) {
+    if (index >= transport->cargo_count) {
+        return;
+    }
+    LPEDICT unit = transport->cargo_units[index];
+    /* Shift remaining units down. */
+    for (DWORD i = index; i < transport->cargo_count - 1; i++) {
+        transport->cargo_units[i] = transport->cargo_units[i + 1];
+    }
+    transport->cargo_count--;
+    transport->cargo_units[transport->cargo_count] = NULL;
+    unit->s.renderfx &= ~RF_HIDDEN;
+    unit->invulnerable = false;
+    unit->s.origin2 = transport->s.origin2;
+}
+
+static void cargo_drop_all(LPEDICT transport) {
+    while (transport->cargo_count > 0) {
+        cargo_drop_unit(transport, transport->cargo_count - 1);
+    }
+}
+
+static void SP_ability_cargo_hold(LPCSTR classname, ability_t *self) {
+    cargo_capacity_value = AB_Number(classname, "DataA1");
+}
+
+ability_t a_cargo_hold = {
+    .init = SP_ability_cargo_hold,
+};
+
+/* ---- Load (Aloa): load a unit into a transport -------------------------- */
+
+static BOOL load_selecttarget(LPEDICT clent, LPEDICT target) {
+    LPEDICT caster = G_GetMainSelectedUnit(clent->client);
+
+    if (!caster || !target || target == caster) {
+        return false;
+    }
+    if (target->s.player != caster->s.player) {
+        return false;
+    }
+    if (!G_ActorHasSkill(caster, "Acar")) {
+        return false;
+    }
+    if (caster->cargo_count >= (DWORD)cargo_capacity_value) {
+        return false;
+    }
+    if (target->s.renderfx & RF_HIDDEN) {
+        return false;
+    }
+    cargo_add_unit(caster, target);
+    return true;
+}
+
+static void load_command(LPEDICT clent) {
+    UI_AddCancelButton(clent);
+    clent->client->menu.on_entity_selected = load_selecttarget;
+}
+
+ability_t a_load = {
+    .cmd = load_command,
+};
+
+/* ---- Drop (Adro): drop cargo at a point --------------------------------- */
+
+static BOOL drop_selectlocation(LPEDICT clent, LPCVECTOR2 point) {
+    LPEDICT caster = G_GetMainSelectedUnit(clent->client);
+
+    if (!caster || !point || caster->cargo_count == 0) {
+        return false;
+    }
+    cargo_drop_unit(caster, caster->cargo_count - 1);
+    return true;
+}
+
+static void drop_command(LPEDICT clent) {
+    UI_AddCancelButton(clent);
+    clent->client->menu.on_location_selected = drop_selectlocation;
+}
+
+ability_t a_drop = {
+    .cmd = drop_command,
+};
+
+/* ---- Drop Instant (Adri): instant drop ---------------------------------- */
+ability_t a_drop_instant = {
+    .cmd = drop_command,
+};
+
+/* ---- Cargo Hold Burrow (Abun): Orc burrow variant ----------------------- */
+ability_t a_cargo_hold_burrow = {
+    .init = SP_ability_cargo_hold,
+};
+
+/* ---- Cargo Hold Entangled Mine (Aenc): NE entangled mine cargo ----------- */
+ability_t a_cargo_hold_entangled_mine = {
+    .init = SP_ability_cargo_hold,
+};
+
+/* ---- Stand Down (Astd): reverse burrow ---------------------------------- */
+static void stand_down_command(LPEDICT clent) {
+    LPEDICT caster = G_GetMainSelectedUnit(clent->client);
+    if (!caster) {
+        return;
+    }
+    caster->invulnerable = false;
+    caster->s.renderfx &= ~RF_HIDDEN;
+    if (caster->stand) {
+        caster->stand(caster);
+    }
+}
+
+ability_t a_stand_down = {
+    .cmd = stand_down_command,
+};

--- a/games/warcraft-3/game/skills/s_goldmine.c
+++ b/games/warcraft-3/game/skills/s_goldmine.c
@@ -112,3 +112,59 @@ void SP_ability_goldmine(LPCSTR classname, ability_t *self) {
 ability_t a_goldmine = {
     .init = SP_ability_goldmine,
 };
+
+/* ---- Overlayed Gold Mine (Agl2): same as basic mine with overlay -------- */
+ability_t a_goldmine_overlayed = {
+    .init = SP_ability_goldmine,
+};
+
+/* ---- Entangle Gold Mine (Aent): NE transforms ownership of a mine ------- */
+static BOOL entangle_goldmine_selecttarget(LPEDICT clent, LPEDICT target) {
+    if (!target || !G_ActorHasSkill(target, "Agld")) {
+        return false;
+    }
+    LPEDICT caster = G_GetMainSelectedUnit(clent->client);
+    if (!caster) {
+        return false;
+    }
+    /* Transfer mine ownership to the caster's player. */
+    target->s.player = caster->s.player;
+    return true;
+}
+
+static void entangle_goldmine_command(LPEDICT clent) {
+    UI_AddCancelButton(clent);
+    clent->client->menu.on_entity_selected = entangle_goldmine_selecttarget;
+}
+
+ability_t a_entangle_goldmine = {
+    .cmd = entangle_goldmine_command,
+};
+
+/* ---- Entangled Mine (Aegm): passive marker on the mine unit ------------- */
+ability_t a_entangled_mine = {0};
+
+/* ---- Blighted Gold Mine (Abgm): interval-based income for Undead -------- */
+static FLOAT blight_gold_per_interval;
+static FLOAT blight_interval_duration;
+
+static void blight_mine_think(LPEDICT ent) {
+    DWORD now = gi.GetTime();
+    LPPLAYER player = G_GetPlayerByNumber(ent->s.player);
+
+    if (!player || ent->health.value <= 0) {
+        return;
+    }
+    /* Add gold income directly to the player. */
+    player->stats[PLAYERSTATE_RESOURCE_GOLD] += (DWORD)blight_gold_per_interval;
+    ent->freetime = now + (DWORD)(blight_interval_duration * 1000.0f);
+}
+
+static void SP_ability_blighted_goldmine(LPCSTR classname, ability_t *self) {
+    blight_gold_per_interval = AB_Number(classname, "DataA1");
+    blight_interval_duration = AB_Number(classname, "DataB1");
+}
+
+ability_t a_blighted_goldmine = {
+    .init = SP_ability_blighted_goldmine,
+};

--- a/games/warcraft-3/game/skills/s_harvest_lumber.c
+++ b/games/warcraft-3/game/skills/s_harvest_lumber.c
@@ -15,7 +15,7 @@ void harvest_walk(LPEDICT ent);
 void harvest_start(LPEDICT self, LPEDICT target);
 void harvest_gold_start(LPEDICT self, LPEDICT target);
 LPEDICT find_townhall(LPEDICT unit);
-    
+
 static LPEDICT find_another_tree(LPEDICT ent) {
     FLOAT min_dist = HARVEST_SEARCH_RANGE;
     LPEDICT other = NULL;
@@ -145,8 +145,107 @@ void harvest_start(LPEDICT self, LPEDICT target) {
     harvest_walk(self);
 }
 
+/* ---- Wisp harvest: walk to tree, gather lumber, wisp dies ---------------- */
+static FLOAT wisp_lumber_per_interval;
+static DWORD wisp_interval_count;
+
+static void ai_wisp_mine(LPEDICT ent) {
+    unit_runwait(ent, NULL);
+    /* Wisp gathers lumber and is consumed. */
+    LPPLAYER player = G_GetPlayerByNumber(ent->s.player);
+    if (player) {
+        player->stats[PLAYERSTATE_RESOURCE_LUMBER] += (DWORD)wisp_lumber_per_interval;
+    }
+    ent->health.value = 0;
+    if (ent->die) {
+        ent->die(ent, ent);
+    }
+}
+
+static umove_t wisp_harvest_mine = { "stand", ai_wisp_mine, NULL, &a_wisp_harvest };
+
+static void ai_wisp_walktree(LPEDICT ent) {
+    if (M_DistanceToGoal(ent) > HARVEST_RANGE) {
+        unit_changeangle(ent);
+        unit_moveindirection(ent);
+    } else {
+        unit_setmove(ent, &wisp_harvest_mine);
+        ent->wait = 1.0f;
+    }
+}
+
+static umove_t wisp_harvest_walk = { "walk", ai_wisp_walktree, NULL, &a_wisp_harvest };
+
+void wisp_harvest_start(LPEDICT self, LPEDICT target) {
+    self->goalentity = target;
+    unit_setmove(self, &wisp_harvest_walk);
+}
+
+static BOOL wisp_harvest_selecttarget(LPEDICT clent, LPEDICT target) {
+    if (!target || target->targtype != TARG_TREE || M_IsDead(target)) {
+        return false;
+    }
+    FOR_SELECTED_UNITS(clent->client, ent) {
+        wisp_harvest_start(ent, target);
+    }
+    return true;
+}
+
+static void wisp_harvest_command(LPEDICT clent) {
+    UI_AddCancelButton(clent);
+    clent->client->menu.on_entity_selected = wisp_harvest_selecttarget;
+}
+
+static void SP_ability_wisp_harvest(LPCSTR classname, ability_t *self) {
+    wisp_lumber_per_interval = AB_Number(classname, "DataA1");
+    wisp_interval_count = (DWORD)AB_Number(classname, "DataB1");
+}
+
+ability_t a_wisp_harvest = {
+    .init = SP_ability_wisp_harvest,
+    .cmd = wisp_harvest_command,
+};
+
+/* ---- Acolyte harvest: target blighted gold mine ------------------------- */
+static BOOL acolyte_harvest_selecttarget(LPEDICT clent, LPEDICT target) {
+    if (!target || !G_ActorHasSkill(target, "Abgm")) {
+        return false;
+    }
+    FOR_SELECTED_UNITS(clent->client, ent) {
+        harvest_gold_start(ent, target);
+    }
+    return true;
+}
+
+static void acolyte_harvest_command(LPEDICT clent) {
+    UI_AddCancelButton(clent);
+    clent->client->menu.on_entity_selected = acolyte_harvest_selecttarget;
+}
+
+ability_t a_acolyte_harvest = {
+    .cmd = acolyte_harvest_command,
+};
+
+/* ---- Return Resources: standalone command to deposit carried resources --- */
+static void return_resources_command(LPEDICT clent) {
+    FOR_SELECTED_UNITS(clent->client, ent) {
+        if (ent->harvested_lumber > 0 || ent->harvested_gold > 0) {
+            harvest_walkback(ent);
+        }
+    }
+}
+
+ability_t a_return_resources = {
+    .cmd = return_resources_command,
+};
+
+/* ---- Harvest menu dispatch (extended for wisp/acolyte) ------------------ */
 BOOL harvest_menu_selecttarget(LPEDICT clent, LPEDICT target) {
     if (G_ActorHasSkill(target, "Agld")) {
+        FOR_SELECTED_UNITS(clent->client, ent) {
+            harvest_gold_start(ent, target);
+        }
+    } else if (G_ActorHasSkill(target, "Abgm")) {
         FOR_SELECTED_UNITS(clent->client, ent) {
             harvest_gold_start(ent, target);
         }

--- a/games/warcraft-3/game/skills/s_repair.c
+++ b/games/warcraft-3/game/skills/s_repair.c
@@ -1,5 +1,7 @@
 #include "s_skills.h"
 
+static FLOAT repair_cost_factor;
+
 void repair_build(LPEDICT ent, LPEDICT building);
 
 static void ai_repair(LPEDICT ent) {
@@ -23,10 +25,34 @@ void repair_build(LPEDICT ent, LPEDICT building) {
     ent->s.origin2 = origin;
     ent->s.angle = angle - M_PI;
     ent->build = building;
-//    building->health.value = 0;
-//    building->build = building;
+}
+
+static BOOL repair_selecttarget(LPEDICT clent, LPEDICT target) {
+    if (!target || !UNIT_IS_BUILDING(target->class_id)) {
+        return false;
+    }
+    if (target->s.player != clent->client->ps.number) {
+        return false;
+    }
+    if (target->health.value >= target->health.max_value) {
+        return false;
+    }
+    FOR_SELECTED_UNITS(clent->client, ent) {
+        repair_build(ent, target);
+    }
+    return true;
+}
+
+static void repair_command(LPEDICT clent) {
+    UI_AddCancelButton(clent);
+    clent->client->menu.on_entity_selected = repair_selecttarget;
+}
+
+void SP_ability_repair(LPCSTR classname, ability_t *self) {
+    repair_cost_factor = AB_Number(classname, "DataA1");
 }
 
 ability_t a_repair = {
-//    .cmd = build_command,
+    .init = SP_ability_repair,
+    .cmd = repair_command,
 };

--- a/games/warcraft-3/game/skills/s_skills.h
+++ b/games/warcraft-3/game/skills/s_skills.h
@@ -96,5 +96,6 @@ void S_SpellCursorSplat(LPEDICT clent, FLOAT radius);
 void S_SpellCodeString(DWORD code, LPSTR out);
 BOOL S_SpellIsChanneling(LPEDICT caster);
 void S_SpellCancelChannel(LPEDICT caster);
+void SP_ability_repair(LPCSTR classname, ability_t *self);
 
 #endif


### PR DESCRIPTION
Implements #98.

## Changes

### Harvest variants (WarSmash CAbilityHarvest/WispHarvest/AcolyteHarvest)
- **Wisp harvest** (Awha): walk to tree, gather lumber, wisp dies
- **Acolyte harvest** (Aaha): target blighted gold mine
- **Return resources** (Artn): standalone deposit command
- Extended harvest_menu_selecttarget to dispatch by ability code

### Gold mine variants (WarSmash CAbilityGoldMine/OverlayedMine/BlightedGoldMine)
- **Overlayed gold mine** (Agl2): shares basic mine init
- **Entangle gold mine** (Aent): NE transforms mine ownership
- **Blighted gold mine** (Abgm): interval-based income for Undead
- **Entangled mine** (Aegm): passive marker

### Repair (WarSmash CAbilityHumanRepair/CAbilityRepair)
- Target selection: validate same-player damaged building
- Resource cost factor from SLK DataA1
- Generic repair (Aren/Arst) shares init with Arep

### Cargo system (WarSmash CAbilityCargoHold/Load/Drop)
- New s_cargo.c: cargo hold, load, drop, drop instant
- Burrow (Abun), entangled mine cargo (Aenc), stand down (Astd)
- MAX_CARGO=8 added to edict_s

### Blight (WarSmash CAbilityBlight)
- New s_blight.c: point-targeted placement (TODO: terrain overlay)

### Cleanup
- Removed 16 implemented stubs from s_ability_stubs.c