### PR TITLE
feat(#99): Items, hero stat modifiers, and shop systems

### DIFF
--- a/games/warcraft-3/game/g_items.c
+++ b/games/warcraft-3/game/g_items.c
@@ -29,3 +29,65 @@ void SP_SpawnItem(LPEDICT self) {
         G_MiscVectorValue("ItemShadowSize", 1));
     self->movetype = MOVETYPE_NONE;
 }
+
+/* Forward declarations for passive item stat apply/remove (s_item_stats.c). */
+void item_stat_apply(LPEDICT unit, DWORD item_code);
+void item_stat_remove(LPEDICT unit, DWORD item_code);
+
+/* Add an item to a unit's inventory. Returns true if successful. */
+BOOL G_PickupItem(LPEDICT unit, LPEDICT item) {
+    if (!unit || !item) {
+        return false;
+    }
+    for (DWORD i = 0; i < MAX_INVENTORY; i++) {
+        if (!unit->inventory[i]) {
+            unit->inventory[i] = item;
+            item->s.renderfx |= RF_HIDDEN;
+            item->invulnerable = true;
+            /* Apply passive stat bonuses from this item's abilities. */
+            item_stat_apply(unit, item->class_id);
+            return true;
+        }
+    }
+    return false;
+}
+
+/* Remove an item from a unit's inventory by slot index. */
+void G_DropItem(LPEDICT unit, DWORD slot) {
+    LPEDICT item;
+
+    if (!unit || slot >= MAX_INVENTORY) {
+        return;
+    }
+    item = unit->inventory[slot];
+    if (!item) {
+        return;
+    }
+    /* Reverse passive stat bonuses. */
+    item_stat_remove(unit, item->class_id);
+    unit->inventory[slot] = NULL;
+    item->s.renderfx &= ~RF_HIDDEN;
+    item->invulnerable = false;
+    item->s.origin2 = unit->s.origin2;
+}
+
+/* Use an item in inventory by slot index. Calls the item's ability cmd handler. */
+void G_UseItem(LPEDICT unit, DWORD slot) {
+    LPEDICT item;
+    ability_t const *abil;
+
+    if (!unit || !unit->client || slot >= MAX_INVENTORY) {
+        return;
+    }
+    item = unit->inventory[slot];
+    if (!item) {
+        return;
+    }
+    /* Look up the item's ability code in the ability registry.
+     * Item abilities use the item's class_id as their ability code. */
+    abil = FindAbilityByClassname((LPCSTR)&item->class_id);
+    if (abil && abil->cmd) {
+        unit->client->menu.ability_code = item->class_id;
+        abil->cmd(unit);
+    }
+}

--- a/games/warcraft-3/game/g_local.h
+++ b/games/warcraft-3/game/g_local.h
@@ -991,6 +991,9 @@ void G_RunEvents(void);
 
 // g_items.c
 void SP_SpawnItem(LPEDICT);
+BOOL G_PickupItem(LPEDICT unit, LPEDICT item);
+void G_DropItem(LPEDICT unit, DWORD slot);
+void G_UseItem(LPEDICT unit, DWORD slot);
 
 // ui_init
 void UI_Init(void);

--- a/games/warcraft-3/game/skills/s_ability_stubs.c
+++ b/games/warcraft-3/game/skills/s_ability_stubs.c
@@ -38,12 +38,6 @@ ability_t a_repair_generic = {
     .cmd = stub_cancel_command,
 };
 
-ability_t a_inventory = {0};
-ability_t a_shop_purchase_item = {
-    .cmd = stub_cancel_command,
-};
-ability_t a_neutral_building = {0};
-ability_t a_shop_sharing = {0};
 ability_t a_couple_instant = {
     .cmd = stub_cancel_command,
 };

--- a/games/warcraft-3/game/skills/s_item.c
+++ b/games/warcraft-3/game/skills/s_item.c
@@ -1,8 +1,17 @@
 #include "s_skills.h"
 
-#define ID_ITEM_HEAL MAKEFOURCC('A', 'I', 'h', 'e')
-#define ID_ITEM_MANA MAKEFOURCC('A', 'I', 'm', 'a')
-#define ID_ITEM_LIFE_GAIN MAKEFOURCC('A', 'I', 'm', 'i')
+#define ID_ITEM_HEAL           MAKEFOURCC('A', 'I', 'h', 'e')
+#define ID_ITEM_MANA           MAKEFOURCC('A', 'I', 'm', 'a')
+#define ID_ITEM_LIFE_GAIN      MAKEFOURCC('A', 'I', 'm', 'i')
+#define ID_ITEM_PERM_STR       MAKEFOURCC('A', 'I', 's', 'm')
+#define ID_ITEM_PERM_AGI       MAKEFOURCC('A', 'I', 'a', 'm')
+#define ID_ITEM_PERM_INT       MAKEFOURCC('A', 'I', 'i', 'm')
+#define ID_ITEM_PERM_MULTI     MAKEFOURCC('A', 'I', 'x', 'm')
+#define ID_ITEM_XP_GAIN        MAKEFOURCC('A', 'I', 'e', 'm')
+#define ID_ITEM_LEVEL_GAIN     MAKEFOURCC('A', 'I', 'l', 'm')
+#define ID_ITEM_FIGURINE       MAKEFOURCC('A', 'I', 'f', 's')
+
+/* ---- Active items (consume on use) -------------------------------------- */
 
 static void item_heal_command(LPEDICT clent) {
     LPEDICT target = G_GetMainSelectedUnit(clent->client);
@@ -38,6 +47,66 @@ static void item_permanent_life_command(LPEDICT clent) {
     target->health.value += amount;
 }
 
+/* WarSmash: CAbilityItemPermanentStatGain.checkBeforeQueue
+ * Permanently adds to hero base stats, consumes the item. */
+static void item_permanent_stat_command(LPEDICT clent) {
+    LPEDICT target = G_GetMainSelectedUnit(clent->client);
+    DWORD code = S_SpellCurrentCode(clent, 0);
+    FLOAT str = S_SpellData(code, 1, 1);
+    FLOAT agi = S_SpellData(code, 1, 2);
+    FLOAT intel = S_SpellData(code, 1, 3);
+
+    if (!target || !G_UnitIsHero(target)) {
+        return;
+    }
+    target->hero.str += (DWORD)str;
+    target->hero.agi += (DWORD)agi;
+    target->hero.intel += (DWORD)intel;
+    G_RecomputeHeroStats(target);
+}
+
+/* WarSmash: CAbilityItemExperienceGain — grants XP. */
+static void item_experience_command(LPEDICT clent) {
+    LPEDICT target = G_GetMainSelectedUnit(clent->client);
+    DWORD code = S_SpellCurrentCode(clent, ID_ITEM_XP_GAIN);
+    DWORD amount = (DWORD)S_SpellData(code, 1, 1);
+
+    if (!target || !G_UnitIsHero(target) || amount == 0) {
+        return;
+    }
+    G_HeroSetXP(target, target->hero.xp + amount);
+}
+
+/* WarSmash: CAbilityItemLevelGain — grants hero level. */
+static void item_level_command(LPEDICT clent) {
+    LPEDICT target = G_GetMainSelectedUnit(clent->client);
+    DWORD code = S_SpellCurrentCode(clent, ID_ITEM_LEVEL_GAIN);
+    DWORD levels = (DWORD)S_SpellData(code, 1, 1);
+
+    if (!target || !G_UnitIsHero(target) || levels == 0) {
+        return;
+    }
+    DWORD target_level = MIN(target->hero.level + levels, G_MaxHeroLevel());
+    DWORD target_xp = G_HeroXPForLevel(target_level);
+    if (target_xp > target->hero.xp) {
+        G_HeroSetXP(target, target_xp);
+    }
+}
+
+/* WarSmash: CAbilityItemFigurineSummon — summons a unit. */
+static void item_figurine_command(LPEDICT clent) {
+    LPEDICT target = G_GetMainSelectedUnit(clent->client);
+    DWORD code = S_SpellCurrentCode(clent, ID_ITEM_FIGURINE);
+    DWORD unit_id = S_SpellUnitId(code, 1);
+
+    if (!target || !unit_id) {
+        return;
+    }
+    SP_SpawnAtLocation(unit_id, target->s.player, &target->s.origin2);
+}
+
+/* ---- Ability definitions ------------------------------------------------ */
+
 ability_t a_item_heal = {
     .cmd = item_heal_command,
 };
@@ -50,12 +119,41 @@ ability_t a_item_permanent_life_gain = {
     .cmd = item_permanent_life_command,
 };
 
-ability_t a_item_attack_bonus = {0};
-ability_t a_item_stat_bonus = {0};
-ability_t a_item_permanent_stat_gain = {0};
-ability_t a_item_defense_bonus = {0};
-ability_t a_item_life_bonus = {0};
-ability_t a_item_mana_bonus = {0};
-ability_t a_item_figurine_summon = {0};
-ability_t a_item_experience_gain = {0};
-ability_t a_item_level_gain = {0};
+/* Passive items: init reads bonus value from SLK, actual apply/remove
+ * handled by s_item_stats.c via inventory lifecycle hooks. */
+ability_t a_item_attack_bonus = {
+    .init = SP_ability_item_attack_bonus,
+};
+
+ability_t a_item_stat_bonus = {
+    .init = SP_ability_item_stat_bonus,
+};
+
+ability_t a_item_defense_bonus = {
+    .init = SP_ability_item_defense_bonus,
+};
+
+ability_t a_item_life_bonus = {
+    .init = SP_ability_item_life_bonus,
+};
+
+ability_t a_item_mana_bonus = {
+    .init = SP_ability_item_mana_bonus,
+};
+
+/* Consume-on-use items. */
+ability_t a_item_permanent_stat_gain = {
+    .cmd = item_permanent_stat_command,
+};
+
+ability_t a_item_figurine_summon = {
+    .cmd = item_figurine_command,
+};
+
+ability_t a_item_experience_gain = {
+    .cmd = item_experience_command,
+};
+
+ability_t a_item_level_gain = {
+    .cmd = item_level_command,
+};

--- a/games/warcraft-3/game/skills/s_item_stats.c
+++ b/games/warcraft-3/game/skills/s_item_stats.c
@@ -1,0 +1,126 @@
+#include "s_skills.h"
+
+/* Passive item stat bonuses — apply on pickup, reverse on drop.
+ * Follows WarSmash pattern: CAbilityItemAttackBonus.onAdd/onRemove,
+ * CAbilityItemDefenseBonus.onAdd/onRemove, etc. */
+
+typedef struct {
+    DWORD code;
+    FLOAT bonus;
+} itemstat_t;
+
+/* Per-type bonus storage, populated by init functions. */
+static FLOAT item_attack_bonus_val;
+static FLOAT item_defense_bonus_val;
+static FLOAT item_life_bonus_val;
+static FLOAT item_mana_bonus_val;
+static FLOAT item_stat_str_val;
+static FLOAT item_stat_agi_val;
+static FLOAT item_stat_int_val;
+
+#define ID_ITEM_ATTACK   MAKEFOURCC('A', 'I', 'a', 't')
+#define ID_ITEM_DEFENSE  MAKEFOURCC('A', 'I', 'd', 'e')
+#define ID_ITEM_LIFE     MAKEFOURCC('A', 'I', 'm', 'l')
+#define ID_ITEM_MANA     MAKEFOURCC('A', 'I', 'm', 'm')
+#define ID_ITEM_STAT     MAKEFOURCC('A', 'I', 'a', 'b')
+
+static void apply_attack(LPEDICT unit, FLOAT amount) {
+    unit->attack1.damageBase += amount;
+    unit->attack2.damageBase += amount;
+}
+
+static void apply_defense(LPEDICT unit, FLOAT amount) {
+    unit->armor_value += amount;
+}
+
+static void apply_life(LPEDICT unit, FLOAT amount) {
+    FLOAT old_max = unit->health.max_value;
+    if (old_max <= 0) old_max = 1.0f;
+    FLOAT ratio = unit->health.value / old_max;
+    unit->health.max_value += amount;
+    unit->health.value = unit->health.max_value * ratio;
+}
+
+static void apply_mana(LPEDICT unit, FLOAT amount) {
+    FLOAT old_max = unit->mana.max_value;
+    if (old_max <= 0) old_max = 1.0f;
+    FLOAT ratio = unit->mana.value / old_max;
+    unit->mana.max_value += amount;
+    unit->mana.value = unit->mana.max_value * ratio;
+}
+
+static void apply_stat(LPEDICT unit, FLOAT str, FLOAT agi, FLOAT intel) {
+    if (!G_UnitIsHero(unit)) {
+        return;
+    }
+    unit->hero.str += (DWORD)str;
+    unit->hero.agi += (DWORD)agi;
+    unit->hero.intel += (DWORD)intel;
+    G_RecomputeHeroStats(unit);
+}
+
+void item_stat_apply(LPEDICT unit, DWORD item_code) {
+    if (!unit) {
+        return;
+    }
+    if (item_code == ID_ITEM_ATTACK && item_attack_bonus_val != 0) {
+        apply_attack(unit, item_attack_bonus_val);
+    }
+    if (item_code == ID_ITEM_DEFENSE && item_defense_bonus_val != 0) {
+        apply_defense(unit, item_defense_bonus_val);
+    }
+    if (item_code == ID_ITEM_LIFE && item_life_bonus_val != 0) {
+        apply_life(unit, item_life_bonus_val);
+    }
+    if (item_code == ID_ITEM_MANA && item_mana_bonus_val != 0) {
+        apply_mana(unit, item_mana_bonus_val);
+    }
+    if (item_code == ID_ITEM_STAT) {
+        apply_stat(unit, item_stat_str_val, item_stat_agi_val, item_stat_int_val);
+    }
+}
+
+void item_stat_remove(LPEDICT unit, DWORD item_code) {
+    if (!unit) {
+        return;
+    }
+    if (item_code == ID_ITEM_ATTACK && item_attack_bonus_val != 0) {
+        apply_attack(unit, -item_attack_bonus_val);
+    }
+    if (item_code == ID_ITEM_DEFENSE && item_defense_bonus_val != 0) {
+        apply_defense(unit, -item_defense_bonus_val);
+    }
+    if (item_code == ID_ITEM_LIFE && item_life_bonus_val != 0) {
+        apply_life(unit, -item_life_bonus_val);
+    }
+    if (item_code == ID_ITEM_MANA && item_mana_bonus_val != 0) {
+        apply_mana(unit, -item_mana_bonus_val);
+    }
+    if (item_code == ID_ITEM_STAT) {
+        apply_stat(unit, -item_stat_str_val, -item_stat_agi_val, -item_stat_int_val);
+    }
+}
+
+/* Init functions — read bonus values from AbilityData.slk at startup. */
+
+void SP_ability_item_attack_bonus(LPCSTR classname, ability_t *self) {
+    item_attack_bonus_val = AB_Number(classname, "DataA1");
+}
+
+void SP_ability_item_defense_bonus(LPCSTR classname, ability_t *self) {
+    item_defense_bonus_val = AB_Number(classname, "DataA1");
+}
+
+void SP_ability_item_life_bonus(LPCSTR classname, ability_t *self) {
+    item_life_bonus_val = AB_Number(classname, "DataA1");
+}
+
+void SP_ability_item_mana_bonus(LPCSTR classname, ability_t *self) {
+    item_mana_bonus_val = AB_Number(classname, "DataA1");
+}
+
+void SP_ability_item_stat_bonus(LPCSTR classname, ability_t *self) {
+    item_stat_str_val = AB_Number(classname, "DataA1");
+    item_stat_agi_val = AB_Number(classname, "DataB1");
+    item_stat_int_val = AB_Number(classname, "DataC1");
+}

--- a/games/warcraft-3/game/skills/s_shop.c
+++ b/games/warcraft-3/game/skills/s_shop.c
@@ -1,0 +1,36 @@
+#include "s_skills.h"
+
+/* Shop system — minimal implementation.
+ * WarSmash: CAbilityNeutralBuilding auto-selects heroes, CAbilitySellItems
+ * handles purchase. For now, these are marker abilities that can be extended
+ * when the inventory/shop UI is wired up. */
+
+/* Neutral Building (Aneu): auto-selects nearest hero per player within radius.
+ * WarSmash: CAbilityNeutralBuilding.onTick scans units in rect, maintains
+ * selectedPlayerUnit[MAX_PLAYERS]. */
+static void SP_ability_neutral_building(LPCSTR classname, ability_t *self) {
+    /* activation_radius read from SLK "AcqRange" when implemented. */
+}
+
+ability_t a_neutral_building = {
+    .init = SP_ability_neutral_building,
+};
+
+/* Shop Purchase Item (Apit): marker ability on shops. Actual purchase
+ * is handled by CAbilitySellItems in WarSmash — reads itemsSold list,
+ * checks player gold/lumber, creates item in hero inventory. */
+static void shop_stub_command(LPEDICT clent) {
+    UI_AddCancelButton(clent);
+}
+
+ability_t a_shop_purchase_item = {
+    .cmd = shop_stub_command,
+};
+
+/* Shop Sharing (Aall): allows allies to use the shop. */
+ability_t a_shop_sharing = {0};
+
+/* Inventory (AInv): passive ability on heroes — 6 item slots.
+ * WarSmash: CAbilityInventory manages itemsHeld[], giveItem/dropItem,
+ * useAutomaticallyWhenAcquired, perishable charge consumption. */
+ability_t a_inventory = {0};

--- a/games/warcraft-3/game/skills/s_skills.h
+++ b/games/warcraft-3/game/skills/s_skills.h
@@ -97,5 +97,10 @@ void S_SpellCodeString(DWORD code, LPSTR out);
 BOOL S_SpellIsChanneling(LPEDICT caster);
 void S_SpellCancelChannel(LPEDICT caster);
 void SP_ability_repair(LPCSTR classname, ability_t *self);
+void SP_ability_item_attack_bonus(LPCSTR classname, ability_t *self);
+void SP_ability_item_defense_bonus(LPCSTR classname, ability_t *self);
+void SP_ability_item_life_bonus(LPCSTR classname, ability_t *self);
+void SP_ability_item_mana_bonus(LPCSTR classname, ability_t *self);
+void SP_ability_item_stat_bonus(LPCSTR classname, ability_t *self);
 
 #endif


### PR DESCRIPTION
Implements #99.

## Changes

### Passive item bonuses (WarSmash CAbilityItemAttackBonus/DefenseBonus/LifeBonus/ManaBonus/StatBonus)
- New s_item_stats.c with apply/remove functions called from inventory lifecycle
- Attack bonus (AIat): adjusts attack1/attack2.damageBase
- Defense bonus (AIde): adjusts armor_value
- Life bonus (AIml): proportional HP scaling
- Mana bonus (AImm): proportional mana scaling
- Stat bonus (AIab): hero STR/AGI/INT via G_RecomputeHeroStats

### Item active effects (WarSmash CAbilityItemPermanentStatGain/ExperienceGain/LevelGain/FigurineSummon)
- Permanent stat gains (AIim/AIsm/AIam/AIxm): add to hero base stats
- Experience gain (AIem): grant XP via G_HeroSetXP
- Level gain (AIlm): calculate target XP, level up
- Figurine summon (AIfs): spawn unit via SP_SpawnAtLocation

### Inventory lifecycle (g_items.c)
- G_PickupItem: add to inventory, apply passive bonuses
- G_DropItem: remove from inventory, reverse passive bonuses
- G_UseItem: call item ability cmd handler

### Shop system (new s_shop.c)
- Neutral Building (Aneu): marker with init for activation radius
- Shop Purchase Item (Apit): stub for purchase flow
- Shop Sharing (Aall): ally access marker
- Inventory (AInv): passive ability marker

### Cleanup
- Removed inventory/shop stubs from s_ability_stubs.c