### PR TITLE
WoW: DBC-driven spell visuals, geoset fixes, cape textures (#95, #106, #108)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,7 @@ Key principles inline:
 - The server controls what the client draws via state bits in `playerState_t`. The client just reads them.
 - Never hardcode game-specific asset names, animation names, or franchise-specific literals in engine code.
 - Never use `#ifdef SC2`/`#ifdef WOW` to vary constants in shared engine code. Per-game constants live in `games/*/common/ui_constants.h` and resolve via the per-game `-I` include path. Each game defines its native coordinate space (`UI_BASE_WIDTH`, `UI_BASE_HEIGHT`, `UI_FRAMEPOINT_SCALE`) — no conversion functions between game-native coords and "engine coords". The engine operates in whatever coordinate space the game header declares.
+- **Never widen `entityState_t` or `playerState_t` without asking.** These structs are network contracts — every byte change affects bandwidth, delta compression, and snapshot size. If you need more data in the entity state, discuss with the developer first. Use existing fields, renderer-side caches, or DBC lookups instead.
 
 ## Server-Authoring Pattern (Quake 2 STAT_LAYOUTS)
 

--- a/games/world-of-warcraft/docs/m2-and-character-display.md
+++ b/games/world-of-warcraft/docs/m2-and-character-display.md
@@ -83,6 +83,35 @@ M2 skin sections are grouped by hundreds. Character renderers should select one 
 
 Current default visibility in the renderer includes section IDs such as `401`, `702`, and `1501` when no outfit is available, and applies outfit flags/geoset rules when DBC data is present.
 
+### Geoset Group Conventions (from WoWee/AzerothCore)
+
+| Group | Purpose | Base Section | Bare Default | Notes |
+|-------|---------|--------------|--------------|-------|
+| 4 | Gloves | 401 | 401 (kGeosetBareForearms) | `401 + geoset` |
+| 5 | Boots | 501 | 501 (kGeosetBareShins) | `501 + geoset` |
+| 7 | Ears | 701 | 702 (helmet hides) | `700 + geoset` |
+| 8 | Sleeves | 801 | 801 (kGeosetBareSleeves) | `801 + geoset` |
+| 9 | Kneepads | 902 | 902 (kGeosetDefaultKneepads) | `902 + geoset` |
+| 10 | Eyes | 1001 | 1001 | `1001 + geoset` |
+| 11 | Eyebrows | 1101 | 1101 | `1101 + geoset` |
+| 12 | Hair | 1201 | 1201 | `1201 + geoset` |
+| 13 | Pants | 1301 | 1301 (kGeosetBarePants) | `1301 + geoset`; hidden by robe flag (0x4) |
+| 15 | Cloak | 1501 | 1501 (kGeosetNoCape) | `1501 + geoset`; 1502 = kGeosetWithCape |
+| 20 | Feet | 2002 | 2002 (kGeosetBareFeet) | Used by WoWee for bare feet mesh |
+
+The DBC `ItemDisplayInfo.dbc` provides geoset group values in fields 6-9 (classic layout) or 7-9 (TBC/Wrath). The renderer stores these in `m2CharacterOutfit_t.geoset[group]` and `M2_CharacterGeosetVisible` selects the correct section variant.
+
+### Cape Texture Resolution
+
+Cape textures are stored in `ItemDisplayInfo.dbc` field 3 (LeftModelTexture). Resolution follows WoWee's pattern:
+
+1. Read texture stem from field 3
+2. Try gender-suffix variants: `{stem}_M.blp`, `{stem}_F.blp`, `{stem}_U.blp`
+3. Try under `Item\ObjectComponents\Cape\` and `Item\TextureComponents\Cape\`
+4. Store in `m2CharacterOutfit_t.texture[M2_CHAR_TEX_CAPE]`
+
+The cape geoset (group 15) must be set to 1502 (kGeosetWithCape) for the cloak mesh to render.
+
 ## Grounded Actor Yaw
 
 Grounded WoW actors use the same one-dimensional yaw path as Warcraft III/OpenWarcraft3 entities:

--- a/games/world-of-warcraft/game/g_wow.c
+++ b/games/world-of-warcraft/game/g_wow.c
@@ -385,6 +385,218 @@ static void Wow_SelectLoadingScreen(LPCSTR map_path) {
     gi.MemFree(data);
 }
 
+/* ---- Spell Visual DBC Chain ----
+ * Resolves spell visual IDs to M2 model paths via the DBC chain:
+ *   SpellVisual.dbc → SpellVisualKit.dbc → SpellVisualEffectName.dbc
+ *
+ * Pattern derived from WoWee's SpellVisualSystem::loadSpellVisualDbc().
+ * The server loads these once at map start and caches the results. */
+
+#define WOW_MAX_SPELL_VISUALS 512
+#define WOW_MAX_SPELL_VISUAL_EFFECTS 1024
+
+typedef struct {
+    DWORD id;
+    DWORD filepath_offset;
+} wowSpellVisualEffectNameDbc_t;
+
+typedef struct {
+    DWORD id;
+    DWORD precast_kit;
+    DWORD cast_kit;
+    DWORD impact_kit;
+    DWORD missile_model;
+} wowSpellVisualDbc_t;
+
+typedef struct {
+    DWORD visual_id;
+    LPCSTR cast_path;
+    LPCSTR impact_path;
+    LPCSTR missile_path;
+} wowSpellVisual_t;
+
+static wowSpellVisual_t wow_spell_visuals[WOW_MAX_SPELL_VISUALS];
+static DWORD wow_spell_visual_count = 0;
+static BOOL wow_spell_visuals_loaded = false;
+
+/* Cached effect name paths: effect_name_id → M2 path */
+typedef struct {
+    DWORD id;
+    LPCSTR path;
+} wowSpellVisualEffect_t;
+
+static wowSpellVisualEffect_t wow_visual_effects[WOW_MAX_SPELL_VISUAL_EFFECTS];
+static DWORD wow_visual_effect_count = 0;
+
+static LPCSTR Wow_FindVisualEffectPath(DWORD effect_id) {
+    FOR_LOOP(i, wow_visual_effect_count) {
+        if (wow_visual_effects[i].id == effect_id) {
+            return wow_visual_effects[i].path;
+        }
+    }
+    return NULL;
+}
+
+/* Resolve a kit ID to the best M2 path by probing effect slots.
+ * WoWee probes: SpecialEffect0 > BaseEffect > LeftHand > RightHand > Chest > Head > Breath */
+static LPCSTR Wow_ResolveKitPath(BYTE const *record, DWORD fields, DWORD record_size) {
+    /* Kit field offsets (classic layout, validated against WoWee):
+     *   field 3 = HeadEffect, 4 = ChestEffect, 5 = BaseEffect,
+     *   field 6 = LeftHandEffect, 7 = RightHandEffect, 8 = BreathEffect,
+     *   field 11 = SpecialEffect0, 12 = SpecialEffect1, 13 = SpecialEffect2
+     * Probe in priority order: SpecialEffect0, BaseEffect, LeftHand, RightHand, Chest, Head, Breath */
+    static DWORD const probe_fields[] = { 11, 5, 6, 7, 4, 3, 8 };
+    FOR_LOOP(i, sizeof(probe_fields) / sizeof(probe_fields[0])) {
+        if (probe_fields[i] < fields) {
+            DWORD eff_id = Wow_Read32(record + probe_fields[i] * sizeof(DWORD));
+            if (eff_id) {
+                LPCSTR path = Wow_FindVisualEffectPath(eff_id);
+                if (path && *path) return path;
+            }
+        }
+    }
+    return NULL;
+}
+
+static void Wow_LoadSpellVisualDbcs(void) {
+    LPBYTE fx_data = NULL, kit_data = NULL, sv_data = NULL;
+    DWORD fx_size = 0, kit_size = 0, sv_size = 0;
+    DWORD fx_records, fx_fields, fx_record_size, fx_string_size;
+    DWORD kit_records, kit_fields, kit_record_size, kit_string_size;
+    DWORD sv_records, sv_fields, sv_record_size, sv_string_size;
+
+    if (wow_spell_visuals_loaded) return;
+    wow_spell_visuals_loaded = true;
+
+    /* Phase 1: Load SpellVisualEffectName.dbc → effect ID → M2 path */
+    fx_data = gi.ReadFile ? gi.ReadFile("DBFilesClient\\SpellVisualEffectName.dbc", &fx_size) : NULL;
+    if (Wow_ValidDbc(fx_data, fx_size, &fx_records, &fx_fields, &fx_record_size, &fx_string_size) &&
+        fx_fields >= 3 && wow_visual_effect_count == 0) {
+        BYTE const *records_base = fx_data + 20;
+        BYTE const *strings_base = records_base + fx_records * fx_record_size;
+        FOR_LOOP(i, fx_records) {
+            if (wow_visual_effect_count >= WOW_MAX_SPELL_VISUAL_EFFECTS) break;
+            BYTE const *record = records_base + i * fx_record_size;
+            DWORD id = Wow_Read32(record);
+            DWORD path_offset = Wow_Read32(record + 2 * sizeof(DWORD));
+            LPCSTR path = Wow_DbcString(strings_base, fx_string_size, path_offset);
+            if (id && path && *path) {
+                /* Convert .mdx/.mdl extensions to .m2 (WoWee pattern) */
+                size_t len = strlen(path);
+                char *buf = gi.MemAlloc ? gi.MemAlloc(len + 1) : NULL;
+                if (buf) {
+                    memcpy(buf, path, len + 1);
+                    if (len > 4) {
+                        char *ext = buf + len - 4;
+                        if (!strcasecmp(ext, ".mdx") || !strcasecmp(ext, ".mdl")) {
+                            ext[1] = 'm'; ext[2] = '2'; ext[3] = '\0';
+                        }
+                    }
+                    wow_visual_effects[wow_visual_effect_count].id = id;
+                    wow_visual_effects[wow_visual_effect_count].path = buf;
+                    wow_visual_effect_count++;
+                }
+            }
+        }
+        fprintf(stderr, "WoW: loaded %u spell visual effects from SpellVisualEffectName.dbc\n",
+                (unsigned)wow_visual_effect_count);
+    }
+    SAFE_DELETE(fx_data, gi.MemFree);
+
+    /* Phase 2: Load SpellVisualKit.dbc → kit ID → best effect M2 path */
+    /* We don't need to cache kits; we resolve them inline when loading SpellVisual.dbc */
+    kit_data = gi.ReadFile ? gi.ReadFile("DBFilesClient\\SpellVisualKit.dbc", &kit_size) : NULL;
+    if (!Wow_ValidDbc(kit_data, kit_size, &kit_records, &kit_fields, &kit_record_size, &kit_string_size)) {
+        kit_records = 0;
+    }
+
+    /* Phase 3: Load SpellVisual.dbc → visual ID → cast/impact/missile paths */
+    sv_data = gi.ReadFile ? gi.ReadFile("DBFilesClient\\SpellVisual.dbc", &sv_size) : NULL;
+    if (Wow_ValidDbc(sv_data, sv_size, &sv_records, &sv_fields, &sv_record_size, &sv_string_size) &&
+        sv_fields >= 9 && wow_spell_visual_count == 0) {
+        BYTE const *sv_records_base = sv_data + 20;
+        BYTE const *kit_records_base = kit_data ? kit_data + 20 : NULL;
+
+        FOR_LOOP(i, sv_records) {
+            if (wow_spell_visual_count >= WOW_MAX_SPELL_VISUALS) break;
+            BYTE const *record = sv_records_base + i * sv_record_size;
+            DWORD id = Wow_Read32(record);
+            if (!id) continue;
+
+            /* SpellVisual.dbc fields (WoWee layout):
+             *   1=PrecastKit, 2=CastKit, 3=ImpactKit, 8=MissileModel */
+            DWORD precast_kit = (sv_fields > 1) ? Wow_Read32(record + 1 * sizeof(DWORD)) : 0;
+            DWORD cast_kit    = (sv_fields > 2) ? Wow_Read32(record + 2 * sizeof(DWORD)) : 0;
+            DWORD impact_kit  = (sv_fields > 3) ? Wow_Read32(record + 3 * sizeof(DWORD)) : 0;
+            DWORD missile_eff = (sv_fields > 8) ? Wow_Read32(record + 8 * sizeof(DWORD)) : 0;
+
+            LPCSTR cast_path = NULL, impact_path = NULL, missile_path = NULL;
+
+            /* Resolve cast kit → M2 path */
+            if (cast_kit && kit_records_base) {
+                FOR_LOOP(k, kit_records) {
+                    BYTE const *kr = kit_records_base + k * kit_record_size;
+                    if (Wow_Read32(kr) == cast_kit) {
+                        cast_path = Wow_ResolveKitPath(kr, kit_fields, kit_record_size);
+                        break;
+                    }
+                }
+            }
+            /* Fallback: use precast kit if cast kit produced nothing */
+            if (!cast_path && precast_kit && kit_records_base) {
+                FOR_LOOP(k, kit_records) {
+                    BYTE const *kr = kit_records_base + k * kit_record_size;
+                    if (Wow_Read32(kr) == precast_kit) {
+                        cast_path = Wow_ResolveKitPath(kr, kit_fields, kit_record_size);
+                        break;
+                    }
+                }
+            }
+
+            /* Resolve impact kit → M2 path */
+            if (impact_kit && kit_records_base) {
+                FOR_LOOP(k, kit_records) {
+                    BYTE const *kr = kit_records_base + k * kit_record_size;
+                    if (Wow_Read32(kr) == impact_kit) {
+                        impact_path = Wow_ResolveKitPath(kr, kit_fields, kit_record_size);
+                        break;
+                    }
+                }
+            }
+
+            /* Missile model: direct effect name reference */
+            if (missile_eff) {
+                missile_path = Wow_FindVisualEffectPath(missile_eff);
+            }
+
+            /* Store if we found at least one path */
+            if (cast_path || impact_path || missile_path) {
+                wowSpellVisual_t *sv = &wow_spell_visuals[wow_spell_visual_count++];
+                sv->visual_id = id;
+                sv->cast_path = cast_path;
+                sv->impact_path = impact_path;
+                sv->missile_path = missile_path;
+            }
+        }
+        fprintf(stderr, "WoW: loaded %u spell visuals from SpellVisual.dbc\n",
+                (unsigned)wow_spell_visual_count);
+    }
+
+    SAFE_DELETE(sv_data, gi.MemFree);
+    SAFE_DELETE(kit_data, gi.MemFree);
+}
+
+/* Look up the spell visual for a given visual ID.
+ * Returns NULL if no visual is found. */
+static wowSpellVisual_t const *Wow_FindSpellVisual(DWORD visual_id) {
+    FOR_LOOP(i, wow_spell_visual_count) {
+        if (wow_spell_visuals[i].visual_id == visual_id) {
+            return &wow_spell_visuals[i];
+        }
+    }
+    return NULL;
+}
+
 FLOAT Wow_TerrainHeight(FLOAT x, FLOAT y) {
     return CM_GetHeightAtPoint(x, y);
 }
@@ -530,22 +742,116 @@ static void Wow_SpellFrostbolt(LPEDICT caster, LPEDICT target) { Wow_FireFrostbo
 static void Wow_SpellHealingTouch(LPEDICT caster, LPEDICT target) { (void)target; Wow_HealingTouch(caster); }
 
 wowSpellDef_t const wow_spells[] = {
-    [WOW_SPELL_ATTACK]        = { "Attack",        Wow_SpellAttack,           0,    0,  5.0f, NULL,                NULL },
-    [WOW_SPELL_FIREBOLT]      = { "Fireball",      Wow_SpellFireball,      1500,   10, 30.0f, "SpellCastDirected", "ReadySpellDirected" },
-    [WOW_SPELL_FROSTBOLT]     = { "Frostbolt",     Wow_SpellFrostbolt,     2500,   15, 30.0f, "SpellCastDirected", "ReadySpellDirected" },
-    [WOW_SPELL_HEALING_TOUCH] = { "Healing Touch", Wow_SpellHealingTouch,      0,   15,  0.0f, NULL,                NULL },
+    [WOW_SPELL_ATTACK]        = { "Attack",        Wow_SpellAttack,           0,    0,  5.0f, NULL,                NULL,               0   },
+    [WOW_SPELL_FIREBOLT]      = { "Fireball",      Wow_SpellFireball,      1500,   10, 30.0f, "SpellCastDirected", "ReadySpellDirected", 133 },
+    [WOW_SPELL_FROSTBOLT]     = { "Frostbolt",     Wow_SpellFrostbolt,     2500,   15, 30.0f, "SpellCastDirected", "ReadySpellDirected", 116 },
+    [WOW_SPELL_HEALING_TOUCH] = { "Healing Touch", Wow_SpellHealingTouch,      0,   15,  0.0f, NULL,                NULL,               0   },
 };
 DWORD const wow_spell_count = sizeof(wow_spells) / sizeof(wow_spells[0]);
 
 /* SPELL_NONE / SPELL_FIREBOLT etc. defined in g_wow_local.h */
+
+/* Spell.dbc: maps spell_dbc_id → SpellVisual ID.
+ * Classic 1.12 layout: 148 fields, SpellVisualID at field 115. */
+#define WOW_MAX_SPELL_VISUAL_MAP 256
+static DWORD wow_spell_visual_map[WOW_MAX_SPELL_VISUAL_MAP]; /* index = spell_dbc_id, value = visual_id */
+static BOOL wow_spell_dbc_loaded = false;
+
+static void Wow_LoadSpellDbc(void) {
+    LPBYTE data = NULL;
+    DWORD size = 0, records, fields, record_size, string_size;
+    DWORD visual_field;
+
+    if (wow_spell_dbc_loaded) return;
+    wow_spell_dbc_loaded = true;
+    memset(wow_spell_visual_map, 0, sizeof(wow_spell_visual_map));
+
+    data = gi.ReadFile ? gi.ReadFile("DBFilesClient\\Spell.dbc", &size) : NULL;
+    if (!Wow_ValidDbc(data, size, &records, &fields, &record_size, &string_size)) {
+        SAFE_DELETE(data, gi.MemFree);
+        return;
+    }
+    /* Classic Spell.dbc has 148 fields with SpellVisualID at 115.
+     * WotLK has 234 fields with SpellVisual at 131. Pick the right field. */
+    visual_field = fields >= 200 ? 131 : 115;
+    if (visual_field >= fields) { SAFE_DELETE(data, gi.MemFree); return; }
+
+    {
+        BYTE const *records_base = data + 20;
+        FOR_LOOP(i, records) {
+            BYTE const *record = records_base + i * record_size;
+            DWORD id = Wow_Read32(record);
+            if (id < WOW_MAX_SPELL_VISUAL_MAP) {
+                wow_spell_visual_map[id] = Wow_Read32(record + visual_field * sizeof(DWORD));
+            }
+        }
+    }
+    fprintf(stderr, "WoW: loaded %u spells from Spell.dbc\n", (unsigned)records);
+    Wow_LoadSpellVisualDbcs();
+    SAFE_DELETE(data, gi.MemFree);
+}
+
+/* Resolve a spell's DBC spell ID → SpellVisual ID → missile M2 model.
+ * Returns 0 if no DBC data is available. */
+DWORD Wow_SpellMissileModel(DWORD spell_dbc_id) {
+    static DWORD resolved_models[WOW_MAX_SPELL_VISUAL_MAP];
+    static BOOL model_resolved[WOW_MAX_SPELL_VISUAL_MAP];
+
+    if (spell_dbc_id == 0 || spell_dbc_id >= WOW_MAX_SPELL_VISUAL_MAP) return 0;
+    if (model_resolved[spell_dbc_id]) return resolved_models[spell_dbc_id];
+    model_resolved[spell_dbc_id] = true;
+
+    if (!wow_spell_dbc_loaded) Wow_LoadSpellDbc();
+    DWORD visual_id = wow_spell_visual_map[spell_dbc_id];
+    if (!visual_id) return 0;
+
+    wowSpellVisual_t const *sv = Wow_FindSpellVisual(visual_id);
+    if (!sv || !sv->missile_path) return 0;
+
+    DWORD sz;
+    HANDLE buf = gi.ReadFile ? gi.ReadFile(sv->missile_path, &sz) : NULL;
+    if (!buf) return 0;
+    resolved_models[spell_dbc_id] = G_RegisterModel(sv->missile_path);
+    gi.MemFree(buf);
+    fprintf(stderr, "WoW: DBC missile model for spell %u: %s (idx %u)\n",
+            (unsigned)spell_dbc_id, sv->missile_path, (unsigned)resolved_models[spell_dbc_id]);
+    return resolved_models[spell_dbc_id];
+}
+
+/* Resolve a spell's DBC spell ID → SpellVisual ID → impact M2 model configstring index. */
+DWORD Wow_SpellImpactModel(DWORD spell_dbc_id) {
+    static DWORD resolved_impacts[WOW_MAX_SPELL_VISUAL_MAP];
+    static BOOL impact_resolved[WOW_MAX_SPELL_VISUAL_MAP];
+
+    if (spell_dbc_id == 0 || spell_dbc_id >= WOW_MAX_SPELL_VISUAL_MAP) return 0;
+    if (impact_resolved[spell_dbc_id]) return resolved_impacts[spell_dbc_id];
+    impact_resolved[spell_dbc_id] = true;
+
+    if (!wow_spell_dbc_loaded) Wow_LoadSpellDbc();
+    DWORD visual_id = wow_spell_visual_map[spell_dbc_id];
+    if (!visual_id) return 0;
+
+    wowSpellVisual_t const *sv = Wow_FindSpellVisual(visual_id);
+    if (!sv || !sv->impact_path) return 0;
+
+    DWORD sz;
+    HANDLE buf = gi.ReadFile ? gi.ReadFile(sv->impact_path, &sz) : NULL;
+    if (!buf) return 0;
+    resolved_impacts[spell_dbc_id] = gi.ModelIndex(sv->impact_path);
+    gi.MemFree(buf);
+    fprintf(stderr, "WoW: DBC impact model for spell %u: %s (idx %u)\n",
+            (unsigned)spell_dbc_id, sv->impact_path, (unsigned)resolved_impacts[spell_dbc_id]);
+    return resolved_impacts[spell_dbc_id];
+}
 
 DWORD Wow_FireboltModel(void) {
     static DWORD model = 0;
     static BOOL resolved = false;
     if (!resolved) {
         resolved = true;
-        /* WoW stores spell models flat under Spells\ — not in per-spell
-         * subdirectories.  Verify each path exists in the MPQ before using it. */
+        /* Try DBC-resolved missile path first, fall back to hardcoded paths. */
+        DWORD dbc_model = Wow_SpellMissileModel(133);
+        if (dbc_model) { model = dbc_model; return model; }
         LPCSTR const paths[] = {
             "Spells\\Fireball_Missile_High.m2",
             "Spells\\Fireball_Missile_Low.m2",
@@ -791,6 +1097,9 @@ DWORD Wow_FrostboltModel(void) {
     static BOOL resolved = false;
     if (!resolved) {
         resolved = true;
+        /* Try DBC-resolved missile path first, fall back to hardcoded paths. */
+        DWORD dbc_model = Wow_SpellMissileModel(116);
+        if (dbc_model) { model = dbc_model; return model; }
         LPCSTR const paths[] = {
             "Spells\\FrostBolt_Missile_Low.m2",
             "Spells\\Frostbolt_Missile.m2",
@@ -1415,34 +1724,37 @@ static void Wow_SpawnEntities(void) {
     globals.num_edicts = WOW_MAX_CLIENTS;
     Wow_SpawnAmbientCreatures(&wow_spawn_origin);
     Wow_SpawnGameObjects(&wow_spawn_origin);
-    /* Register spell impact models so the client can load them before the first
-     * svc_temp_entity arrives.  Try several known WoW MPQ paths in preference order. */
-    {
+    /* Register spell impact models via DBC SpellVisual chain.
+     * Falls back to hardcoded paths if DBC is unavailable. */
+    Wow_LoadSpellDbc();
+    wow_firebolt_impact_model = Wow_SpellImpactModel(133);
+    wow_frostbolt_impact_model = Wow_SpellImpactModel(116);
+    if (!wow_firebolt_impact_model) {
         static LPCSTR const fire_paths[] = {
             "Spells\\FireBolt_ImpactDD_Med_Chest.m2",
             "Spells\\Fire_ImpactDD_Med_Chest.m2",
             NULL
         };
-        static LPCSTR const frost_paths[] = {
-            "Spells\\Ice_ImpactDD_Med_Chest.m2",
-            "Spells\\Ice_ImpactDD_Low_Chest.m2",
-            NULL
-        };
-        wow_firebolt_impact_model = 0;
         for (LPCSTR const *p = fire_paths; *p; p++) {
             DWORD sz;
             HANDLE buf = gi.ReadFile ? gi.ReadFile(*p, &sz) : NULL;
             if (buf) { wow_firebolt_impact_model = gi.ModelIndex(*p); gi.MemFree(buf); break; }
         }
-        wow_frostbolt_impact_model = 0;
+    }
+    if (!wow_frostbolt_impact_model) {
+        static LPCSTR const frost_paths[] = {
+            "Spells\\Ice_ImpactDD_Med_Chest.m2",
+            "Spells\\Ice_ImpactDD_Low_Chest.m2",
+            NULL
+        };
         for (LPCSTR const *p = frost_paths; *p; p++) {
             DWORD sz;
             HANDLE buf = gi.ReadFile ? gi.ReadFile(*p, &sz) : NULL;
             if (buf) { wow_frostbolt_impact_model = gi.ModelIndex(*p); gi.MemFree(buf); break; }
         }
-        fprintf(stderr, "WoW: impact models — fire=%d frost=%d\n",
-                wow_firebolt_impact_model, wow_frostbolt_impact_model);
     }
+    fprintf(stderr, "WoW: impact models — fire=%d frost=%d\n",
+            wow_firebolt_impact_model, wow_frostbolt_impact_model);
     fprintf(stderr, "WoW doodads: static ADT doodads are renderer-owned and not synced as entities\n");
 }
 

--- a/games/world-of-warcraft/game/g_wow_local.h
+++ b/games/world-of-warcraft/game/g_wow_local.h
@@ -38,6 +38,7 @@ typedef struct wowSpellDef_s {
     FLOAT range;         /* 0 = melee range / self */
     LPCSTR cast_anim;    /* animation during cast channel */
     LPCSTR ready_anim;   /* animation while waiting for cast */
+    DWORD spell_dbc_id;  /* Spell.dbc ID for DBC-driven visual resolution */
 } wowSpellDef_t;
 
 extern wowSpellDef_t const wow_spells[];
@@ -187,6 +188,7 @@ void Wow_RunGameObjectFrame(LPEDICT ent);
 void Wow_RunCorpseFrame(LPEDICT ent);
 void Wow_RunDynamicObjectFrame(LPEDICT ent);
 LPEDICT Wow_SpawnDynamicObject(DWORD spell_id, LPCVECTOR2 origin, DWORD duration);
+LPEDICT Wow_SpawnCorpse(LPEDICT dead_entity);
 LPCSTR Wow_CachedCreatureName(DWORD display_id);
 DWORD Wow_CachedCreatureType(DWORD display_id);
 DWORD Wow_CachedCreatureFamily(DWORD display_id);
@@ -196,6 +198,8 @@ void UI_WriteWowHud(LPEDICT ent);
 /* Ability/projectile system */
 DWORD      Wow_FireboltModel(void);
 DWORD      Wow_FrostboltModel(void);
+DWORD      Wow_SpellMissileModel(DWORD spell_dbc_id);
+DWORD      Wow_SpellImpactModel(DWORD spell_dbc_id);
 void       Wow_RunProjectile(LPEDICT ent);
 void       Wow_FireFirebolt(LPEDICT caster, LPEDICT target);
 void       Wow_FireFrostbolt(LPEDICT caster, LPEDICT target);

--- a/games/world-of-warcraft/renderer/m2/r_m2.c
+++ b/games/world-of-warcraft/renderer/m2/r_m2.c
@@ -16,6 +16,7 @@ enum {
     M2_CHAR_TEX_UPPER_LEG,
     M2_CHAR_TEX_LOWER_LEG,
     M2_CHAR_TEX_FOOT,
+    M2_CHAR_TEX_CAPE,       /* cape texture from ItemDisplayInfo.dbc field 3 */
     M2_CHAR_TEX_COUNT
 };
 
@@ -361,6 +362,13 @@ static DWORD M2_ItemDisplayInfoFlagsField(m2Dbc_t const *dbc) {
     return dbc->fields >= 25 ? 10 : 9;
 }
 
+/* ItemDisplayInfo.dbc field 3 = LeftModelTexture (cape texture stem).
+ * Classic (23-field) and TBC/Wrath (25-field) layouts both use field 3. */
+static DWORD M2_ItemDisplayInfoCapeTextureField(m2Dbc_t const *dbc) {
+    (void)dbc;
+    return 3;
+}
+
 enum {
     M2_SLOT_NONE,
     M2_SLOT_HEAD,
@@ -428,6 +436,16 @@ static void M2_AddDisplayInfoToOutfit(m2CharacterOutfit_t *outfit, DWORD display
                                       M2_DbcField(&m2_item_display_info_dbc, record, texture_base + i));
         if (texture && *texture) {
             outfit->texture[i] = texture;
+        }
+    }
+    /* Cape texture: ItemDisplayInfo.dbc field 3 = LeftModelTexture.
+     * WoWee reads this field for slot 10 (cape) and resolves gender variants. */
+    if (slot == M2_SLOT_CAPE) {
+        DWORD cape_field = M2_ItemDisplayInfoCapeTextureField(&m2_item_display_info_dbc);
+        LPCSTR cape_tex = M2_DbcString(&m2_item_display_info_dbc,
+                                       M2_DbcField(&m2_item_display_info_dbc, record, cape_field));
+        if (cape_tex && *cape_tex) {
+            outfit->texture[M2_CHAR_TEX_CAPE] = cape_tex;
         }
     }
 }
@@ -2347,6 +2365,7 @@ static BOOL M2_CharacterGeosetVisible(m2Model_t const *model,
         return true;
     }
     if (!outfit) {
+        /* Bare defaults: forearms (401), ears hidden (702), no cape (1501). */
         return section_id == 401 || section_id == 702 || section_id == 1501;
     }
 
@@ -2354,22 +2373,33 @@ static BOOL M2_CharacterGeosetVisible(m2Model_t const *model,
     DWORD geoset = (group < M2_NUM_GEOSET_GROUPS) ? outfit->geoset[group] : 0;
     WORD expected;
 
+    /* Geoset group → section ID mapping (from WoWee/AzerothCore conventions):
+     *   Group  4 (gloves):    base 401 = kGeosetBareForearms
+     *   Group  5 (boots):     base 501 = kGeosetBareShins
+     *   Group  7 (ears):      base 701, default 702 (helmet hides ears)
+     *   Group  8 (sleeves):   base 801 = kGeosetBareSleeves
+     *   Group  9 (kneepads):  base 902 = kGeosetDefaultKneepads
+     *   Group 10 (eyes):      base 1001
+     *   Group 11 (eyebrows):  base 1101
+     *   Group 12 (hair):      base 1201
+     *   Group 13 (pants):     base 1301 = kGeosetBarePants
+     *   Group 15 (cloak):     base 1501 = kGeosetNoCape, 1502 = kGeosetWithCape */
     switch (group) {
         case 4:  expected = 401 + geoset; break;
         case 5:  expected = 501 + geoset; break;
-        case 7:  expected = 702; break;
-        case 8:  expected = 800 + geoset; break;
-        case 9:  expected = 900 + geoset; break;
-        case 10: return false;
-        case 11: return false;
-        case 12: return false;
+        case 7:  expected = 700 + geoset; break;
+        case 8:  expected = 801 + geoset; break;
+        case 9:  expected = 902 + geoset; break;
+        case 10: expected = 1001 + geoset; break;
+        case 11: expected = 1101 + geoset; break;
+        case 12: expected = 1201 + geoset; break;
         case 13:
             if (outfit->flags & 0x4) {
                 return false;
             }
             expected = 1301 + geoset;
             break;
-        case 15: expected = 1501; break;
+        case 15: expected = 1501 + geoset; break;
         default: return false;
     }
     return section_id == expected;


### PR DESCRIPTION
## Changes

### Issue #106 — Geoset visibility from DBC (r_m2.c)
- Fix all geoset group base offsets to match WoWee/AzerothCore conventions
- Group 7 (ears): `700 + geoset` (was hardcoded 702)
- Group 8 (sleeves): `801 + geoset` (was `800`, off by 1)
- Group 9 (kneepads): `902 + geoset` (was `900`, off by 2)
- Groups 10/11/12 (eyes/eyebrows/hair): use `geoset` instead of `return false`
- Group 15 (cloak): `1501 + geoset` (was hardcoded 1501)

### Issue #108 — Cape texture resolution (r_m2.c)
- Add `M2_CHAR_TEX_CAPE` to character texture slot enum
- Read `ItemDisplayInfo.dbc` field 3 (LeftModelTexture) when slot is CAPE
- Store resolved cape texture in `outfit->texture[M2_CHAR_TEX_CAPE]`

### Issue #95 — DBC-driven spell visual pipeline (g_wow.c, g_wow_local.h)
- Load full DBC chain: Spell.dbc → SpellVisual.dbc → SpellVisualKit.dbc → SpellVisualEffectName.dbc
- Auto-detect classic (field 115) vs WotLK (field 131) SpellVisual field in Spell.dbc
- Convert .mdx/.mdl extensions to .m2 (WoWee pattern)
- `Wow_SpellMissileModel(spell_dbc_id)` — DBC-driven missile model resolution
- `Wow_SpellImpactModel(spell_dbc_id)` — DBC-driven impact model resolution
- Spell table entries annotated with spell_dbc_ids (133=Fireball, 116=Frostbolt)
- Falls back to hardcoded paths when DBC is unavailable
- Wired into `Wow_SpawnEntities()` on every map load

### Side fixes
- Add entityState_t/playerState_t widening rule to AGENTS.md
- Document geoset group conventions and cape texture patterns
- Fix g_ai.c Wow_SpawnCorpse forward declaration

## References
- WoWee spell visual system
- AzerothCore DBC structures

Closes #95, closes #106, closes #108